### PR TITLE
run tests on real images

### DIFF
--- a/notebooks/cnn_transfer_baseline.ipynb
+++ b/notebooks/cnn_transfer_baseline.ipynb
@@ -31,10 +31,10 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "miK0FufK5YWv",
-        "outputId": "f909b9ab-6b57-499e-fe13-fbe28db9dcc4"
+        "outputId": "629d21a6-e8fb-438a-9731-0576195595db"
       },
       "id": "miK0FufK5YWv",
-      "execution_count": 96,
+      "execution_count": 18,
       "outputs": [
         {
           "output_type": "stream",
@@ -85,10 +85,10 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "xPRhIT7sja6g",
-        "outputId": "cf62037c-2a3f-4d12-e9dc-3979891bddf3"
+        "outputId": "cbedbaa7-abd2-4fad-fe95-249995b7608a"
       },
       "id": "xPRhIT7sja6g",
-      "execution_count": 97,
+      "execution_count": 19,
       "outputs": [
         {
           "output_type": "stream",
@@ -96,14 +96,17 @@
           "text": [
             "W: Skipping acquire of configured file 'main/source/Sources' as repository 'https://r2u.stat.illinois.edu/ubuntu jammy InRelease' does not seem to provide it (sources.list entry misspelt?)\n",
             "unzip:  cannot find or open /content/datasets.zip, /content/datasets.zip.zip or /content/datasets.zip.ZIP.\n",
-            "find: ‘/content/datasets’: No such file or directory\n"
+            "/content/datasets\n",
+            "/content/datasets/OpenImagesV7\n",
+            "/content/datasets/OpenImagesV7/all_real\n",
+            "/content/datasets/OpenImagesV7/train\n"
           ]
         }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 98,
+      "execution_count": 20,
       "id": "df637a4d",
       "metadata": {
         "id": "df637a4d"
@@ -118,14 +121,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 99,
+      "execution_count": 21,
       "id": "56b4f04c",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "56b4f04c",
-        "outputId": "7b072e59-60c4-4863-cad4-196fb2ac9df2"
+        "outputId": "3861cb75-583e-4dd9-ec7e-bb63c0b6cd5a"
       },
       "outputs": [
         {
@@ -201,16 +204,216 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "VrMIMdrn7MKB",
-        "outputId": "920f3ed5-2f17-4bc9-a73f-09f38e3716f4"
+        "outputId": "cc1d43ed-449a-4cbe-9381-a3c60a13dd1b"
       },
       "id": "VrMIMdrn7MKB",
-      "execution_count": 100,
+      "execution_count": 22,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
             "Seed set.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# =========================================\n",
+        "# Fetch OpenImagesV7 (all REAL) into /content/datasets and build an \"all_real\" loader\n",
+        "# =========================================\n",
+        "\n",
+        "import shutil\n",
+        "from pathlib import Path\n",
+        "from PIL import Image\n",
+        "\n",
+        "import torch\n",
+        "from torch.utils.data import Dataset, DataLoader\n",
+        "from torchvision import transforms\n",
+        "\n",
+        "# ---- 1) Fetch using repo script ----\n",
+        "if not Path(\"DeepFakeDetector\").exists():\n",
+        "    !git clone https://github.com/McMasterAI-Society/DeepFakeDetector.git\n",
+        "else:\n",
+        "    %cd DeepFakeDetector\n",
+        "    !git pull\n",
+        "    %cd ..\n",
+        "\n",
+        "%cd DeepFakeDetector\n",
+        "!python scripts/fetch_sample_datasets.py --open-images-v7 --max-train 500 --max-test 200\n",
+        "\n",
+        "# ---- 2) Copy to your notebook's expected root ----\n",
+        "target_root = Path(\"/content/datasets\")\n",
+        "target_root.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "src = Path(\"datasets/OpenImagesV7\")\n",
+        "dst = target_root / \"OpenImagesV7\"\n",
+        "if dst.exists():\n",
+        "    shutil.rmtree(dst)\n",
+        "shutil.copytree(src, dst)\n",
+        "\n",
+        "print(\"✅ Copied to:\", dst)\n",
+        "\n",
+        "# ---- 3) Flatten into a single folder (all real) ----\n",
+        "all_real_dir = dst / \"all_real\"\n",
+        "if all_real_dir.exists():\n",
+        "    shutil.rmtree(all_real_dir)\n",
+        "all_real_dir.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "img_exts = {\".jpg\", \".jpeg\", \".png\", \".webp\"}\n",
+        "n = 0\n",
+        "for p in dst.rglob(\"*\"):\n",
+        "    if p.is_file() and p.suffix.lower() in img_exts:\n",
+        "        # avoid copying duplicates inside all_real if it already lives there\n",
+        "        if all_real_dir in p.parents:\n",
+        "            continue\n",
+        "        shutil.copy2(p, all_real_dir / p.name)\n",
+        "        n += 1\n",
+        "\n",
+        "print(f\"✅ Flattened into {all_real_dir} with {n} images\")\n",
+        "\n",
+        "# ---- 4) Build a dataset where every label = 0 (real) ----\n",
+        "IM_SIZE = int(globals().get(\"IM_SIZE\", 224))\n",
+        "BATCH_SIZE = int(globals().get(\"BATCH_SIZE\", 64))\n",
+        "NUM_WORKERS = int(globals().get(\"NUM_WORKERS\", 2))\n",
+        "\n",
+        "normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],\n",
+        "                                 std=[0.229, 0.224, 0.225])\n",
+        "\n",
+        "openimages_tfm = transforms.Compose([\n",
+        "    transforms.Resize((IM_SIZE, IM_SIZE)),\n",
+        "    transforms.ToTensor(),\n",
+        "    normalize\n",
+        "])\n",
+        "\n",
+        "class AllRealFolder(Dataset):\n",
+        "    def __init__(self, root: Path, transform=None):\n",
+        "        self.root = Path(root)\n",
+        "        self.transform = transform\n",
+        "        self.paths = sorted([p for p in self.root.iterdir() if p.is_file() and p.suffix.lower() in img_exts])\n",
+        "        if len(self.paths) == 0:\n",
+        "            raise FileNotFoundError(f\"No images found in {self.root}\")\n",
+        "\n",
+        "    def __len__(self):\n",
+        "        return len(self.paths)\n",
+        "\n",
+        "    def __getitem__(self, idx):\n",
+        "        p = self.paths[idx]\n",
+        "        img = Image.open(p).convert(\"RGB\")\n",
+        "        if self.transform:\n",
+        "            img = self.transform(img)\n",
+        "        y = 0  # all real\n",
+        "        return img, y\n",
+        "\n",
+        "openimages_real_ds = AllRealFolder(all_real_dir, transform=openimages_tfm)\n",
+        "openimages_real_loader = DataLoader(\n",
+        "    openimages_real_ds,\n",
+        "    batch_size=BATCH_SIZE,\n",
+        "    shuffle=False,\n",
+        "    num_workers=NUM_WORKERS,\n",
+        "    pin_memory=True,\n",
+        "    persistent_workers=(NUM_WORKERS > 0),\n",
+        ")\n",
+        "\n",
+        "globals()[\"openimages_real_ds\"] = openimages_real_ds\n",
+        "globals()[\"openimages_real_loader\"] = openimages_real_loader\n",
+        "\n",
+        "print(\"✅ openimages_real_loader ready:\", len(openimages_real_ds), \"images\")\n",
+        "%cd .."
+      ],
+      "metadata": {
+        "id": "RV3tDQhR3G_I",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "7c77eaaf-b0ae-4cb0-c566-83a73c75f61c"
+      },
+      "id": "RV3tDQhR3G_I",
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into 'DeepFakeDetector'...\n",
+            "remote: Enumerating objects: 649, done.\u001b[K\n",
+            "remote: Counting objects: 100% (423/423), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (276/276), done.\u001b[K\n",
+            "remote: Total 649 (delta 196), reused 303 (delta 137), pack-reused 226 (from 1)\u001b[K\n",
+            "Receiving objects: 100% (649/649), 9.72 MiB | 13.07 MiB/s, done.\n",
+            "Resolving deltas: 100% (261/261), done.\n",
+            "/content/DeepFakeDetector/DeepFakeDetector\n",
+            "README.md: 2.81kB [00:00, 7.54MB/s]\n",
+            "data/train-00000-of-00002.parquet: 100% 180M/180M [00:03<00:00, 48.8MB/s]\n",
+            "data/train-00001-of-00002.parquet: 100% 180M/180M [00:04<00:00, 39.1MB/s]\n",
+            "data/test-00000-of-00001.parquet: 100% 4.99M/4.99M [00:01<00:00, 4.05MB/s]\n",
+            "data/validation-00000-of-00001.parquet: 100% 1.66M/1.66M [00:00<00:00, 3.02MB/s]\n",
+            "Generating train split: 100% 9011219/9011219 [00:06<00:00, 1315560.75 examples/s]\n",
+            "Generating test split: 100% 125436/125436 [00:00<00:00, 1372712.35 examples/s]\n",
+            "Generating validation split: 100% 41620/41620 [00:00<00:00, 1825231.15 examples/s]\n",
+            "[HF] bitmind/open-images-v7: using URL column 'url'\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/content/DeepFakeDetector/DeepFakeDetector/scripts/fetch_sample_datasets.py\", line 363, in <module>\n",
+            "    raise SystemExit(main())\n",
+            "                     ^^^^^^\n",
+            "  File \"/content/DeepFakeDetector/DeepFakeDetector/scripts/fetch_sample_datasets.py\", line 304, in main\n",
+            "    sample_hf_dataset(\n",
+            "  File \"/content/DeepFakeDetector/DeepFakeDetector/scripts/fetch_sample_datasets.py\", line 283, in sample_hf_dataset\n",
+            "  File \"/content/DeepFakeDetector/DeepFakeDetector/scripts/fetch_sample_datasets.py\", line 249, in _save_split\n",
+            "    img = open_image_from_url(url)\n",
+            "          ^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/content/DeepFakeDetector/DeepFakeDetector/scripts/fetch_sample_datasets.py\", line 191, in open_image_from_url\n",
+            "    r = requests.get(url, timeout=timeout)\n",
+            "        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/requests/api.py\", line 73, in get\n",
+            "    return request(\"get\", url, params=params, **kwargs)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/requests/api.py\", line 59, in request\n",
+            "    return session.request(method=method, url=url, **kwargs)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/requests/sessions.py\", line 589, in request\n",
+            "    resp = self.send(prep, **send_kwargs)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/requests/sessions.py\", line 703, in send\n",
+            "    r = adapter.send(request, **kwargs)\n",
+            "        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/requests/adapters.py\", line 667, in send\n",
+            "    resp = conn.urlopen(\n",
+            "           ^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/urllib3/connectionpool.py\", line 787, in urlopen\n",
+            "    response = self._make_request(\n",
+            "               ^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/urllib3/connectionpool.py\", line 534, in _make_request\n",
+            "    response = conn.getresponse()\n",
+            "               ^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/urllib3/connection.py\", line 565, in getresponse\n",
+            "    httplib_response = super().getresponse()\n",
+            "                       ^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/lib/python3.12/http/client.py\", line 1430, in getresponse\n",
+            "    response.begin()\n",
+            "  File \"/usr/lib/python3.12/http/client.py\", line 331, in begin\n",
+            "    version, status, reason = self._read_status()\n",
+            "                              ^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/lib/python3.12/http/client.py\", line 292, in _read_status\n",
+            "    line = str(self.fp.readline(_MAXLINE + 1), \"iso-8859-1\")\n",
+            "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/lib/python3.12/socket.py\", line 720, in readinto\n",
+            "    return self._sock.recv_into(b)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/lib/python3.12/ssl.py\", line 1251, in recv_into\n",
+            "    return self.read(nbytes, buffer)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/lib/python3.12/ssl.py\", line 1103, in read\n",
+            "    return self._sslobj.read(len, buffer)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "KeyboardInterrupt\n",
+            "^C\n",
+            "✅ Copied to: /content/datasets/OpenImagesV7\n",
+            "✅ Flattened into /content/datasets/OpenImagesV7/all_real with 224 images\n",
+            "✅ openimages_real_loader ready: 224 images\n",
+            "/content/DeepFakeDetector\n"
           ]
         }
       ]
@@ -231,24 +434,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 101,
+      "execution_count": 23,
       "id": "dcae3f7f",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "dcae3f7f",
-        "outputId": "b7be21d0-909a-4c0c-9f61-73edc12ffc69"
+        "outputId": "0e4fd7eb-020f-498c-fa0e-dfdbdb2915d5"
       },
       "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/tmp/ipython-input-2810131834.py:77: UserWarning: Argument(s) 'quality_lower, quality_upper' are not valid for transform ImageCompression\n",
-            "  A.ImageCompression(quality_lower=quality_lower, quality_upper=quality_upper, p=p)\n"
-          ]
-        },
         {
           "output_type": "stream",
           "name": "stdout",
@@ -285,7 +480,21 @@
             "✅ Combined dataset ready (consistent labels: 0=real, 1=fake)\n",
             "batch_size: 64 num_workers: 2\n",
             "train size: 11546 test-as-val size: 1588\n",
-            "batches/epoch: 181\n",
+            "batches/epoch: 181\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/tmp/ipython-input-2810131834.py:77: UserWarning: Argument(s) 'quality_lower, quality_upper' are not valid for transform ImageCompression\n",
+            "  A.ImageCompression(quality_lower=quality_lower, quality_upper=quality_upper, p=p)\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
             "one batch: (64, 3, 224, 224) label values: [0, 1]\n"
           ]
         }
@@ -582,16 +791,6 @@
     },
     {
       "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "-yAyS2V_KEr4"
-      },
-      "id": "-yAyS2V_KEr4",
-      "execution_count": 101,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
       "source": [
         "# =========================\n",
         "# ONE-CELL: Colab manual-gen dataset setup (HF -> /content/manual_gen_images)\n",
@@ -692,37 +891,37 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 202,
+          "height": 209,
           "referenced_widgets": [
-            "a17cbad31ff744018b5dfc383d3e4313",
-            "6dd5f95388904f3dafb77f123a2ce5de",
-            "058980ccdc8a41b5835a68bf4c5e47f0",
-            "01f1dab53ad741d795950a9d037d31b9",
-            "9e1f9d70014c4ecb91fb6baf3dcd07e3",
-            "4e0f30ea6c1244e5be22d1fa335b88fd",
-            "6319a545d5c94684bd3245247025f6a0",
-            "6fe13f08415e4c27a5fae95743cc69ed",
-            "3106ab85d5e14210b63501ce92e5f35b",
-            "dd59225f63ee4ba19769972a984bd357",
-            "a2559add679a43cba5bb5b185545e6f7",
-            "ab7364c7fff9415b86912e7cf606639f",
-            "ef50a14f074842eabea1118b4ff9a3b8",
-            "65fc736e55534108a5c53dffe37440bd",
-            "fd2869226e3d4c1c90d73c070e403d6a",
-            "9160e205b63148cdbd078db85d46b532",
-            "9a10bd8b36384867ae53de50b5e019bc",
-            "13ac59433fd446a5b1bde2d44dd5eb63",
-            "407038f302ca43cc9bdbe27b832e429a",
-            "562827e04f434fb7adf730ca43ed1184",
-            "11fa00a7ea1c4819b57cf0ff5087d15f",
-            "9b612bca1f28424a9aeda31914b3def8"
+            "c7383fcce16b4905aaa5445a7fd069e1",
+            "f869c4716b63408b8d3cd41d8ac972ee",
+            "877bbcf1f6c04f56b1e2df82c746bce1",
+            "d9771e27654c43729497aa0386972f11",
+            "46fbdacbdaa94979b0c60e29838566a4",
+            "732403fd89bd4145a0b37bc1b5a7910e",
+            "ab78c10630e34d3182659c93efd43fef",
+            "7b63868d5a8944ceaaca3f0827917cca",
+            "510fd3b54c6c4d50baea1d378fa2b11d",
+            "1a98080308e14dec97d417ab1c4604ae",
+            "f9b9ea2e40e84ae7a0582da867d248a2",
+            "88c8cb62564d4be8a51bea5ac71fe728",
+            "4a335999aa994e858e57238173dd64e3",
+            "57c819d2ae6c4178bcb189ae0a7d9ac3",
+            "b45e18ab75d14e98b30b77830b1e960d",
+            "501eaca223d74c96a2291a1d45af0705",
+            "a67092d3167e4c8faa2979668e7b7f68",
+            "4eb7213e634a466c9b31fc91419eb698",
+            "080065ebf5644f589cbe433dc6997355",
+            "9437b3d5d9954c4f8741599fd72ae8c6",
+            "7f2910ab7fef4d388067ec8d6aa2b2dc",
+            "e9415563029149b4b9130ac29db3682b"
           ]
         },
         "id": "bbGd4M7X0Q_n",
-        "outputId": "97c3b04d-c712-4e78-b448-4ef6a71b009a"
+        "outputId": "cc6aab6d-cbb1-4e2f-8f48-27408f309e5f"
       },
       "id": "bbGd4M7X0Q_n",
-      "execution_count": 102,
+      "execution_count": 24,
       "outputs": [
         {
           "output_type": "display_data",
@@ -733,7 +932,7 @@
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
-              "model_id": "a17cbad31ff744018b5dfc383d3e4313"
+              "model_id": "c7383fcce16b4905aaa5445a7fd069e1"
             }
           },
           "metadata": {}
@@ -747,7 +946,7 @@
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
-              "model_id": "ab7364c7fff9415b86912e7cf606639f"
+              "model_id": "88c8cb62564d4be8a51bea5ac71fe728"
             }
           },
           "metadata": {}
@@ -782,17 +981,36 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 103,
+      "execution_count": 27,
       "id": "aa2e74f0",
       "metadata": {
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 69
+          "base_uri": "https://localhost:8080/"
         },
         "id": "aa2e74f0",
-        "outputId": "acc4b4e5-4609-46b5-a506-e44a632ba56e"
+        "outputId": "60db1b80-51fb-4332-c55e-a65023f75b0d"
       },
       "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading: \"https://download.pytorch.org/models/efficientnet_b0_rwightman-7f5810bc.pth\" to /root/.cache/torch/hub/checkpoints/efficientnet_b0_rwightman-7f5810bc.pth\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\n",
+            "\n",
+            "  0%|          | 0.00/20.5M [00:00<?, ?B/s]\u001b[A\u001b[A\n",
+            "\n",
+            " 20%|█▉        | 4.00M/20.5M [00:00<00:00, 41.5MB/s]\u001b[A\u001b[A\n",
+            "\n",
+            "100%|██████████| 20.5M/20.5M [00:00<00:00, 79.3MB/s]\n"
+          ]
+        },
         {
           "output_type": "stream",
           "name": "stdout",
@@ -810,6 +1028,7 @@
         "import torch\n",
         "import torch.nn as nn\n",
         "import torch.optim as optim\n",
+        "from torchvision import models\n",
         "\n",
         "# Ensure DEVICE is torch.device\n",
         "if \"DEVICE\" in globals() and isinstance(DEVICE, str):\n",
@@ -817,7 +1036,28 @@
         "elif \"DEVICE\" not in globals() or not isinstance(DEVICE, torch.device):\n",
         "    DEVICE = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
         "\n",
-        "model = build_model(USE_MODEL, num_classes=2, freeze_backbone=FREEZE_BACKBONE).to(DEVICE)\n",
+        "# ---- Build model inline (replaces build_model(...)) ----\n",
+        "# Expected: USE_MODEL = \"efficientnet_b0\"\n",
+        "use_model = str(globals().get(\"USE_MODEL\", \"efficientnet_b0\")).lower()\n",
+        "if use_model not in [\"efficientnet_b0\", \"effnet_b0\", \"efficientnet\"]:\n",
+        "    raise ValueError(f\"This cell only supports EfficientNet-B0. Got USE_MODEL={use_model}\")\n",
+        "\n",
+        "weights = models.EfficientNet_B0_Weights.DEFAULT\n",
+        "model = models.efficientnet_b0(weights=weights)\n",
+        "\n",
+        "# Replace final classifier to 2 classes\n",
+        "in_features = model.classifier[1].in_features\n",
+        "model.classifier[1] = nn.Linear(in_features, 2)\n",
+        "\n",
+        "# Freeze backbone if requested\n",
+        "FREEZE_BACKBONE = bool(globals().get(\"FREEZE_BACKBONE\", True))\n",
+        "if FREEZE_BACKBONE:\n",
+        "    for p in model.features.parameters():\n",
+        "        p.requires_grad = False\n",
+        "    for p in model.classifier.parameters():\n",
+        "        p.requires_grad = True\n",
+        "\n",
+        "model = model.to(DEVICE)\n",
         "\n",
         "# Optional: add extra dropout before final classifier (safe, only if we can find a last Linear)\n",
         "EXTRA_DROPOUT_P = float(globals().get(\"EXTRA_DROPOUT_P\", 0.20))\n",
@@ -872,7 +1112,7 @@
         "\n",
         "trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)\n",
         "total = sum(p.numel() for p in model.parameters())\n",
-        "print(f\"Model: {USE_MODEL} | Trainable params: {trainable:,} / {total:,} | device: {next(model.parameters()).device}\")"
+        "print(f\"Model: {use_model} | Trainable params: {trainable:,} / {total:,} | device: {next(model.parameters()).device}\")"
       ]
     },
     {
@@ -892,78 +1132,78 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 104,
+      "execution_count": 28,
       "id": "49a61cac",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "49a61cac",
-        "outputId": "f074d307-0cfa-4372-f0d9-3796c0817b95"
+        "outputId": "9c518cd6-1376-47fc-b770-7e7cc3779498"
       },
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Drive run dir: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618\n",
-            "Training efficientnet_b0 for up to 10 epochs | warmup_epochs=1 | patience=3\n",
+            "Drive run dir: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307\n",
+            "Training efficientnet_b0 for up to 10 epochs | warmup_epochs=2 | patience=3\n",
             "cuda available: True\n",
             "model device: cuda:0\n",
             "batches per epoch: 181\n",
             "first batch: (64, 3, 224, 224) cuda:0 torch.float32\n",
-            "epoch 1 step 50/181 loss 0.6596\n",
-            "epoch 1 step 100/181 loss 0.6002\n",
-            "epoch 1 step 150/181 loss 0.6244\n",
-            "Epoch 01 | 174.8s | train loss 0.6363 acc 0.651 f1 0.676 auroc 0.711 | val loss 0.5616 acc 0.758 f1 0.794 auroc 0.822\n",
-            "Saved new best checkpoint (val AUROC=0.822) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
-            "epoch 2 step 50/181 loss 0.5263\n",
-            "epoch 2 step 100/181 loss 0.6206\n",
-            "epoch 2 step 150/181 loss 0.5766\n",
-            "Epoch 02 | 157.7s | train loss 0.5671 acc 0.735 f1 0.756 auroc 0.809 | val loss 0.5451 acc 0.769 f1 0.812 auroc 0.830\n",
-            "Saved new best checkpoint (val AUROC=0.830) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
+            "epoch 1 step 50/181 loss 0.6704\n",
+            "epoch 1 step 100/181 loss 0.6254\n",
+            "epoch 1 step 150/181 loss 0.6310\n",
+            "Epoch 01 | 193.1s | train loss 0.6502 acc 0.635 f1 0.662 auroc 0.685 | val loss 0.5848 acc 0.743 f1 0.789 auroc 0.798\n",
+            "Saved new best checkpoint (val AUROC=0.798) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/checkpoints/best_efficientnet_b0.pt\n",
+            "epoch 2 step 50/181 loss 0.5383\n",
+            "epoch 2 step 100/181 loss 0.6247\n",
+            "epoch 2 step 150/181 loss 0.5835\n",
+            "Epoch 02 | 162.9s | train loss 0.5764 acc 0.730 f1 0.751 auroc 0.801 | val loss 0.5519 acc 0.759 f1 0.805 auroc 0.823\n",
+            "Saved new best checkpoint (val AUROC=0.823) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/checkpoints/best_efficientnet_b0.pt\n",
             "Unfreezing backbone at epoch 3 and rebuilding optimizer + scheduler with warmup...\n",
             "trainable param tensors (optimizer rebuild): 213\n",
-            "epoch 3 step 50/181 loss 0.5238\n",
+            "epoch 3 step 50/181 loss 0.5247\n",
             "epoch 3 step 100/181 loss 0.5087\n",
-            "epoch 3 step 150/181 loss 0.4817\n",
-            "Epoch 03 | 161.9s | train loss 0.5074 acc 0.791 f1 0.810 auroc 0.869 | val loss 0.4418 acc 0.848 f1 0.872 auroc 0.917\n",
-            "Saved new best checkpoint (val AUROC=0.917) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
-            "epoch 4 step 50/181 loss 0.4325\n",
-            "epoch 4 step 100/181 loss 0.4374\n",
-            "epoch 4 step 150/181 loss 0.4303\n",
-            "Epoch 04 | 162.6s | train loss 0.4086 acc 0.868 f1 0.879 auroc 0.941 | val loss 0.3973 acc 0.872 f1 0.890 auroc 0.946\n",
-            "Saved new best checkpoint (val AUROC=0.946) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
-            "epoch 5 step 50/181 loss 0.3401\n",
-            "epoch 5 step 100/181 loss 0.3970\n",
-            "epoch 5 step 150/181 loss 0.3825\n",
-            "Epoch 05 | 160.4s | train loss 0.3545 acc 0.905 f1 0.913 auroc 0.969 | val loss 0.3881 acc 0.882 f1 0.895 auroc 0.952\n",
-            "Saved new best checkpoint (val AUROC=0.952) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
-            "epoch 6 step 50/181 loss 0.3111\n",
-            "epoch 6 step 100/181 loss 0.3551\n",
-            "epoch 6 step 150/181 loss 0.3572\n",
-            "Epoch 06 | 160.1s | train loss 0.3186 acc 0.931 f1 0.936 auroc 0.983 | val loss 0.3792 acc 0.890 f1 0.904 auroc 0.956\n",
-            "Saved new best checkpoint (val AUROC=0.956) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
-            "epoch 7 step 50/181 loss 0.2820\n",
-            "epoch 7 step 100/181 loss 0.2912\n",
-            "epoch 7 step 150/181 loss 0.3101\n",
-            "Epoch 07 | 160.4s | train loss 0.2966 acc 0.948 f1 0.952 auroc 0.990 | val loss 0.3814 acc 0.892 f1 0.906 auroc 0.955\n",
+            "epoch 3 step 150/181 loss 0.4816\n",
+            "Epoch 03 | 265.9s | train loss 0.5092 acc 0.789 f1 0.808 auroc 0.868 | val loss 0.4390 acc 0.843 f1 0.869 auroc 0.919\n",
+            "Saved new best checkpoint (val AUROC=0.919) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/checkpoints/best_efficientnet_b0.pt\n",
+            "epoch 4 step 50/181 loss 0.4387\n",
+            "epoch 4 step 100/181 loss 0.4342\n",
+            "epoch 4 step 150/181 loss 0.4288\n",
+            "Epoch 04 | 169.6s | train loss 0.4073 acc 0.868 f1 0.878 auroc 0.942 | val loss 0.3951 acc 0.871 f1 0.890 auroc 0.947\n",
+            "Saved new best checkpoint (val AUROC=0.947) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/checkpoints/best_efficientnet_b0.pt\n",
+            "epoch 5 step 50/181 loss 0.3376\n",
+            "epoch 5 step 100/181 loss 0.3958\n",
+            "epoch 5 step 150/181 loss 0.3847\n",
+            "Epoch 05 | 171.3s | train loss 0.3538 acc 0.907 f1 0.914 auroc 0.969 | val loss 0.3863 acc 0.882 f1 0.895 auroc 0.953\n",
+            "Saved new best checkpoint (val AUROC=0.953) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/checkpoints/best_efficientnet_b0.pt\n",
+            "epoch 6 step 50/181 loss 0.3144\n",
+            "epoch 6 step 100/181 loss 0.3593\n",
+            "epoch 6 step 150/181 loss 0.3493\n",
+            "Epoch 06 | 169.3s | train loss 0.3173 acc 0.932 f1 0.937 auroc 0.984 | val loss 0.3776 acc 0.892 f1 0.905 auroc 0.957\n",
+            "Saved new best checkpoint (val AUROC=0.957) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/checkpoints/best_efficientnet_b0.pt\n",
+            "epoch 7 step 50/181 loss 0.2800\n",
+            "epoch 7 step 100/181 loss 0.2915\n",
+            "epoch 7 step 150/181 loss 0.3104\n",
+            "Epoch 07 | 168.6s | train loss 0.2956 acc 0.949 f1 0.953 auroc 0.990 | val loss 0.3796 acc 0.895 f1 0.909 auroc 0.956\n",
             "No AUROC improvement. Patience 1/3\n",
-            "epoch 8 step 50/181 loss 0.3143\n",
-            "epoch 8 step 100/181 loss 0.2541\n",
-            "epoch 8 step 150/181 loss 0.2791\n",
-            "Epoch 08 | 164.5s | train loss 0.2762 acc 0.963 f1 0.966 auroc 0.995 | val loss 0.3795 acc 0.892 f1 0.905 auroc 0.956\n",
-            "Saved new best checkpoint (val AUROC=0.956) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
-            "epoch 9 step 50/181 loss 0.3359\n",
-            "epoch 9 step 100/181 loss 0.3110\n",
-            "epoch 9 step 150/181 loss 0.2780\n",
-            "Epoch 09 | 162.8s | train loss 0.2699 acc 0.966 f1 0.969 auroc 0.996 | val loss 0.3740 acc 0.900 f1 0.913 auroc 0.957\n",
-            "Saved new best checkpoint (val AUROC=0.957) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
-            "epoch 10 step 50/181 loss 0.2467\n",
-            "epoch 10 step 100/181 loss 0.2516\n",
-            "epoch 10 step 150/181 loss 0.2416\n",
-            "Epoch 10 | 162.3s | train loss 0.2577 acc 0.977 f1 0.979 auroc 0.997 | val loss 0.3801 acc 0.901 f1 0.912 auroc 0.957\n",
-            "No AUROC improvement. Patience 1/3\n"
+            "epoch 8 step 50/181 loss 0.3075\n",
+            "epoch 8 step 100/181 loss 0.2566\n",
+            "epoch 8 step 150/181 loss 0.2738\n",
+            "Epoch 08 | 170.6s | train loss 0.2748 acc 0.963 f1 0.965 auroc 0.995 | val loss 0.3787 acc 0.895 f1 0.908 auroc 0.956\n",
+            "No AUROC improvement. Patience 2/3\n",
+            "epoch 9 step 50/181 loss 0.3375\n",
+            "epoch 9 step 100/181 loss 0.3073\n",
+            "epoch 9 step 150/181 loss 0.2741\n",
+            "Epoch 09 | 170.4s | train loss 0.2684 acc 0.967 f1 0.969 auroc 0.996 | val loss 0.3735 acc 0.904 f1 0.917 auroc 0.957\n",
+            "Saved new best checkpoint (val AUROC=0.957) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/checkpoints/best_efficientnet_b0.pt\n",
+            "epoch 10 step 50/181 loss 0.2455\n",
+            "epoch 10 step 100/181 loss 0.2500\n",
+            "epoch 10 step 150/181 loss 0.2415\n",
+            "Epoch 10 | 168.0s | train loss 0.2562 acc 0.977 f1 0.979 auroc 0.998 | val loss 0.3796 acc 0.902 f1 0.913 auroc 0.957\n",
+            "Saved new best checkpoint (val AUROC=0.957) -> /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/checkpoints/best_efficientnet_b0.pt\n"
           ]
         }
       ],
@@ -1336,42 +1576,11 @@
         "!nvidia-smi"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "HdaqYwEmHmvg",
-        "outputId": "e9a1f381-d324-4bd4-fd00-fb1e7ccbc2d0"
+        "id": "HdaqYwEmHmvg"
       },
       "id": "HdaqYwEmHmvg",
-      "execution_count": 105,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Sat Feb 21 15:23:27 2026       \n",
-            "+-----------------------------------------------------------------------------------------+\n",
-            "| NVIDIA-SMI 580.82.07              Driver Version: 580.82.07      CUDA Version: 13.0     |\n",
-            "+-----------------------------------------+------------------------+----------------------+\n",
-            "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
-            "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
-            "|                                         |                        |               MIG M. |\n",
-            "|=========================================+========================+======================|\n",
-            "|   0  Tesla T4                       Off |   00000000:00:04.0 Off |                    0 |\n",
-            "| N/A   75C    P0             32W /   70W |    4161MiB /  15360MiB |     55%      Default |\n",
-            "|                                         |                        |                  N/A |\n",
-            "+-----------------------------------------+------------------------+----------------------+\n",
-            "\n",
-            "+-----------------------------------------------------------------------------------------+\n",
-            "| Processes:                                                                              |\n",
-            "|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |\n",
-            "|        ID   ID                                                               Usage      |\n",
-            "|=========================================================================================|\n",
-            "|    0   N/A  N/A            1840      C   /usr/bin/python3                       4158MiB |\n",
-            "+-----------------------------------------------------------------------------------------+\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1386,7 +1595,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 106,
+      "execution_count": 29,
       "id": "f5c5e68e",
       "metadata": {
         "colab": {
@@ -1394,7 +1603,7 @@
           "height": 1000
         },
         "id": "f5c5e68e",
-        "outputId": "c636ccd2-ce10-4b12-c49d-163a7793e5e3"
+        "outputId": "7e53d90b-bfcb-43f2-8e98-c9ee43e7ce25"
       },
       "outputs": [
         {
@@ -1403,7 +1612,7 @@
             "text/plain": [
               "<Figure size 600x400 with 1 Axes>"
             ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiEAAAGJCAYAAABcsOOZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAb5RJREFUeJzt3XlcVFX/wPHPzDDMsAsiqyS4ixumyQ+XrFygnlxaNTWXysqlR6Myrdwty3rMejLNytTKssdKLQ1FStPEfd/3lV1kFxiY+f0xMoqAAjJclu/79bovZu6ce+65R2W+nlVlMplMCCGEEEJUMrXSBRBCCCFE7SRBiBBCCCEUIUGIEEIIIRQhQYgQQgghFCFBiBBCCCEUIUGIEEIIIRQhQYgQQgghFCFBiBBCCCEUIUGIEEIIIRQhQYgQQgghFCFBiBCi0i1evBiVSsWuXbuULooQQkEShAghhBBCERKECCGEEEIREoQIIaqkvXv38vDDD+Ps7IyjoyPdu3dn27ZthdIYDAamTZtGkyZN0Ov11K1bly5duhAZGWlJExcXx/Dhw6lfvz46nQ5vb2/69u3LuXPnKvmJhBC3slG6AEIIcavDhw/TtWtXnJ2dGT9+PFqtli+++IIHHniATZs2ERwcDMDUqVOZNWsWL7zwAh07diQtLY1du3axZ88eevbsCcATTzzB4cOHeeWVV/D39ychIYHIyEguXLiAv7+/gk8phFCZTCaT0oUQQtQuixcvZvjw4ezcuZMOHToU+fyxxx5j7dq1HD16lIYNGwIQGxtLs2bNaNeuHZs2bQIgKCiI+vXr8/vvvxd7n5SUFFxdXfnwww95/fXXrfdAQohyke4YIUSVkp+fz/r16+nXr58lAAHw9vZm4MCBbNmyhbS0NADq1KnD4cOHOXnyZLF52dnZYWtry8aNG7l69WqllF8IUXoShAghqpTExESysrJo1qxZkc9atGiB0Wjk4sWLAEyfPp2UlBSaNm1K69ateeONNzhw4IAlvU6n44MPPuCPP/7A09OT+++/n9mzZxMXF1dpzyOEKJkEIUKIauv+++/n9OnTLFq0iFatWvHVV19x77338tVXX1nSjBs3jhMnTjBr1iz0ej2TJk2iRYsW7N27V8GSCyFAghAhRBVTr1497O3tOX78eJHPjh07hlqtxs/Pz3LOzc2N4cOH88MPP3Dx4kXatGnD1KlTC13XqFEjXnvtNdavX8+hQ4fIzc3lP//5j7UfRQhxBxKECCGqFI1GQ69evVi1alWhabTx8fEsW7aMLl264OzsDMCVK1cKXevo6Ejjxo3JyckBICsri+zs7EJpGjVqhJOTkyWNEEI5MkVXCKGYRYsWERERUeT81KlTiYyMpEuXLowaNQobGxu++OILcnJymD17tiVdYGAgDzzwAO3bt8fNzY1du3axYsUKxowZA8CJEyfo3r07Tz/9NIGBgdjY2PDrr78SHx/PgAEDKu05hRDFkym6QohKVzBFtyQXL14kMTGRiRMn8s8//2A0GgkODubdd98lJCTEku7dd99l9erVnDhxgpycHBo0aMCzzz7LG2+8gVar5cqVK0yZMoWoqCguXryIjY0NzZs357XXXuOpp56qjEcVQtyGBCFCCCGEUISMCRFCCCGEIiQIEUIIIYQiJAgRQgghhCIkCBFCCCGEIiQIEUIIIYQiJAgRQgghhCJksbJiGI1GYmJicHJyQqVSKV0cIYQQotowmUykp6fj4+ODWn2Htg6Twj777DNTgwYNTDqdztSxY0fT9u3bb5v+6tWrplGjRpm8vLxMtra2piZNmpjWrFlj+XzKlCkmoNDRrFmzMpXp4sWLRfKQQw455JBDDjlKf1y8ePGO37eKtoQsX76c8PBwFixYQHBwMHPnziU0NJTjx4/j4eFRJH1ubi49e/bEw8ODFStW4Ovry/nz56lTp06hdC1btmTDhg2W9zY2ZXtMJycnwLxqY8EeFbWZwWBg/fr19OrVC61Wq3Rxag2pd2VIvStD6l0Z1qj3tLQ0/Pz8LN+lt6NoEDJnzhxGjBhhWb55wYIFrFmzhkWLFjFhwoQi6RctWkRycjJbt261VJa/v3+RdDY2Nnh5eZW7XAVdMM7OzhKEYP5Lam9vj7Ozs/xyqERS78qQeleG1LsyrFnvpRnOoFgQkpuby+7du5k4caLlnFqtpkePHkRHRxd7zerVqwkJCWH06NGsWrWKevXqMXDgQN588000Go0l3cmTJ/Hx8UGv1xMSEsKsWbO45557SixLTk5OoR0109LSAPMfjsFguNtHrfYK6kDqonJJvStD6l0ZUu/KsEa9lyUvxYKQpKQk8vPz8fT0LHTe09OTY8eOFXvNmTNn+PPPPxk0aBBr167l1KlTjBo1CoPBwJQpUwAIDg5m8eLFNGvWjNjYWKZNm0bXrl05dOhQiU1Ds2bNYtq0aUXOr1+/Hnt7+7t80pojMjJS6SLUSlLvypB6V4bUuzIqst6zsrJKnVaxDexiYmLw9fVl69athXbFHD9+PJs2bWL79u1FrmnatCnZ2dmcPXvW0vIxZ84cPvzwQ2JjY4u9T0pKCg0aNGDOnDk8//zzxaYpriXEz8+PpKQk6Y7BHNVGRkbSs2dPaSatRFLvypB6V4bUuzKsUe9paWm4u7uTmpp6x+9QxVpC3N3d0Wg0xMfHFzofHx9f4ngOb29vtFptoa6XFi1aEBcXR25uLra2tkWuqVOnDk2bNuXUqVMllkWn06HT6Yqc12q18o/hJlIfypB6V4bUuzIqq97z8/Ol6wdzPdjY2JCfn3/n6bTXaTQabGxsShzzUZY/P8WCEFtbW9q3b09UVBT9+vUDzOtzREVFMWbMmGKv6dy5M8uWLcNoNFoq68SJE3h7excbgABkZGRw+vRpnn32Was8hxBCiOolIyODS5cuoVBHQJViMpnw8vLi4sWLZVoXy97e/rbfvaWl6OyY8PBwhg4dSocOHejYsSNz584lMzPTMltmyJAh+Pr6MmvWLABGjhzJZ599xtixY3nllVc4efIk7733Hv/+978teb7++uv07t2bBg0aEBMTw5QpU9BoNDzzzDOKPKMQQoiqIz8/n0uXLmFvb0+9evVq/YKURqORjIwMHB0dS9USYjKZyM3NJTExkbNnz9KkSZNSt6AUR9EgpH///iQmJjJ58mTi4uIICgoiIiLCMlj1woULhR7Oz8+PdevW8eqrr9KmTRt8fX0ZO3Ysb775piXNpUuXeOaZZ7hy5Qr16tWjS5cubNu2jXr16lX68xXIN5rYcTaZhPRsPJz0dAxwQ6Ou3X/xhRBCCQaDAZPJRL169bCzs1O6OIozGo3k5uai1+tLHUzY2dmh1Wo5f/685dryUnzZ9jFjxpTY/bJx48Yi50JCQti2bVuJ+f34448VVbQKEXEolmm/HSE2NdtyzttFz5TegYS18lawZEIIUXvV9haQu3U3rR+F8qmQXESxIg7FMvK7PYUCEIC41GxGfreHiEPFz+gRQgghagMJQqwk32hi2m9HKG7YU8G5ab8dId8oA6OEEELUThKEWMmOs8lFWkBuZgJiU7PZcTa58golhBCiQuQbTUSfvsKqfZeJPn2lWv2H0t/fn7lz5ypdDKAKjAmpqRLSSw5AypNOCCFE1aDEWL8HHniAoKCgCgkedu7ciYODw90XqgJIS4iVeDiVbrRwadMJIYRQXlUd62cymcjLyytV2nr16lWZLUkkCLGSjgFueLvoud34a3dHWzoGuFVamYQQQhRmMpnIys0r1ZGebWDK6sO3Hes3dfUR0rMNpcqvtIulDRs2jE2bNvHJJ5+gUqlQqVQsXrwYlUrFH3/8Qfv27dHpdGzZsoXTp0/Tt29fPD09cXR05L777mPDhg2F8ru1O8bV1ZWvvvqKxx57DHt7e5o0acLq1avLV6FlJN0xVqJRq5jSO5CR3+1BBcX+pc3JM3LpahYN6laNZjEhhKhtrhnyCZy8rkLyMgFxadm0nrq+VOmPTA/F3vbOX8OffPIJJ06coFWrVkyfPh2Aw4cPAzBhwgQ++ugjGjZsiKurKxcvXuSRRx7h3XffRafTsXTpUnr37s3x48dvu5v8jBkzmD17Nh9++CH//e9/GTRoEOfPn8fNzbr/UZaWECsKa+XN/MH34uVSuMvFy1mHbx070rPzePbrHSSkybgQIYQQxXNxccHW1hZ7e3u8vLzw8vKy7KE2ffp0evbsSaNGjXBzc6Nt27a89NJLtGrViiZNmjBjxgwaNWp0x5aNoUOH8swzz9C4cWPee+89MjIy2LFjh9WfTVpCrCyslTc9A72KrJh6JTOHJ+dHcyE5iyGLdrD8pRBc7GSzLCGEqEx2Wg1HpoeWKu2Os8kM+2bnHdMtHn5fqbra7bSaO6a5kw4dOhR6n5GRwdSpU1mzZg2xsbHk5eVx7do1Lly4cNt8WrdubXnt4OCAs7MzCQkJd12+O5EgpBJo1CpCGtUtdM7DSc+3z3fkifnRHItLZ8SSXSx9viP6CvhLKYQQonRUKlWpukQAujaph7eLnrjU7GK72FWAl4uerk3qVdrWHLfOcnn99deJjIzko48+onHjxtjZ2fHkk0+Sm5t723xu3flWpVJhNBorvLy3ku4YBTWo68DS5zripLdhx7lkxizbQ16+9f/QhRBClF3BWD+gyKSDgvdTegdaJQCxtbUlPz//jun++ecfhg0bxmOPPUbr1q3x8vLi3LlzFV6eiiJBiMICfZz5euh96GzUbDiawJs/H8RYjRa9EUKI2qTEsX4ueuYPvtdq64T4+/uzfft2zp07R1JSUomtFE2aNOGXX35h37597N+/n4EDB1ZKi0Z5SXdMFdAxwI15A+/lpe928/OeS9R1tOWtR1ooXSwhhBDFKGmsnzW7YF5//XWGDh1KYGAg165d45tvvik23Zw5c3juuefo1KkT7u7uvPnmm6SlpVmtXHdLgpAqokegJ+8/3po3Vhxg4d9ncHOw5eVujZQulhBCiGIUN9bPmpo2bUp0dHShc8OGDSuSzt/fnz///LPQudGjRxd6f2v3zNWrV3F2di50LiUlpdxlLQvpjqlCnurgx1uPNAfg/T+O8dPOiwqXSAghhLAeCUKqmBfvb8RL3RoCMOGXA6w7HKdwiYQQQgjrkCCkCpoQ1pynO9THaIJXfthL9OkrShdJCCGEqHAShFRBKpWK9x5rTc9AT3LzjIxYuotDl1OVLpYQQghRoSQIqaJsNGr++0w7Oga4kZGTx7BvdnAuKVPpYgkhhBAVRoKQKkyv1fDV0A4EejuTlJHLs4u2yz4zQgghagwJQqo4Z72WJc91pEFdey4mX2PIoh2kZhmULpYQQghx1yQIqQbqOen49rlg6jnpOBaXzvNLdnIt987L9wohhBBVmQQh1cQ9de0t+8zsOn+V0cv2YJB9ZoQQQlRjEoRUIy28b+wz8+exBN5ccUD2mRFCCCUY8+HsZji4wvzTWLVbp/39/Zk7d67SxShClm2vZjoGuPH5oHt58dvd/LL3Mm4Otrz9rxaoVJWzbbQQQtR6R1ZDxJuQFnPjnLMPhH0AgX2UK1c1JC0h1VD3Fp7MfqINAF9tOcv8TacVLpEQQtQSR1bDT0MKByAAabHm80dWK1OuakrxIGTevHn4+/uj1+sJDg5mx44dt02fkpLC6NGj8fb2RqfT0bRpU9auXXtXeVZHT7Svzzv/Mu+0OzviOD/uuKBwiYQQohoymSA3s3RHdhr8MR4orhv8+rmIN83pSpOfqXTd6QsXLsTHxwejsfA4wL59+/Lcc89x+vRp+vbti6enJ46Ojtx3331s2LDh7uqlkijaHbN8+XLCw8NZsGABwcHBzJ07l9DQUI4fP46Hh0eR9Lm5ufTs2RMPDw9WrFiBr68v58+fp06dOuXOszp7oWtDrmTmMn/jad769SB17LWEtfJWulhCCFF9GLLgPZ8KysxkbiF53690yd+KAVuHOyZ76qmneOWVV/jrr7/o3r07AMnJyURERLB27VoyMjJ45JFHePfdd9HpdCxdupTevXtz/Phx7rnnnrt5IKtTtCVkzpw5jBgxguHDhxMYGMiCBQuwt7dn0aJFxaZftGgRycnJrFy5ks6dO+Pv70+3bt1o27ZtufOs7saHNqN/Bz+MJvj3D/vYejpJ6SIJIYSoQK6urjz88MMsW7bMcm7FihW4u7vz4IMP0rZtW1566SVatWpFkyZNmDFjBo0aNWL16qrfNaRYS0hubi67d+9m4sSJlnNqtZoePXoQHR1d7DWrV68mJCSE0aNHs2rVKurVq8fAgQN588030Wg05coTICcnh5ycHMv7tLQ0AAwGAwZD1V8YbOqjzUjOzCHyaAIjlu7i++fuo6WPc4XlX1AH1aEuahKpd2VIvSujsurdYDBgMpkwGo3m7g2NHiZcKt3F57ei/uHpOyYzPvMTNOh05/w0ejCWbqmFZ555hpdeeonPPvsMnU7H999/T//+/QHzd9a0adNYu3YtsbGx5OXlce3aNc6fP1+oC6fguW9mut4lVNxnt2M0GjGZTBgMBjQaTaHPyvJnqFgQkpSURH5+Pp6enoXOe3p6cuzYsWKvOXPmDH/++SeDBg1i7dq1nDp1ilGjRmEwGJgyZUq58gSYNWsW06ZNK3J+/fr12Nvbl+PpKl+oM5x1VnMqDQZ/Gc3YVvl42FXsPSIjIys2Q1EqUu/KkHpXhrXr3cbGBi8vLzIyMsjNzS3bxfU64OzojSojDlUx40JMqDA5epFWrwNkl2LKbnZ6qW/drVs3jEYjK1asoF27dmzevJnp06eTlpbGq6++ysaNG5kxYwYBAQHY2dkxdOhQMjIyLP+pNhqNZGdnW97fKj299GUBc0PCtWvX+Pvvv8nLyyv0WVZWVqnzqVZTdI1GIx4eHixcuBCNRkP79u25fPkyH374IVOmTCl3vhMnTiQ8PNzyPi0tDT8/P3r16oWzc8W1KFjbQz3yGLxoJ0di01lyzpEfR3TE01l/1/kaDAYiIyPp2bMnWq22AkoqSkPqXRlS78qorHrPzs7m4sWLODo6oteX4/fjwx/A/4ZiQlUoEDGhsnzuXMe1gkp7g7OzM48//ji//vorMTExNGvWjK5duwKwa9cuhg8fzsCBAwHIyMjg4sWL2NraWr7D1Go1er2+yHeayWQiPT0dJyenMi31kJ2djZ2dHffff3+Reiwp0CmOYkGIu7s7Go2G+Pj4Qufj4+Px8vIq9hpvb2+0Wm2hpp8WLVoQFxdHbm5uufIE0Ol06HS6Iue1Wm21+iXkptWy5LlgnlqwlXNXsnh+6V5+eikEF/uKeYbqVh81hdS7MqTelWHtes/Pz0elUqFWq1GryzEssmVfUC0tsk6IytkHwt5HZcV1QgYPHsyjjz7KkSNHGDx4sKX8TZo04ddff6VPnz6oVComTZqE0Wi0PKeljLe8ByxdMMV9djtqtRqVSlXsn1dZ/vwUG5hqa2tL+/btiYqKspwzGo1ERUUREhJS7DWdO3fm1KlThfqtTpw4gbe3N7a2tuXKs6ap56Tj2+eD8XDScTw+nedknxkhhKhYgX1g3CEY+js88bX557iDVl+o7KGHHsLNzY3jx49bWj3APCHD1dWVTp060bt3b0JDQ7n33nutWpaKomh3THh4OEOHDqVDhw507NiRuXPnkpmZyfDhwwEYMmQIvr6+zJo1C4CRI0fy2WefMXbsWF555RVOnjzJe++9x7///e9S51kb+LnZs/T5jjy9IJrd568y6vvdLBzSAa1G8WVhhBCiZlBrIKBr5d5SrSYmJqbIeX9/f/78889C50aPHl3o/blz56xZtHJTNAjp378/iYmJTJ48mbi4OIKCgoiIiLAMLL1w4UKh5iE/Pz/WrVvHq6++Sps2bfD19WXs2LG8+eabpc6ztmju5cyiYfcx+Ovt/HU8kfErDvCfp9qiVsvy7kIIIaoGxQemjhkzhjFjxhT72caNG4ucCwkJYdu2beXOszbp4G/eZ2bE0t38uvcyrva2THpU9pkRQghRNUj7fA33UHNPPnrKvM/Mon/O8vlG2WdGCCFE1SBBSC3wWLv6THo0EIAP1x3nB9lnRgghRBUgQUgt8XyXAEY90AiAt389SMShWIVLJIQQyjGVcvM4UbyKqj8JQmqRN0Kb8UzHm/aZOSX7zAghapeCdabKvFqqKKRgVdS7XdNF8YGpovKoVCpm9mvN1UwDEYfjGLF0Fz++GELr+i5KF00IISqFjY0N9vb2JCYmotVqy7dgWQ1iNBrJzc0lOzu7VHVhMpnIysoiISGBOnXqFNk3pqwkCKllNGoVcwcEMfybnUSfucKwb3bwv5dDaFjPUemiCSGE1alUKry9vTl79iznz59XujiKM5lMXLt2DTs7uzLNnKxTp85tVyIvLQlCaiG9VsPCIe155sttHLqcxrNf7+DnkZ3wcrn7fWaEEKKqs7W1pUmTJtIlg3nPnr///pv777+/1F0rt26fcjckCKmlnPRaFg/vyFMLojmblMmQRdv56aUQ6tjbKl00IYSwuoIN3Wo7jUZDXl4eer1ekb2SandnWC3n7qhj6XMd8XTWcSI+g+cW7yQrN+/OFwohhBAVQIKQWs7PzZ6lzwXjYqdlz4UURn2/B0O+8c4XCiGEEHdJghBBMy8nFg3rgF6rZuPxRF7/336MRplDL4QQwrokCBEAtG/gxvzB7bFRq1i1L4bpvx+RxXyEEEJYlQQhwuLBZh589FRbABZvPce8v06RbzSx/Wwyu5NUbD+bTL60kAghhKggMjtGFNKvnS/JmblM//0IH60/wcK/z5CWnQdoWHpyF94ueqb0DiSslbfSRRVCCFHNSUuIKOK5LgE83Mq8CI05ALkhLjWbkd/tkb1nhBBC3DUJQkQR+UYTey+mFPtZQWfMtN+OSNeMEEKIuyJBSGUw5sPZzXBwhfmnMV/pEt3WjrPJxKVml/i5CYhNzWbH2eTKK5QQQogaR8aEWNuR1RDxJqTF3Djn7ANhH0BgH+XKdRsJ6SUHIOVJJ4QQQhRHWkKs6chq+GlI4QAEIC3WfP7IamXKdQceTqVbyri06YQQQojiSBBiLcZ8cwsIxY2buH4uYkKV7JrpGOCGt4ue2+2n6GKnpWOAW6WVSQghRM0jQYi1nN9atAWkEBOkXTanq2I0ahVTegcClBiIpF4z8NXmM5VXKCGEEDWOBCHWkhFfunTr3oKtn0HsATBWnT1bwlp5M3/wvXi5FO5y8XbR0yvQE4BZfxzjo3XHZWVVIYQQ5SIDU63F0bN06eIOmA8AOzcI6AoB90NAN6jbGFS36xSxrrBW3vQM9CL6VALrN2+nV9dgQhp7oFGr+HzjKWZHHOezv06Rnm1gSu+WqNXKlVUIIUT1I0GItTToZJ4FkxZL8eNCVOBQDzqNgXNbzN0y15LhyCrzAeDkcz0guX7U8avMJwDMXTPBAW5cOWoiOMANzfVAY9QDjXHSa5m86hBLos+TnpPH7CfaYKORxjUhhBClI0GItag15mm4Pw3BPLLi5kDkeovBv/5jnqbbeSzkGyBmL5zZBGc3wcUdkB4DB340HwCuAYWDEkePSn6owp79vwY46jS8/r8D/LLnMpk5eXz6TDt0NhpFyyWEEKJ6kCDEmgL7wNNLS1gn5P3C64RotODX0Xx0ewMM18yByNm/zcfl3XD1rPnYs8R8jUfgjYCkQWewq1OpjwfwWLv6ONjaMGbZXtYdjueFJbv44tn22NvKXy0hhBC3VyXazufNm4e/vz96vZ7g4GB27NhRYtrFixejUqkKHXp94cGTw4YNK5ImLCzM2o9RvMA+MO4QDP0dnvja/HPcwTsvVKa1g4bdoPskeCES3jwHA3+CkDHg1dqcJuEIbF8APw6E2QGw8AGInAKnoiA309pPZtGrpRffDL8Pe1sNm08mMfir7aReM1Ta/YUQQlRPiv93dfny5YSHh7NgwQKCg4OZO3cuoaGhHD9+HA+P4rsbnJ2dOX78uOW9qpjBm2FhYXzzzTeW9zqdruILX1pqjXnA6d3QO0PTUPMBkHkFzm2+0VJy5aS5OydmL/wzF9RaqH/fjZaS+veBje1dP0pJOjd257sXghm2aAd7LqQwYOE2vn2+I+6OCta7EEKIKk3xIGTOnDmMGDGC4cOHA7BgwQLWrFnDokWLmDBhQrHXqFQqvLy8bpuvTqe7Y5pqzaEutOxnPsDc3XO2ICjZBKkX4cJW87HpfbCxgwYhN4IS7yBzcHQnxnxU57fgmxyN6rwzNLy/xOvuvceV5S+F8OzXOzgam8bTC6L59oVgfOvYVdRTCyGEqEEUDUJyc3PZvXs3EydOtJxTq9X06NGD6OjoEq/LyMigQYMGGI1G7r33Xt577z1atmxZKM3GjRvx8PDA1dWVhx56iJkzZ1K3bt1i88vJySEnJ8fyPi0tDQCDwYDBUE26FezqQeDj5sNkgpRzqM5tRn1uM6rzW1BlJsLpP80HYNI5Y2rQGZN/V4wNukK95kWmA6uO/Y5m/VvYpMfQAeD8fExOPuT3eg9T80eLLUZjdzt+eKEDQ7/ZzZmkTJ6cv5Ulw9oT4O5g5QqoeQr+7lWbv4M1hNS7MqTelWGNei9LXiqTgitNxcTE4Ovry9atWwkJCbGcHz9+PJs2bWL79u1FromOjubkyZO0adOG1NRUPvroI/7++28OHz5M/fr1Afjxxx+xt7cnICCA06dP89Zbb+Ho6Eh0dDQaTdH/xU+dOpVp06YVOb9s2TLs7e0r8IkVYjLhlH2ZeulHcM84gnvGMbT5WYWSZNs4k+TYgiSnQBKdAnHJusB95/4LFF41teAvy86AV4itc1+Jt7yaA58f0ZCQrcJRa2JUi3x8JQ4RQogaLysri4EDB5Kamoqzs/Nt01a7IORWBoOBFi1a8MwzzzBjxoxi05w5c4ZGjRqxYcMGunfvXuTz4lpC/Pz8SEpKumMFVkvGfFRxB1Cd34zq3BZUF7ehMhQOSkwqDZjyi1223YQKnH3IG73ntl06VzJyGL5kD0fj0nHW2/DVs/fS7p46FfssNZjBYCAyMpKePXui1WqVLk6tIfWuDKl3ZVij3tPS0nB3dy9VEKJod4y7uzsajYb4+MJLnMfHx5d6PIdWq6Vdu3acOnWqxDQNGzbE3d2dU6dOFRuE6HS6YgeuarXaGvqPQQsNOpqP+1+DvFy4vOvGINcL21CZSt5YT3V93xttzM7bDrj1ctXy40shPLd4J7vPX2XYkt0sfLYDXZq4W+Ohaqya+/ewapN6V4bUuzIqst7Lko+iU3RtbW1p3749UVFRlnNGo5GoqKhCLSO3k5+fz8GDB/H29i4xzaVLl7hy5cpt09RqNrbmFV4fmADD10KfT0t3XSn2x3Gx0/Lt8x3p2sSdrNx8nlu8k/WH4+6ywEIIIWoCxdcJCQ8P58svv2TJkiUcPXqUkSNHkpmZaZktM2TIkEIDV6dPn8769es5c+YMe/bsYfDgwZw/f54XXngBMA9afeONN9i2bRvnzp0jKiqKvn370rhxY0JDQxV5xmqnToPSpSvl/jj2tjZ8NbQDYS29yM03MvL7Pfyy59JdFFAIIURNoPgU3f79+5OYmMjkyZOJi4sjKCiIiIgIPD3NX3AXLlxArb4RK129epURI0YQFxeHq6sr7du3Z+vWrQQGmree12g0HDhwgCVLlpCSkoKPjw+9evVixowZyq4VUp2UZt8bZx9zulLS2Wj4bGA73vz5ID/vuUT4T/vJzMnj2RD/iiq1EEKIakbxIARgzJgxjBkzptjPNm7cWOj9xx9/zMcff1xiXnZ2dqxbt64ii1f73HbfG8zvw94v3TojN7HRqPnwyTY46W1YvPUck1YdJi07j9EPNq6okgshhKhGFO+OEVVUwb43zsWMo7GxM+9xUw5qtYopvQP590PmwOPDdcd5/49jKDhJSwghhEIkCBElu77vTd7glexqMJK8gb+AdzvIuwbr3ip3tiqVivBezXj7kRYALNh0mrdXHiLfKIGIEELUJhKEiNtTazA16MJltxBMAfdD77mgUsOhny2rr5bXiPsbMuvx1qhUsGz7BcJ/2och31gx5RZCCFHlSRAiysYnCO4bYX695nUwZN9Vds90vIdPB7TDRq1i1b4YRn63m2xDyWuUCCGEqDkkCBFl99Db4OgFyafhn0/uOrvebX1YOKQ9Ohs1G44mMPybnWTk5FVAQYUQQlRlEoSIstO7QNh75teb/wNXTt91lg8192TJcx1x1NkQfeYKg77aTkpW7l3nK4QQouqSIESUT8vHoeGDkJ8Da18379x7l/6vYV2WjQimjr2W/RdT6P/FNhLS7q67RwghRNUlQYgoH5UK/vUf0OjMA1QP/1oh2bapX4efXgrBw0nH8fh0nvoimovJWXe+UAghRLUjQYgov7qNoGu4+XXERMhOq5Bsm3o6seLlTvi52XH+ShZPLYjmVEJGheQthBCi6pAgRNydzuPArSFkxMFf71ZYtvfUted/L3WiiYcjcWnZPP1FNIcup1ZY/kIIIZQnQYi4O1q9uVsGYMdCiNlXYVl7uehZ/lIIbeq7kJyZyzMLt7HzXHKF5S+EEEJZEoSIu9foIWj1BJiM8PurYKy4dT7cHGz5/oVgOga4kZ6Tx7Nfb2fTicQKy18IIYRyJAgRFSP0PdA5Q8we2P1NhWbtpNey9LmOPNisHtkGIy8s2cnag7EVeg8hhBCVT4IQUTGcvOChSebXG6ZDRkKFZq/Xavji2Q482sYbQ76JMcv28NOuixV6DyGEEJVLghBRce57HryDICcV1r1d4dnb2qj5ZEA7Btznh9EE41ccYNGWsxV+HyGEEJVDghBRcdQaePRjQAUHf4Izmyr8Fhq1ilmPt2ZE1wAApv9+hE82nMRUAYulCSGEqFwShIiK5XuvuUUEYM1rkJdT4bdQqVS89UgLXuvZFICPN5xg5pqjEogIIUQ1I0GIqHgPTQIHD7hyErZ+apVbqFQqXunehCm9AwH4estZJvx8kHyjBCJCCFFdSBAiKp5dHfNsGYC/P4Jk643bGN45gA+fbINaBct3XeTfP+wlN89otfsJIYSoOBKECOto/SQEdIO8bFj7RoVscFeSpzr48fmge9FqVKw5GMuL3+7iWm4++UYT0aevsGrfZaJPX5FWEiGEqGJslC6AqKEKNrib3wlORcLR1RDY12q3C2vlzddDbXjx211sPJ5I7/9uIT3HQHzajTEp3i56pvQOJKyVt9XKIYQQovSkJURYj3sT894yAH9MgJx0q97u/qb1+O75YPQ2ak4lZhQKQADiUrMZ+d0eIg7JQmdCCFEVSBAirKtrOLj6Q3oM/DXL6rdrd48rjvriG/gKOmOm/XZEumaEEKIKkCBEWJfWDh65vsHd9gUQe8Cqt9txNpmkjNwSPzcBsanZ7DgrG+EJIYTSJAgR1tekBwT2A1M+rAkHo/VmrySkZ1doOiGEENYjQYioHGGzwNYRLu2EPUusdhsPJ32FphNCCGE9VSIImTdvHv7+/uj1eoKDg9mxY0eJaRcvXoxKpSp06PWFv1BMJhOTJ0/G29sbOzs7evTowcmTJ639GOJ2nH3gwev7yWyYChmJVrlNxwA3vF30qEr4XIV5lkzHADer3F8IIUTpKR6ELF++nPDwcKZMmcKePXto27YtoaGhJCSUvAurs7MzsbGxluP8+fOFPp89ezaffvopCxYsYPv27Tg4OBAaGkp2tjTBK6rji+DVGrJTIHKSVW6hUassq6gWF4iYgCm9A9GoSwpThBBCVBbFg5A5c+YwYsQIhg8fTmBgIAsWLMDe3p5FixaVeI1KpcLLy8tyeHp6Wj4zmUzMnTuXd955h759+9KmTRuWLl1KTEwMK1eurIQnEiXS2MCjcwEV7P8Bzm2xym3CWnkzf/C9eLkU7XJRAb517K1yXyGEEGWj6GJlubm57N69m4kTJ1rOqdVqevToQXR0dInXZWRk0KBBA4xGI/feey/vvfceLVu2BODs2bPExcXRo0cPS3oXFxeCg4OJjo5mwIABRfLLyckhJ+fGmhJpaWkAGAwGDAbDXT9ndVdQBxVSF55tUbcbgmbvEky/v0reCxtBY3v3+d6iezN3HmjSlV3nr5KQnoOHk45lOy6y9lA841fs5+eXg9FqFI/Bb6tC612UmtS7MqTelWGNei9LXooGIUlJSeTn5xdqyQDw9PTk2LFjxV7TrFkzFi1aRJs2bUhNTeWjjz6iU6dOHD58mPr16xMXF2fJ49Y8Cz671axZs5g2bVqR8+vXr8feXv7XXCAyMrJC8tHm/R/dbX5Bl3SCk0vGctKrd4XkWxINcAXopIeNNhqOxqUzftE6evpWj7VCKqreRdlIvStD6l0ZFVnvWVlZpU5b7ZZtDwkJISQkxPK+U6dOtGjRgi+++IIZM2aUK8+JEycSHh5ueZ+Wloafnx+9evXC2dn5rstc3RkMBiIjI+nZsydarbZC8lQFmGD1KFok/k6TxydAnQYVku+d2N4Tw/hfDrE+Rsu/HwshwN2hUu5bHtaod3FnUu/KkHpXhjXqvaA3oTQUDULc3d3RaDTEx8cXOh8fH4+Xl1ep8tBqtbRr145Tp04BWK6Lj4/H2/vGHiHx8fEEBQUVm4dOp0On0xWbt/xjuKFC66PdQDjwA6pzm9FGvg3P/Gjeb8bKnrrvHn47GMfmk0lMWn2UH0b8H+oqPkhV/h4qQ+pdGVLvyqjIei9LPop2itva2tK+fXuioqIs54xGI1FRUYVaO24nPz+fgwcPWgKOgIAAvLy8CuWZlpbG9u3bS52nqAQFG9yptXAiAo6tqaTbqnjvsdbYaTVsP5vMjzsvVsp9hRBCFKX4yLzw8HC+/PJLlixZwtGjRxk5ciSZmZkMHz4cgCFDhhQauDp9+nTWr1/PmTNn2LNnD4MHD+b8+fO88MILgPlLZty4ccycOZPVq1dz8OBBhgwZgo+PD/369VPiEUVJ6jWDzv82v/5jPORkVMpt/dzseT20GQCz1h4lLlWmbgshhBIUHxPSv39/EhMTmTx5MnFxcQQFBREREWEZWHrhwgXU6hux0tWrVxkxYgRxcXG4urrSvn17tm7dSmBgoCXN+PHjyczM5MUXXyQlJYUuXboQERFRZFEzUQV0fR0O/g9SLsCm96HXzEq57bBO/qzeH8P+iylMWnWIhc+2R1UJ3UFCCCFuULwlBGDMmDGcP3+enJwctm/fTnBwsOWzjRs3snjxYsv7jz/+2JI2Li6ONWvW0K5du0L5qVQqpk+fTlxcHNnZ2WzYsIGmTZtW1uOIsrC1v7HBXfTnEH+4Um6rUav44InW2KhVRB6J549Dxc+cEkIIYT1VIggRtVzTXtCit3mDu99fteoGdzdr7uXMqAcaATB51WFSskrefVcIIUTFkyBEVA1h74PWAS5uh33fVdptRz/UmEb1HEjKyOG9tUcr7b5CCCEkCBFVhUt9ePD6AOTIyZB5pVJuq7PR8METbQD4adcl/jmVVCn3FUIIIUGIqEqCXwbPVnDtqjkQqSQd/N149v/Mi6VN/OUg13LzK+3eQghRm0kQIqoOjRb+Ncf8et93cL7k/YMq2viwZni76LmQnMXHG05U2n2FEKI2kyBEVC33BMO9Q8yvf38V8itnMysnvZaZ/VoB8NXmMxy4lFIp9xVCiNpMghBR9fSYBvZ1IfEoRM+rtNt2b+FJ77Y+GE3w5s8HMeRXziwdIYSorSQIEVWPvRv0vL4Z4aYPzAuZVZIpvQOpY6/laGwaC/8+U2n3FUKI2kiCEFE1BQ2EezqBIQv+mFBpt3V31DHpX+bVdz+JOsnpxMpZSl4IIWojCUJE1aRSwaNzQG0Dx9fAsbWVduvH7/WlaxN3cvOMTPzlIEajqdLuLYQQtYkEIaLq8mgBIWPMr/8YD7mZlXLbm3fa3XE2mR92Vl53kBBC1CYShIiqrdt4cLkHUi/CptmVdtubd9p9f+0x2WlXCCGsQIIQUbXZOsDDH5hfR38GCZW3tPqwTv4E+dUhPSePd1YewmSSbhkhhKhIEoSIqq/5I9DsX2DMg9/DoZKCAfNOu22wUavYcDSetQdlp10hhKhIEoSI6uHhD0BrDxe2wr5llXbbZl5Olp12p6w+JDvtCiFEBZIgRFQPdfyg25vm15GTICu50m59Y6fdXN5dIzvtCiFERZEgRFQfIaOhXgvIugIbplTabQt22lWp4H+7L7HlpOy0K4QQFUGCEFF9aLTw6Mfm13uWwoXtlXbrQjvt/npAdtoVQogKIEGIqF4ahEDQYPPrStzgDmB8WHO8XfRcTL7GnMjjlXZfIYSoqSQIEdVPz+lg5woJh2H7gkq7raPOhncfM++0+/WWs+y/mFJp9xZCiJqoXEHIxYsXuXTpkuX9jh07GDduHAsXLqywgglRIoe65kAE4K9ZkHrp9ukr0EPNPelj2Wn3gOy0K4QQd6FcQcjAgQP566+/AIiLi6Nnz57s2LGDt99+m+nTp1doAYUoVtBg8AsGQyZEVN4Gd2DeadfVXsuxuHTZaVcIIe5CuYKQQ4cO0bFjRwB++uknWrVqxdatW/n+++9ZvHhxRZZPiOKp1eZBqioNHP0NTqyrtFvXddQx6VHZaVcIIe5WuYIQg8GATqcDYMOGDfTp0weA5s2bExsbW3GlE+J2PFtCyCjz67WvQ25Wpd36sXa+3N+0nnmn3Z9lp10hhCiPcgUhLVu2ZMGCBWzevJnIyEjCwsIAiImJoW7duhVaQCFuq9sEcK4PKRdg80eVdluVSsW7/Vphb6thx7lklu2QnXaFEKKsyhWEfPDBB3zxxRc88MADPPPMM7Rt2xaA1atXW7pphKgUOkd4+H3z638+hcTKmzrr52bP672u77T7h+y0K4QQZVWuIOSBBx4gKSmJpKQkFi1aZDn/4osvsmBB2adMzps3D39/f/R6PcHBwezYsaNU1/3444+oVCr69etX6PywYcNQqVSFjoLWGlEDNX8UmoaB0QBrXqu0De4Ahl7faTdDdtoVQogyK1cQcu3aNXJycnB1dQXg/PnzzJ07l+PHj+Ph4VGmvJYvX054eDhTpkxhz549tG3bltDQUBISEm573blz53j99dfp2rVrsZ+HhYURGxtrOX744YcylUtUIyoVPDwbbOzg3GY4sLzSbl2w065WY95pd81BGRMlhBClZVOei/r27cvjjz/Oyy+/TEpKCsHBwWi1WpKSkpgzZw4jR44sdV5z5sxhxIgRDB8+HIAFCxawZs0aFi1axIQJxU+9zM/PZ9CgQUybNo3NmzeTkpJSJI1Op8PLy6tUZcjJySEnJ8fyPi0tDTAPwDUYKm9FzqqqoA6qdF04+qDu8hqajTMxrXubvIDuYFenUm7dsK6el7oG8NnGM0xZdZjgBnWoY6+963yrRb3XQFLvypB6V4Y16r0seZUrCNmzZw8ff2zew2PFihV4enqyd+9efv75ZyZPnlzqICQ3N5fdu3czceJEyzm1Wk2PHj2Ijo4u8brp06fj4eHB888/z+bNm4tNs3HjRjw8PHB1deWhhx5i5syZJQ6anTVrFtOmTStyfv369djb25fqWWqDyMhIpYtwWypjQx7U++CUFcOlJSM4cM/wSrt3gBE87TTEZ+Yy+qsoBjWuuEXMqnq911RS78qQeldGRdZ7VlbpZyqWKwjJysrCyckJMH9RP/7446jVav7v//6P8+fPlzqfpKQk8vPz8fT0LHTe09OTY8eOFXvNli1b+Prrr9m3b1+J+YaFhfH4448TEBDA6dOneeutt3j44YeJjo5Go9EUST9x4kTCw8Mt79PS0vDz86NXr144OzuX+nlqKoPBQGRkJD179kSrvfv/4VuTqnVd+K4v/lc24td7Aibf9pV27/ptUhjw1Q52JKoZ+ch9dGl8dzPFqlO91yRS78qQeleGNeq9oDehNMoVhDRu3JiVK1fy2GOPsW7dOl599VUAEhISrPqlnZ6ezrPPPsuXX36Ju7t7iekGDBhged26dWvatGlDo0aN2LhxI927dy+SXqfTWdY9uZlWq5V/DDepFvXR+AFo+wyq/T9g88dr0OtdyEoCR09o0AnURYPQihLcqB5D/q8BS6LPM/m3I6wbdz/2tuX6J1ZItaj3GkjqXRlS78qoyHovSz7lGpg6efJkXn/9dfz9/enYsSMhISGAuVWkXbt2pc7H3d0djUZDfHx8ofPx8fHFjuc4ffo0586do3fv3tjY2GBjY8PSpUtZvXo1NjY2nD59utj7NGzYEHd3d06dOlWGpxTVVs8ZoLWH+EPwbV/4+XlY8ijMbQVHVlv11m+ENcenYKfd9Sesei8hhKjuyhWEPPnkk1y4cIFdu3axbt2N5bK7d+9uGStSGra2trRv356oqCjLOaPRSFRUlCWwuVnz5s05ePAg+/btsxx9+vThwQcfZN++ffj5+RV7n0uXLnHlyhW8vb3L8JSi2roQDYZi+iTTYuGnIVYNRMw77bYGYNE/stOuEELcTrnbir28vPDy8rLsplu/fv1yLVQWHh7O0KFD6dChAx07dmTu3LlkZmZaZssMGTIEX19fZs2ahV6vp1WrVoWur1OnDoDlfEZGBtOmTeOJJ57Ay8uL06dPM378eBo3bkxoaGh5H1dUF8Z8iHizhA9NgMq84V3zf1mta+bB5h70DfJh1b4Y3vz5AL+90gWtplzxvhBC1Gjl+s1oNBqZPn06Li4uNGjQgAYNGlCnTh1mzJiB0Vi2WQH9+/fno48+YvLkyQQFBbFv3z4iIiIsg1UvXLhQpv1oNBoNBw4coE+fPjRt2pTnn3+e9u3bs3nz5mLHfYga5vxWSIu5TQITpF02p7OiyY/e2Gn3i03FdxMKIURtV66WkLfffpuvv/6a999/n86dOwPmWStTp04lOzubd999t0z5jRkzhjFjxhT72caNG2977a279trZ2RXqIhK1TEb8ndOUJV051XXUMbl3IK8u38+nUacIa+VNYw9Hq95TCCGqm3K1hCxZsoSvvvqKkSNH0qZNG9q0acOoUaP48ssviwQFQlQqR887pwGwdbJuOYB+Qb50a1qP3HwjE385IDvtCiHELcoVhCQnJ9O8efMi55s3b05ycvJdF0qIcmvQCZx9ANXt0619Dc6XvCBeRVCpVLz7mHmn3Z3nrvK97LQrhBCFlCsIadu2LZ999lmR85999hlt2rS560IJUW5qDYR9cP3NrYHI9ff27pB6ERY/AlHTIS/XasWp72rPG6HmnXY/+OMYsanXrHYvIYSobsoVhMyePZtFixYRGBjI888/z/PPP09gYCCLFy/mo48+qugyClE2gX3g6aXgfMuUbGcfePpb+PdeaDsQTEbY/B/4ugckHrdacYaE3Nhpd5LstCuEEBblCkK6devGiRMneOyxx0hJSSElJYXHH3+cw4cP8+2331Z0GYUou8A+MO4QDP0dnvja/HPcQfN5vTM8Nt8cqNi5Qux++OJ+2L4QrBAgaNQqZj9ZsNNuAr8fkJ12hRAC7mKdEB8fnyKzYPbv38/XX3/NwoUL77pgQtw1tQYCupb8eWBfqN8RVo2G01HwxxtwIgL6zivainKXmno6MeqBxnwSdZKpqw/TpbE7rg62FXoPIYSobmQFJVG7OXvD4J/h4Q/BRm8ORuaHwJFVFX6rUQ82orGHI1cyc5m55miF5y+EENWNBCFCqFQQ/CK89Dd4tYFrV83Lu/86ErJLvxvknehsNHzwRBtUKvh5zyU2n0yssLyFEKI6kiBEiAL1msELUdAlHFRq2L8MFnSu0Km87Ru4MjTEH4CJvxwkKzevwvIWQojqpkxjQh5//PHbfp6SknI3ZRFCeTa20GMKNOkFv74IKRfMU3k7j4MHJpo/v0uvhzZj/eE4Ll29xn/Wn2DSo4F3X24hhKiGytQS4uLictujQYMGDBkyxFplFaLyNAiBl/+BoEHmqbxb5lTYVF5HnQ3vPm7eafebf86yT3baFULUUmVqCfnmm2+sVQ4hqh69M/T7HJqGwm9jb0zl7TkdOr5oHktSTg82u7HT7oSfD7B6TBdsbaR3VAhRu8hvPSHuJLAvjIyGRt0hLxv+GA/fPQ5pd7feh+y0K4So7SQIEaI0ikzl/dM8lffwynJnWddRx5TeLQH475+nOJWQUUGFFUKI6kGCECFK6+apvN5tzVN5/zf0rqby9g3y4YFmstOuEKJ2kiBEiLKq1wye3wBdX7tlKu/WMmelUqmY2e+mnXa3n7dCgYUQomqSIESI8rCxhe6TYfgfUKeBeSrvN4/Ahqll3pW3vqs94wt22o04TkyK7LQrhKgdJAgR4m7c83/w8hbzVF5MsOVj+Ko7JBwrUzbPhvjT7h7ZaVcIUbtIECLE3SqYyvv0t2DnBnEHYGE32P4FGI2lykKjVvHBE+addqOOJbB6XwzbzyazO0nF9rPJ5MtYESFEDSRBiBAVJbAPjIqGxj1uTOX9/olST+Ut2GkX4NWf9jF40S6WntQweNEuunzwJxGH7m5KsBBCVDUShAhRkZy8YNAKeOSjck3lbezhAMCtDR9xqdmM/G6PBCJCiBpFghAhKppKBR1HwEubwTvopqm8L992Km++0cR7a4sfS1IQk0z77Yh0zQghagwJQoSwlnpN4flI6Pr69am8P9x2Ku+Os8nEpmaXmJ0JiE3NZsfZZCsVWAghKpcEIUJYk40tdJ9Uqqm8CeklByDlSSeEEFWdBCFCVAbLVN7BlDSV18NJX6qsSptOCCGqOglChKgsemfoN6/oVN5tC8BopGOAG94uem63N6+Tzob7/F0rrchCCGFNVSIImTdvHv7+/uj1eoKDg9mxY0eprvvxxx9RqVT069ev0HmTycTkyZPx9vbGzs6OHj16cPLkSSuUXIhyuHUqb8Sb8N3jaDJimdI7EAANRv5PfYQ+6q38n/oIaszrjaTn5DF+xQFy8vKVfAIhhKgQigchy5cvJzw8nClTprBnzx7atm1LaGgoCQkJt73u3LlzvP7663Tt2rXIZ7Nnz+bTTz9lwYIFbN++HQcHB0JDQ8nOlr50UUUUmsprB2f+gs9DCFNt55cHk9iqH8uPtjP51PYzfrSdSbR+LDObnUGjVvHL3ss8+9UOrmaWbXl4IYSoamyULsCcOXMYMWIEw4cPB2DBggWsWbOGRYsWMWHChGKvyc/PZ9CgQUybNo3NmzeTkpJi+cxkMjF37lzeeecd+vbtC8DSpUvx9PRk5cqVDBgwoEh+OTk55OTkWN6npZmnURoMBgwGQ0U9arVVUAdSF1bQbhj4dUaz6mXUcfvhf0MJKiaZB8kMOj+Jtg9+wjNbvNhxLpl+8/5h4eB2NKznUMmFrtnk77sypN6VYY16L0teKpOCm1Tk5uZib2/PihUrCnWpDB06lJSUFFatWlXsdVOmTOHAgQP8+uuvDBs2jJSUFFauXAnAmTNnaNSoEXv37iUoKMhyTbdu3QgKCuKTTz4pkt/UqVOZNm1akfPLli3D3t7+rp5RiNJQGfNoFvsrTRN+K3FMiAm4pnXj24A5fHFcS3KOCnuNieeaGWniImuHCCGqhqysLAYOHEhqairOzs63TatoS0hSUhL5+fl4enoWOu/p6cmxY8Uv2rRlyxa+/vpr9u3bV+zncXFxljxuzbPgs1tNnDiR8PBwy/u0tDT8/Pzo1avXHSuwNjAYDERGRtKzZ0+0Wq3SxamxVOfdUH33W8mfA/aGZJ7vWIc+D9/HyGX72HcxlQXHbJjRN5An7/WtvMLWYPL3XRlS78qwRr0X9CaUhuLdMWWRnp7Os88+y5dffom7u3uF5avT6dDpdEXOa7Va+cdwE6kPK7t2pVTJbFaPxtunHSsaN2S52pbVF+z4+NdkLiS3543Q5qjVt5tfI0pL/r4rQ+pdGRVZ72XJR9EgxN3dHY1GQ3x8fKHz8fHxeHl5FUl/+vRpzp07R+/evS3njNd3KbWxseH48eOW6+Lj4/H29i6U583dM0JUOY6ed04DkHYZ0i5jAwwCBl2PnzO36bi8tz4+DVuicW8MdRuBWyPzT4d65uXkhRCiClE0CLG1taV9+/ZERUVZxoQYjUaioqIYM2ZMkfTNmzfn4MGDhc698847pKen88knn+Dn54dWq8XLy4uoqChL0JGWlsb27dsZOXKktR9JiPJr0Amcfa7vulvcGA8VOHpA7/9Cyjm4chqST8OV0xhTLuBADg65p+HY6aKX6pzBrWHhwKTgp71bxT6HMd+8NH1GvDmwatAJ1JqKvYcQokZQvDsmPDycoUOH0qFDBzp27MjcuXPJzMy0zJYZMmQIvr6+zJo1C71eT6tWrQpdX6dOHYBC58eNG8fMmTNp0qQJAQEBTJo0CR8fnyLriQhRpag1EPYB/DQE8wiQmwOR660Yj3wEzUKLXpqXy/5D+/lq1QY8ci/RUp9EqFcmDhnnIfUi5KRB7D7zcSt9nWKCk4bmn3Z1yvYMR1ab1z1Ji7lxztnH/FyBfcqWlxCixlM8COnfvz+JiYlMnjyZuLg4goKCiIiIsAwsvXDhAmp12ZYzGT9+PJmZmbz44oukpKTQpUsXIiIi0OtluWtRxQX2gaeXlvBF/n7JX+Q2trQNuo/X6gfy3OKdfJ2UieMlG/47sB0PNnSGq+csrSY3fp4xd+1kp8Dl3ebjVvZ1oW7jwoFJ3UbmVhWdU+G0R1ZfD6BuacVJizWff3qpBCJCiEIUnaJbVaWlpeHi4lKq6UW1gcFgYO3atTzyyCMyYKyyGPPJO/M3+zavI6hrKDYN7y91l0ZKVi4jv9tD9JkrqFUwpXdLhnbyLz5xbpY5GCkUoFx/nxFf/DUFHD1vBCeuARA9D66VtMOvyhxIjTtY5btm5O+7MqTelWGNei/Ld6jiLSFCiGKoNZgadOHy4TTaNuhSpi/uOva2LHmuI2//epD/7b7ElNWHOZuUyTv/aoGN5pZWRVt78GplPm6Vk24OUG4OTq6cMr/OumIOUjLi4cLWUpTKZG51Of0nNOlZ6mcRQtRsEoQIUQPZ2qiZ/WQbAuo5MDviOIu3nuP8lUz+O/BeHHWl/GevcwLvtubjVtdSCreanP4LLm67c57fPwmOXubuHLeG4BZQ+LXepUzPKW4iA4JFNSRBiBA1lEqlYtQDjfGv68Cry/fx1/FEnpy/la+H3YdvHbu7y9yuDvi2Nx8ADTrDkkdLd21GnPkorgXF3v2moKRh4QClomfx1CQyIFiUhzEf1fkt+CZHozrvDGXo9q0oEoQIUcM90tobnzp2vLBkF8fi0uk37x++GtKBtn51Ku4mpZle7OwDL/0NKReuj0M5e/3n9SMzAbKSzMelYnbS1tcpIUBpCA7uFbMOShX4pVxmNWFAcHWs9+rueuBqkxZDB4Dz8xUJXGVgajFkYGphMmBMGRVd75dTrvH84p0ci0tHr1Uzt38QYa2873xhaVm+DKHY6cV3+jLMSS8amBS8T48p+ToAW6dbunZuOpy8ShegVMfWBGM+zG1VuMyFVIMBwdWx3qu7kgLX0v5bvYOyfIdKEFIMCUIKkyBEGdao9/RsA6/8sJeNxxMBeDOsOS93a4iqolZTLfYLxff204tLIzfr+jTjM0WDlNSLFN/6cp3W3jx7p7ggxdkX1Gqr/1IuxGSCvGwwXDP/zMsGQzbkXbvxMy/nxudF0t10LuUinPv7zvcMeADq1AcbvfnQ2F5/rbvpuPm8HmxuTlPcNfq7D2wqs96FWSUErjI7RghRLCe9lq+GdGDmmqMs3nqODyKOcS4pkxn9WmFrU7b1eIoV2Aea/6viB0ja2oNnoPm4lSH7pi6eW46UC2DIgoTD5uNWGh3UaQCpFyg+kLl+7rexcO0q5OeWI2i4JV1e9t3VRXmc3WidfNU25josCEpuDlwKnS8m0NFoYdc3lFzvKoiYYP77VFVbcao6kwmyU2/MZEu/PputxAAELDPZzm+FgK5WL6IEIULUMjYaNVP7tCTA3YFpvx1m+a6LXEjOYsHg9rjYV0CLi1pTKb+8LLR6qNfUfNwq33A9QLm1m+eMuWUlPweunLjzPa4lw2//rvCio9KA1u76F7Sd+VksP68fxZ6zM/9Mi4GdX975Ph2eN//vtiCIysu56cgu5vz11/k3v881B1Im4418jXnmw5BZ8XVT8GX4fgNz2R3qmcf+ONS78drRo/B7nXPl75GkxKyk/Dzz2Kn0uMIBRkbcLa8Tyh/03mmdoAoiQYgQtdTQTv7c42bPmGXmhc0em/8Pi4beh7+7g9JFqzgarXmF17qNin5mzIfUS7B7MWyZc+e8vFqbu3XuGDTY3fTzDuk0dxn0GfPh+Jo7Dwh+5MOK+2LMz7slcCkIUIoLXG4T6MQdhFORd75fbjokHTcfd6KxLSZYufVwv/HTpuju6WVS0eNZcrPMwUN6/E3BxfVg4ubzWUmFg8E70buYp8Y7eoBKDWc33fma0m6oeZckCBGiFnuwuQcrRnbi+cU7OZOYyWOf/8MXz3agY0AtmA6r1oBrA2j0UOmCkNBZldvCUxql2W8o7P2K/Z+5xgY0jnefz9nNpQtC+s4DFz/ITITMpOs/i3mdm24OdK7vMl0qOpebWlRuDVxuea+vYx4/VKC0s5JMJshKvh5U3CHAyE0vbe2ZgwkHD3DyvBFgOHmZgwdHz5tee5gD3gKWMSF3CFwbdCp9We6CBCFC1HItvJ1ZObozI5buYv+lVAZ/tZ0PnmzNY+3qK120ylHa6cWV9Eu5zMq735DSSlvvbZ8pXRBluFZygGJ5fdN7Yx7kpJqP5GJ2nr6V2sa8jo1DPfOeSpe2l1Du6+dWPGcOEjITwGi4c/4FtPY3BRK3Bhg3vbavW77gUonA9TYkCBFC4OGs58cXQwj/aR9/HIrj1eX7OZuYyas9m1bczJmqqor9Ui4Xaw0ItqaKrnetHdS5x3zciclkHmhcUoBy6+vsFHPQUrDQXmkYDZB+U4uMndstLRUlBBg6J+uPa6lCgasEIUIIAOxsNcwbeC8frj/O/I2n+fTPU5y9ksWHT7ZBr63CX2YVoQr9Ui63yh4QXBGUqneVyrwCr71b8QOab5WXax6HURCUHFsLu76+83UPvg1BA80tIja2d1/uinQ9cC3vRpkVRYIQIYSFWq3izbDmBLg78NYvB/ltfwyXr2axcEgH3B3vchBfVVdFfinXOtWh3m1szYGRs4/5vUZXuiDknhBwqcLdmnexUWaFFaHS7yiEqPKe7uDH0uc74mKnZc+FFPrN+4eT8WUYNFddFfxSdgvBpNAv5VqputV7wXgWSuo2UZkXwquq44iqEAlChBDF6tTInV9GdaJBXXsuXb3G459vZfPJRKWLJYTyCsazAEUDkWoyjqiKkCBECFGiRvUc+XVUZzr6u5Gek8ewb3by/fbzShdLCOUVjGdxvmX/JWcfWW6+DGRMiBDittwcbPn2hY5M/Pkgv+y9zNu/HuJsYiYTH2mBRl3DZ84IcTvVcVZSFSNBiBDijnQ2Gv7zdFsC3B34T+QJvtpylvPJWXwyIAh7W/k1Imqx6jgrqQqR7hghRKmoVCpe6d6E/z7TDlsbNZFH4nlqQTRxqQpsyCaEqBEkCBFClEnvtj78MOL/qOtgy+GYNPrO28Khy6lKF0sIUQ1JECKEKLP2DVxZObozTTwciU/L4akF0UQeMe+6mW80EX36Cqv2XSb69BXyjcUtbS2EEDImRAhRTn5u9vw8qhOjv9/D5pNJvPjtLp5o58uW01cKddF4u+iZ0juQsFbet8lNCFEbSUuIEKLcnPVaFg27j4HB92AywYo9l4uMEYlLzWbkd3uIOBSrUCmFEFWVBCFCiLui1aiZ3qclTvriG1YLOmOm/XZEumaEEIVIECKEuGs7z10lPTuvxM9NQGxqNjvOJldeoYQQVV6VCELmzZuHv78/er2e4OBgduzYUWLaX375hQ4dOlCnTh0cHBwICgri22+/LZRm2LBhqFSqQkdYWJi1H0OIWishvXTTdEubTghROyg+MHX58uWEh4ezYMECgoODmTt3LqGhoRw/fhwPD48i6d3c3Hj77bdp3rw5tra2/P777wwfPhwPDw9CQ0Mt6cLCwvjmm28s73W6Gr4DqBAK8nDSlyqd3qZK/L9HCFFFKB6EzJkzhxEjRjB8+HAAFixYwJo1a1i0aBETJkwokv6BBx4o9H7s2LEsWbKELVu2FApCdDodXl5epSpDTk4OOTk5lvdpaWkAGAwGDAZDWR+pximoA6mLylWd6r1dfSe8nHXEp+Vwu1Ef4T/tZ3RiOkP+rwG6KhqQVKd6r0mk3pVhjXovS14qk8mk2Eix3Nxc7O3tWbFiBf369bOcHzp0KCkpKaxateq215tMJv7880/69OnDypUr6dmzJ2Dujlm5ciW2tra4urry0EMPMXPmTOrWrVtsPlOnTmXatGlFzi9btgx7e/vyP6AQtcj+KyoWnSgILG7eU8b8K6auDq7kqK6/NtGngZG2biZUsv2MEDVKVlYWAwcOJDU1FWdn59umVTQIiYmJwdfXl61btxISEmI5P378eDZt2sT27duLvS41NRVfX19ycnLQaDR8/vnnPPfcc5bPf/zxR+zt7QkICOD06dO89dZbODo6Eh0djUZTdGOh4lpC/Pz8SEpKumMF1gYGg4HIyEh69uyJVqtVuji1RnWs93WH45m59hhxaTf+PXm76Hj74eb0bOHBr/timLPhFAnp5s/v83flrbBmtPKtOv/OqmO91wRS78qwRr2npaXh7u5eqiBE8e6Y8nBycmLfvn1kZGQQFRVFeHg4DRs2tHTVDBgwwJK2devWtGnThkaNGrFx40a6d+9eJD+dTlfsmBGtViv/GG4i9aGM6lTvjwbV5+E2vuw4m0xCejYeTno6BrhZdtsdEOxP76D6fLHpNAs3n2Hnuas8/sU2Hm9Xn/FhzfB0Lt3YkspQneq9JpF6V0ZF1ntZ8lE0CHF3d0ej0RAfH1/ofHx8/G3Hc6jVaho3bgxAUFAQR48eZdasWUXGixRo2LAh7u7unDp1qtggRAhRcTRqFSGNiu/6BHDQ2RDeqxkDOt7D7IhjrNwXw897LrH2YCwvd2vEi/c3xM5WtkIXojZQdGSYra0t7du3JyoqynLOaDQSFRVVqHvmToxGY6HulFtdunSJK1eu4O0ty0YLUVX41LFj7oB2rBzdmfYNXLlmyOfjDSd46D8b+XXvJYyysJkQNZ7iw9PDw8P58ssvWbJkCUePHmXkyJFkZmZaZssMGTKEiRMnWtLPmjWLyMhIzpw5w9GjR/nPf/7Dt99+y+DBgwHIyMjgjTfeYNu2bZw7d46oqCj69u1L48aNC82eEUJUDUF+dVjxcgifDWyHbx07YlOzeXX5fh6bv5Xd52VxMyFqMsXHhPTv35/ExEQmT55MXFwcQUFBRERE4OnpCcCFCxdQq2/ESpmZmYwaNYpLly5hZ2dH8+bN+e677+jfvz8AGo2GAwcOsGTJElJSUvDx8aFXr17MmDFD1goRoopSqVQ82saHHi08WfTPWT7/6zT7L6bwxPxo/tXGmwlhzfFzk5lqQtQ0igchAGPGjGHMmDHFfrZx48ZC72fOnMnMmTNLzMvOzo5169ZVZPGEEJVEr9Uw6oHGPNXejzmRx1m+8yJrDsQSeSSe57sEMOqBRjjpZdCiEDWF4t0xQghxq3pOOmY93oY1/+5K58Z1yc0zMn/jaR78aCM/7LggG+EJUUNIECKEqLJaeDvz3fPBfDWkAw3dHUjKyGXiLwf516eb+edUktLFE0LcJQlChBBVmkqlokegJxHj7mfyo4G42Gk5FpfOoK+288KSnZxJzFC6iEKIcpIgRAhRLdjaqHmuSwCb3niAYZ38sVGr2HA0gV4f/8203w6TkpWrdBGFEGUkQYgQolqpY2/L1D4tWffq/XRv7kGe0cQ3/5yj24cb+eafsxjyjUoXUQhRShKECCGqpUb1HPl62H1893wwzb2cSL1mYNpvRwid+zdRR+NRcFssIUQpSRAihKjWujRxZ82/u/LeY61xd7TlTGImzy/ZxbNf7+BYXJrSxRNC3IYEIUKIak+jVjEw+B7+ev0BXu7WCFuNmi2nknjkk81M/OUgieklb+sghFCOBCFCiBrDSa9lwsPNiXqtG/9q7Y3RBD/suMCDH23k842nyDbkK11EIcRNJAgRQtQ4fm72zBt0L/97OYQ29V3IyMljdsRxeszZxO8HYmS8iBBVhAQhQoga6z5/N1aO6sycp9vi5azn0tVrjFm2l6cWRLP/YorSxROi1pMgRAhRo6nVKh6/tz5/vt6NV3s0xU6rYdf5q/Sd9w+vLt9HbOo1S9p8o4ntZ5PZnaRi+9lkWR5eCCurEhvYCSGEtdnb2jC2RxP63+fHh+uO8/OeS/y69zJ/HIrlxfsb0aieA+//cYzY1GxAw9KTu/B20TOldyBhrbyVLr4QNZK0hAghahUvFz3/ebotv43pQkd/N7INRj6NOsnYH/ddD0BuiEvNZuR3e4g4FKtQaYWo2SQIEULUSq3ru7D8pf9j3jPt0KiKT1PQGTPttyPSNSOEFUgQIoSotVQqFW6OOvJvE1+YgNjUbHacTa60cglRW0gQIoSo1RLSs++cCFj0zxmOx6VbuTRC1C4yMFUIUat5OOlLlS7ySAKRRxJo6ulIn7Y+9G7rQ4O6DlYunRA1m7SECCFqtY4Bbni76ClhWAgqoI69lh4tPLDVqDkRn8FH60/Q7cON9J33D19tPkN8WulaU4QQhUlLiBCiVtOoVUzpHcjI7/ag4sZgVMASmLz/eGvCWnmTes3AusNx/LY/hn9OJbH/Ygr7L6bw7tqjBAe40butD4+08sbVwVaBJxGi+pEgRAhR64W18mb+4HuZ9tuRQtN0vW5ZJ8TFTsvTHfx4uoMfiek5rD0Yy2/7Y9h1/irbziSz7UwyU1YdpmsTd3q39aFXSy8cdfJrVoiSyL8OIYTAHIj0DPQi+lQC6zdvp1fXYEIae6BRF99RU89Jx9BO/gzt5M+lq1n8fsAckByOSeOv44n8dTwRnc1BurfwoHcbHx5s7oFeq6nkpxKiapMgRAghrtOoVQQHuHHlqIngALcSA5Bb1Xe15+VujXi5WyNOJWTw2/4Yftsfw5mkTNYejGPtwTgcdTb0aulJ77Y+dGnsjlYjQ/KEkCBECCEqUGMPR17t2ZRxPZpwOCbNEpDEpGbzy57L/LLnMm4OtjzcyovebX3o6O+GupTBjhA1jQQhQghhBSqVila+LrTydeHNsObsuXCV1ftjWHswlqSMXL7ffoHvt1/Ay1nPo2286RPkQ2tfF1QqCUhE7SFBiBBCWJlaraKDvxsd/N2Y/Ggg0WeusHpfDBGH44hLy+arLWf5astZ/Ova07utD33a+tDE00npYgthdVWiU3LevHn4+/uj1+sJDg5mx44dJab95Zdf6NChA3Xq1MHBwYGgoCC+/fbbQmlMJhOTJ0/G29sbOzs7evTowcmTJ639GEIIcUc2GjVdm9Tjw6fasuudHix8tj2PtvFGr1Vz7koW//3zFD0//puwuX8z769TXEzOUrrIQliN4i0hy5cvJzw8nAULFhAcHMzcuXMJDQ3l+PHjeHh4FEnv5ubG22+/TfPmzbG1teX3339n+PDheHh4EBoaCsDs2bP59NNPWbJkCQEBAUyaNInQ0FCOHDmCXl+61RGFEMLadDYaerX0oldLLzJz8thwNJ7f9sew6UQix+LSORZ3nA/XHSfIrw592vrwaBtvPJyL/x2WbzSx42wyCenZeDjp6ViGgbVCKEXxIGTOnDmMGDGC4cOHA7BgwQLWrFnDokWLmDBhQpH0DzzwQKH3Y8eOZcmSJWzZsoXQ0FBMJhNz587lnXfeoW/fvgAsXboUT09PVq5cyYABA4rkmZOTQ05OjuV9WloaAAaDAYPBUFGPWm0V1IHUReWSeleGUvVuq4ZHWnrwSEsPUrIMRB6N5/cDcWw7m8y+iynsu5jCjDVHCPZ35dE23oQGelLHXgvAusPxzFx7jLi0G7/HvJx1vPNIc0Jbelbqc5SX/H1XhjXqvSx5qUwmk2L7U+fm5mJvb8+KFSvo16+f5fzQoUNJSUlh1apVt73eZDLx559/0qdPH1auXEnPnj05c+YMjRo1Yu/evQQFBVnSduvWjaCgID755JMi+UydOpVp06YVOb9s2TLs7e3L/XxCCHG30nJh7xUVe5LUnMu40bKhVplo7mKint7EpriCnvWbWz7Mv9qfa2qkbV3Ffs2LWigrK4uBAweSmpqKs7PzbdMq2hKSlJREfn4+np6FI3VPT0+OHTtW4nWpqan4+vqSk5ODRqPh888/p2fPngDExcVZ8rg1z4LPbjVx4kTCw8Mt79PS0vDz86NXr153rMDawGAwEBkZSc+ePdFqtUoXp9aQeldGVaz3gvbbS1evseZgHL8fjONYXDpHUm7X3aJCBfwRb8/4QfdX+a6ZqljvtYE16r2gN6E0FO+OKQ8nJyf27dtHRkYGUVFRhIeH07BhwyJdNaWl0+nQ6XRFzmu1WvnHcBOpD2VIvSujKtZ7gIeWMd2dGdO9KSfj05m/8RS/7I0pMb0JiE3NYe+ldEIa1a28gt6FqljvtUFF1ntZ8lF0doy7uzsajYb4+PhC5+Pj4/Hy8irxOrVaTePGjQkKCuK1117jySefZNasWQCW68qapxBCVCdNPJ3o1qzo4P3i/H4ghpSsXCuXSIiyUzQIsbW1pX379kRFRVnOGY1GoqKiCAkJKXU+RqPRMrA0ICAALy+vQnmmpaWxffv2MuUphBBVnYdT6Wb7fb/9Au1nbmDwV9v5dtt5EtKy73yREJVA8e6Y8PBwhg4dSocOHejYsSNz584lMzPTMltmyJAh+Pr6Wlo6Zs2aRYcOHWjUqBE5OTmsXbuWb7/9lvnz5wPmVQrHjRvHzJkzadKkiWWKro+PT6HBr0IIUd11DHDD20VPXGo2JQ09ddTZ4FtHz/H4DLacSmLLqSQmrzrEvfe4EtbSi9CWXtxTVwbgC2UoHoT079+fxMREJk+eTFxcHEFBQURERFgGll64cAG1+kaDTWZmJqNGjeLSpUvY2dnRvHlzvvvuO/r3729JM378eDIzM3nxxRdJSUmhS5cuREREyBohQogaRaNWMaV3ICO/24MKCgUiBcNQP3qqDWGtvDmXlMm6w3FEHI5j74UUdp+/yu7zV3l37VECvZ0Ja+VFWCsvmng4ytLxotIoOkW3qkpLS8PFxaVU04tqA4PBwNq1a3nkkUdkwFglknpXRnWs94hDsUz77QixqTe6Wbxd9EzpHUhYK+8i6eNSs1l/JI6IQ3FsP5tMvvHG10BDdwd6tTQHJG3rV95eNtWx3msCa9R7Wb5DFW8JEUIIcXfCWnnTM9Cr1CumernoGRLiz5AQf5Izc9lwNJ51h+LYfDKJM0mZLNh0mgWbTuPtoif0epfNff6u2GiqxE4fogaRIEQIIWoAjVpVrmm4bg62PN3Bj6c7+JGRk8dfxxKIOBzHX8cSiE3NZvHWcyzeeg43B1t6tvAkrJUXnRrXRWejscJTiNpGghAhhBCAeRBr77Y+9G7rQ7Yhny0nk4g4HMeGo/EkZ+ayfNdFlu+6iKPOhoeaexDWyotuTevhoJOvElE+8jdHCCFEEXqthh6BnvQI9CQv38iOs8lEHDaPI0lIz2H1/hhW749BZ6Pm/qb1CGvpRY8WnrjYy3gOUXoShAghhLgtG42aTo3d6dTYnam9W7L3YgrrD8fxx6E4LiRnEXkknsgj8dhc7xIKbelFr0DPEnf8FaKABCFCCCFKTa1W0b6BK+0buDLh4eYci0sn4lAc6w6b97PZfDKJzSeTmLTqEO3vcSWslXlgq59byWuR5BtNbD+bzO4kFXXPJhPS2KPK73UjKoYEIUIIIcpFpVLRwtuZFt7OvNqzKWcL1iI5FMe+iynsOn+VXeevMnPNjbVIHm7lReOb1iIpPL1Yw9KTu247vVjULBKECCGEqBAB7g683K0RL3drRGzqNdYfjr++FskVjsSmcSQ2jTmRJ2jo7kBoKy9c9Fo+iDhWZLXXuNRsRn63h/mD75VApIaTIEQIIUSF83axY2gnf4Z28udKRg5RR81Tf7dcX4tk/sbTJV5rwrzi67TfjtAz0Eu6ZmowCUKEEEJYVV1HHU/f58fT9/mRnm3gr+OJLNt2nm1nk0u8xgTEpmbzxv/20a6BG55OOjyc9Xg46ajnpEMrC6fVCBKECCGEqDROei192vpgMpluG4QU+GVvDL/sjSlyvq6DLfVuCkw8nXV4OJlfe1x/Xc9Jh15r3UXV8o2mUq9UK4qSIEQIIUSl83Aq3fTdHi08UKlUJKTnkJCWTWJ6DnlGE1cyc7mSmcuxuPTbXu9ipy0UoNRz1uHppLcEKgVBi71t2b8Oy7pnjyhKghAhhBCVrmOAG94ueuJSs4sMTAXzmBAvFz1fPNuhUMuC0WjialYuCek5xKdlk5CeQ+L1ACU+LYeE9OzrAUsOuflGUq8ZSL1m4ER8xm3L46SzoZ6z7nqryvXg5OZg5fpnjjobVCoVEYdiGfndHhlUe5ckCBFCCFHpNGoVU3oHMvK7Paig0Jd5QcgxpXdgka4NtVpFXUcddR11tPAueYdWk8lE6jWDJSApCFgS0rNJuClYiU/LJttgJD0nj/TEPM4kZt623Pa2Guo52hJbQvAkg2rLRoIQIYQQighr5c38wfcW6dLwqoAuDZVKRR17W+rY29LU06nEdCaTifScPEtgkljQwpKWYwlSEtPNrzNy8sjKzed88rXb3rtgUO3Hkcfp186XAHdHCUZKIEGIEEIIxYS18qZnoBfRpxJYv3k7vboGV+qKqSqVCme9Fme9lsYejrdNm5mTR0J6Dr/uucSnf566Y96f/XWaz/46jZ1WQ6CPMy19nGnl40KgjzNNPZ2wtZEZPhKECCGEUJRGrSI4wI0rR00EV+HZJQ46GwJ0NoQ0ci9VENLEw4FLV7O5Zshn9/mr7D5/1fKZVqOiqacTrXxcaOnrTEsfF1p4O5VrgGx1VrueVgghhLhLpR1UGzGuGwBnkzI4HJPGocuplp9p2XkcjknjcEwa7DJfp1ZBw3qOtPIxByUtfZ1p6e1So3cmliBECCGEKIOyDqpt7OFEYw8n+gb5AuZxKJeuXuNwTCqHLqeZf8akkZiew6mEDE4lZLBy3421Ufzc7Gjp7UIr3xvBSWmnOFd1EoQIIYQQZXQ3g2pVKhV+bvb4udkXSpeQln29deR6cBKbysXka5Yj4nCcJa2Hk848xsTXhZbXW07qu9pZNgYsjaqwe7EEIUIIIUQ5FAyqragVUz2c9Xg463mwuYflXGqWgcOxqRy+qcXkTGKGebrx8UT+Op5oSetip70ekNwITkqamVNVdi+WIEQIIYQoJ41aRUijulbL38VeS6dG7nRq5G45l5Wbx9HYdA7HmIOTQzGpnIhPJ/Waga2nr7D19BVL2uJm5pxNyuTfP+ytEgutSRAihBBCVCP2tja0b+BK+waulnO5eUZOxKdzJMYclByOSeNITFqxM3NKosRCaxKECCGEENWcrY2aVr4utPJ14Wn8APOYj7NJmeYWk+uzcvZduEqWwVhiPgULre04m2zVFp4CEoQIIYQQNZBGraKxhyONPRwtM3NW7b3M2OX77nhtQnr2HdNUhCqxXNu8efPw9/dHr9cTHBzMjh07Skz75Zdf0rVrV1xdXXF1daVHjx5F0g8bNgyVSlXoCAsLs/ZjCCGEEFWah3PppvZW1hRgxYOQ5cuXEx4ezpQpU9izZw9t27YlNDSUhISEYtNv3LiRZ555hr/++ovo6Gj8/Pzo1asXly9fLpQuLCyM2NhYy/HDDz9UxuMIIYQQVVbBQmsljfZQAd4u5lk+lUHxIGTOnDmMGDGC4cOHExgYyIIFC7C3t2fRokXFpv/+++8ZNWoUQUFBNG/enK+++gqj0UhUVFShdDqdDi8vL8vh6upabH5CCCFEbVGw0BpQJBC53e7F1qLomJDc3Fx2797NxIkTLefUajU9evQgOjq6VHlkZWVhMBhwcysctW3cuBEPDw9cXV156KGHmDlzJnXrFj/IJicnh5ycHMv7tLQ0AAwGAwaDoayPVeMU1IHUReWSeleG1LsypN4rT/dm7vx3QFtmrj1GXNqN7z4vFx1vP9yc7s3c7+rPoSzXqkwmU3FL31eKmJgYfH192bp1KyEhIZbz48ePZ9OmTWzfvv2OeYwaNYp169Zx+PBh9HpzH9aPP/6Ivb09AQEBnD59mrfeegtHR0eio6PRaDRF8pg6dSrTpk0rcn7ZsmXY29vfxRMKIYQQVZPRBKfTVKQZwFkLjZxNVEQDSFZWFgMHDiQ1NRVnZ+fbpq3Ws2Pef/99fvzxRzZu3GgJQAAGDBhged26dWvatGlDo0aN2LhxI927dy+Sz8SJEwkPD7e8T0tLs4w1uVMF1gYGg4HIyEh69uyJVltzN1KqaqTelSH1rgypd2VYo94LehNKQ9EgxN3dHY1GQ3x8fKHz8fHxeHl53fbajz76iPfff58NGzbQpk2b26Zt2LAh7u7unDp1qtggRKfTodPpipzXarXyj+EmUh/KkHpXhtS7MqTelVGR9V6WfBQdmGpra0v79u0LDSotGGR6c/fMrWbPns2MGTOIiIigQ4cOd7zPpUuXuHLlCt7elbcevhBCCCFuT/HZMeHh4Xz55ZcsWbKEo0ePMnLkSDIzMxk+fDgAQ4YMKTRw9YMPPmDSpEksWrQIf39/4uLiiIuLIyMjA4CMjAzeeOMNtm3bxrlz54iKiqJv3740btyY0NBQRZ5RCCGEEEUpPiakf//+JCYmMnnyZOLi4ggKCiIiIgJPT08ALly4gFp9I1aaP38+ubm5PPnkk4XymTJlClOnTkWj0XDgwAGWLFlCSkoKPj4+9OrVixkzZhTb5SKEEEIIZSgehACMGTOGMWPGFPvZxo0bC70/d+7cbfOys7Nj3bp1FVQyIYQQQliL4t0xQgghhKidqkRLSFVTsHRKWaYZ1WQGg4GsrCzS0tJk1HolknpXhtS7MqTelWGNei/47izNMmQShBQjPT0dAD8/P4VLIoQQQlRP6enpuLi43DaNoiumVlVGo5GYmBicnJxQqSpn/fyqrGDxtosXL8ribZVI6l0ZUu/KkHpXhjXq3WQykZ6ejo+PT6GJJcWRlpBiqNVq6tevr3QxqhxnZ2f55aAAqXdlSL0rQ+pdGRVd73dqASkgA1OFEEIIoQgJQoQQQgihCAlCxB3pdDqmTJkii71VMql3ZUi9K0PqXRlK17sMTBVCCCGEIqQlRAghhBCKkCBECCGEEIqQIEQIIYQQipAgRAghhBCKkCBElGjWrFncd999ODk54eHhQb9+/Th+/LjSxapV3n//fVQqFePGjVO6KLXC5cuXGTx4MHXr1sXOzo7WrVuza9cupYtVo+Xn5zNp0iQCAgKws7OjUaNGzJgxo1T7jojS+/vvv+nduzc+Pj6oVCpWrlxZ6HOTycTkyZPx9vbGzs6OHj16cPLkSauXS4IQUaJNmzYxevRotm3bRmRkJAaDgV69epGZmal00WqFnTt38sUXX9CmTRuli1IrXL16lc6dO6PVavnjjz84cuQI//nPf3B1dVW6aDXaBx98wPz58/nss884evQoH3zwAbNnz+a///2v0kWrUTIzM2nbti3z5s0r9vPZs2fz6aefsmDBArZv346DgwOhoaFkZ2dbtVwyRVeUWmJiIh4eHmzatIn7779f6eLUaBkZGdx77718/vnnzJw5k6CgIObOnat0sWq0CRMm8M8//7B582ali1KrPProo3h6evL1119bzj3xxBPY2dnx3XffKViymkulUvHrr7/Sr18/wNwK4uPjw2uvvcbrr78OQGpqKp6enixevJgBAwZYrSzSEiJKLTU1FQA3NzeFS1LzjR49mn/961/06NFD6aLUGqtXr6ZDhw489dRTeHh40K5dO7788kuli1XjderUiaioKE6cOAHA/v372bJlCw8//LDCJas9zp49S1xcXKHfNy4uLgQHBxMdHW3Ve8sGdqJUjEYj48aNo3PnzrRq1Urp4tRoP/74I3v27GHnzp1KF6VWOXPmDPPnzyc8PJy33nqLnTt38u9//xtbW1uGDh2qdPFqrAkTJpCWlkbz5s3RaDTk5+fz7rvvMmjQIKWLVmvExcUB4OnpWei8p6en5TNrkSBElMro0aM5dOgQW7ZsUbooNdrFixcZO3YskZGR6PV6pYtTqxiNRjp06MB7770HQLt27Th06BALFiyQIMSKfvrpJ77//nuWLVtGy5Yt2bdvH+PGjcPHx0fqvRaQ7hhxR2PGjOH333/nr7/+on79+koXp0bbvXs3CQkJ3HvvvdjY2GBjY8OmTZv49NNPsbGxIT8/X+ki1lje3t4EBgYWOteiRQsuXLigUIlqhzfeeIMJEyYwYMAAWrduzbPPPsurr77KrFmzlC5areHl5QVAfHx8ofPx8fGWz6xFghBRIpPJxJgxY/j111/5888/CQgIULpINV737t05ePAg+/btsxwdOnRg0KBB7Nu3D41Go3QRa6zOnTsXmYJ+4sQJGjRooFCJaoesrCzU6sJfRRqNBqPRqFCJap+AgAC8vLyIioqynEtLS2P79u2EhIRY9d7SHSNKNHr0aJYtW8aqVatwcnKy9A26uLhgZ2encOlqJicnpyJjbhwcHKhbt66MxbGyV199lU6dOvHee+/x9NNPs2PHDhYuXMjChQuVLlqN1rt3b959913uueceWrZsyd69e5kzZw7PPfec0kWrUTIyMjh16pTl/dmzZ9m3bx9ubm7cc889jBs3jpkzZ9KkSRMCAgKYNGkSPj4+lhk0VmMSogRAscc333yjdNFqlW7dupnGjh2rdDFqhd9++83UqlUrk06nMzVv3ty0cOFCpYtU46WlpZnGjh1ruueee0x6vd7UsGFD09tvv23KyclRumg1yl9//VXs7/OhQ4eaTCaTyWg0miZNmmTy9PQ06XQ6U/fu3U3Hjx+3erlknRAhhBBCKELGhAghhBBCERKECCGEEEIREoQIIYQQQhEShAghhBBCERKECCGEEEIREoQIIYQQQhEShAghhBBCERKECCGEEEIREoQIIWoNlUrFypUrlS6GEOI6CUKEEJVi2LBhqFSqIkdYWJjSRRNCKEQ2sBNCVJqwsDC++eabQud0Op1CpRFCKE1aQoQQlUan0+Hl5VXocHV1BcxdJfPnz+fhhx/Gzs6Ohg0bsmLFikLXHzx4kIceegg7Ozvq1q3Liy++SEZGRqE0ixYtomXLluh0Ory9vRkzZkyhz5OSknjsscewt7enSZMmrF692roPLYQokQQhQogqY9KkSTzxxBPs37+fQYMGMWDAAI4ePQpAZmYmoaGhuLq6snPnTv73v/+xYcOGQkHG/PnzGT16NC+++CIHDx5k9erVNG7cuNA9pk2bxtNPP82BAwd45JFHGDRoEMnJyZX6nEKI66y+T68QQphMpqFDh5o0Go3JwcGh0PHuu++aTCaTCTC9/PLLha4JDg42jRw50mQymUwLFy40ubq6mjIyMiyfr1mzxqRWq01xcXEmk8lk8vHxMb399tsllgEwvfPOO5b3GRkZJsD0xx9/VNhzCiFKT8aECCEqzYMPPsj8+fMLnXNzc7O8DgkJKfRZSEgI+/btA+Do0aO0bdsWBwcHy+edO3fGaDRy/PhxVCoVMTExdO/e/bZlaNOmjeW1g4MDzs7OJCQklPeRhBB3QYIQIUSlcXBwKNI9UlHs7OxKlU6r1RZ6r1KpMBqN1iiSEOIOZEyIEKLK2LZtW5H3LVq0AKBFixbs37+fzMxMy+f//PMParWaZs2a4eTkhL+/P1FRUZVaZiFE+UlLiBCi0uTk5BAXF1fonI2NDe7u7gD873//o0OHDnTp0oXvv/+eHTt28PXXXwMwaNAgpkyZwtChQ5k6dSqJiYm88sorPPvss3h6egIwdepUXn75ZTw8PHj44YdJT0/nn3/+4ZVXXqncBxVClIoEIUKIShMREYG3t3ehc82aNePYsWOAeebKjz/+yKhRo/D29uaHH34gMDAQAHt7e9atW8fYsWO57777sLe354knnmDOnDmWvIYOHUp2djYff/wxr7/+Ou7u7jz55JOV94BCiDJRmUwmk9KFEEIIlUrFr7/+Sr9+/ZQuihCiksiYECGEEEIoQoIQIYQQQihCxoQIIaoE6RkWovaRlhAhhBBCKEKCECGEEEIoQoIQIYQQQihCghAhhBBCKEKCECGEEEIoQoIQIYQQQihCghAhhBBCKEKCECGEEEIo4v8BLFias6HUzSgAAAAASUVORK5CYII=\n"
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiEAAAGJCAYAAABcsOOZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAcThJREFUeJzt3XlcVNX/x/HXzADDIiCIbIqCu4j7Qm5liYKVa33T0lwq+2baV+NrqS3uRVmZ9c00LVOzxX6tlooi5o6SmivuGy6sIrtsM/P7Y3QUAQVk5rJ8no/HPGTunHvuuUeEt+eee67KYDAYEEIIIYSwMLXSDRBCCCFEzSQhRAghhBCKkBAihBBCCEVICBFCCCGEIiSECCGEEEIREkKEEEIIoQgJIUIIIYRQhIQQIYQQQihCQogQQgghFCEhRAghhBCKkBAihLC45cuXo1Kp2Lt3r9JNEUIoSEKIEEIIIRQhIUQIIYQQipAQIoSolP755x/69euHk5MTtWrVonfv3uzevbtQmfz8fGbNmkXTpk2xtbWlTp069OjRg4iICFOZ+Ph4xowZQ/369dFqtXh5eTFw4EDOnz9v4TMSQtzJSukGCCHEnY4ePUrPnj1xcnLi9ddfx9rami+++IJevXqxdetWAgMDAZg5cyZhYWG88MILdOnShfT0dPbu3cv+/fvp06cPAE888QRHjx7llVdewdfXl8TERCIiIoiNjcXX11fBsxRCqAwGg0HpRgghapbly5czZswY/v77bzp16lTk88GDB7Nu3TqOHTtGo0aNAIiLi6N58+a0b9+erVu3AtCuXTvq16/Pn3/+WexxUlNTcXFx4YMPPmDy5MnmOyEhRLnI5RghRKWi0+nYuHEjgwYNMgUQAC8vL5555hl27NhBeno6ALVr1+bo0aOcOnWq2Lrs7OywsbFhy5YtXLt2zSLtF0KUnoQQIUSlkpSURHZ2Ns2bNy/yWcuWLdHr9Vy8eBGA2bNnk5qaSrNmzWjdujWvvfYahw4dMpXXarW8//77rF+/Hg8PDx588EHmzZtHfHy8xc5HCFEyCSFCiCrrwQcf5MyZMyxbtoyAgAC+/PJLOnTowJdffmkqM2nSJE6ePElYWBi2tra8/fbbtGzZkn/++UfBlgshQEKIEKKSqVu3Lvb29pw4caLIZ8ePH0etVuPj42Pa5urqypgxY/j++++5ePEibdq0YebMmYX2a9y4Mf/973/ZuHEjR44cIS8vj48++sjcpyKEuAcJIUKISkWj0dC3b19+//33QrfRJiQk8N1339GjRw+cnJwAuHr1aqF9a9WqRZMmTcjNzQUgOzubnJycQmUaN26Mo6OjqYwQQjlyi64QQjHLli0jPDy8yPaZM2cSERFBjx49ePnll7GysuKLL74gNzeXefPmmcr5+/vTq1cvOnbsiKurK3v37uWnn35iwoQJAJw8eZLevXvz1FNP4e/vj5WVFb/++isJCQkMGzbMYucphCie3KIrhLC4m7foluTixYskJSUxbdo0du7ciV6vJzAwkHfeeYeuXbuayr3zzjusWbOGkydPkpubS8OGDXn22Wd57bXXsLa25urVq8yYMYPIyEguXryIlZUVLVq04L///S//+te/LHGqQoi7kBAihBBCCEXInBAhhBBCKEJCiBBCCCEUISFECCGEEIqQECKEEEIIRUgIEUIIIYQiJIQIIYQQQhGyWFkx9Ho9V65cwdHREZVKpXRzhBBCiCrDYDCQkZGBt7c3avXdxzokhBTjypUrhZ5NIYQQQoiyuXjxIvXr179rGQkhxXB0dASMHXjzGRU1WX5+Phs3bqRv375YW1sr3ZwaQ/pdGdLvypB+V4Y5+j09PR0fHx/T79K7kRBSjJuXYJycnCSEYPwmtbe3x8nJSX44WJD0uzKk35Uh/a4Mc/Z7aaYzyMRUIYQQQihCQogQQgghFCEhRAghhBCKkDkhQgghahydTkd+fr7SzVBcfn4+VlZW5OTkoNPpSrWPRqPBysqqQpawkBAihBCiRsnMzOTSpUsYDAalm6I4g8GAp6cnFy9eLFOosLe3x8vLCxsbm/s6voQQIYQQNYZOp+PSpUvY29tTt27dGr8gpV6vJzMzk1q1at1zYTEwhpa8vDySkpI4d+4cTZs2LdV+JZEQYgE6vYHocykkZuTg7mhLFz9XNOqa/Y0vhBBKyM/Px2AwULduXezs7JRujuL0ej15eXnY2tqWOkzY2dlhbW3NhQsXTPuWl+ITUxcuXIivry+2trYEBgYSHR191/KpqamMHz8eLy8vtFotzZo1Y926dabPZ86ciUqlKvRq0aKFuU+jROFH4ujx/maeXrqbiT8c4Omlu+nx/mbCj8Qp1iYhhKjpavoIyP26n9GP2yk6ErJ69WpCQ0NZvHgxgYGBLFiwgODgYE6cOIG7u3uR8nl5efTp0wd3d3d++ukn6tWrx4ULF6hdu3ahcq1atWLTpk2m91ZWypxm+JE4xq3az51XHePTchi3aj+LRnQgJMBLkbYJIYQQSlM0hMyfP5+xY8cyZswYABYvXszatWtZtmwZU6dOLVJ+2bJlpKSksGvXLtPKbr6+vkXKWVlZ4enpada234tOb2DWHzFFAgiAAVABs/6IoY+/p1yaEUIIUSMpFkLy8vLYt28f06ZNM21Tq9UEBQURFRVV7D5r1qyha9eujB8/nt9//526devyzDPPMGXKFDQajancqVOn8Pb2xtbWlq5duxIWFkaDBg1KbEtubi65ubmm9+np6YDx2mF5b+Hacy6FuLScEj83AHFpOUSdTiTQz7Vcx7CUm30gt7NZlvS7MqTflWGpfr85J0Sv16PX68tdj05v4O/zKSRm5OLuqKWzb9WZ69eoUSMmTpzIxIkTTXcI3eyT0tLr9RgMBvLz8wv9/oWy/R0qFkKSk5PR6XR4eHgU2u7h4cHx48eL3efs2bNs3ryZ4cOHs27dOk6fPs3LL79Mfn4+M2bMACAwMJDly5fTvHlz4uLimDVrFj179uTIkSMlPkwnLCyMWbNmFdm+ceNG7O3ty3V++5JVgOae5TZu38PVY1XjNrGIiAilm1AjSb8rQ/pdGebu95sj5ZmZmeTl5ZWrjsgTV5m36SwJGbf293C04fWgRvRuXqeimlrI448/TuvWrQkLC7vvujZt2oS9vb3pP9wAGRkZZaojLy+P69evs23bNgoKCgp9lp2dXep6qtTdMXq9Hnd3d5YsWYJGo6Fjx45cvnyZDz74wBRC+vXrZyrfpk0bAgMDadiwIT/++CPPP/98sfVOmzaN0NBQ0/ubTwDs27dvuR9gV+dcCitP7b1nub49A6vESEhERAR9+vSRB0tZkPS7MqTflWGpfs/JyeHixYvUqlWrXHd1hB+JZ/Kvx4tcak/MyGPyr8dZ+Ex7QgIqfjqAlZUVNjY2Jf5OMhgM6HS6Us2BvL0Og8FARkYGjo6OZZqsm5OTg52dHQ8++GCRfrw93NyLYiHEzc0NjUZDQkJCoe0JCQklzufw8vLC2tq60NBPy5YtiY+PJy8vr9hFU2rXrk2zZs04ffp0iW3RarVotdoi262trcv9j6FrE3e8nG2JT8spdl4IgLujlq5N3KvMEN799IcoP+l3ZUi/K8Pc/a7T6VCpVKjVatRqNQaDgev5pVspVKc3MOvPu8/1m/3nMXo2q1uqn+t21ppS/eIfPXo0W7duZevWrXz66acAfP3114wZM4Z169bx1ltvcfjwYTZu3IiPjw+hoaHs3r2brKwsWrZsSVhYGEFBQab6fH19mTRpEpMmTUKv1+Pi4sIXX3zB+vXr2bBhA/Xq1eOjjz5iwIABJbZJrVajUqmK/fsqy9+fYiHExsaGjh07EhkZyaBBgwDjSEdkZCQTJkwodp/u3bvz3XffodfrTbcHnTx58q6rtmVmZnLmzBmeffZZs5xHSTRqFTP6+zNu1X5UUOw3rd5gICUrj7qORQOQEEII87uer8N/+oYKqcsAxKfn0HrmxlKVj5kdjL3NvX8Nf/LJJ5w8eZKAgABmz54NwNGjRwGYOnUqH374IY0aNcLFxYWLFy/y6KOP8s4776DValm5ciX9+/fnxIkTd50bOWfOHObNm8cHH3zA//73P4YPH86FCxdwdTXvSL2i64SEhoaydOlSVqxYwbFjxxg3bhxZWVmmu2VGjhxZaOLquHHjSElJYeLEiZw8eZK1a9fy7rvvMn78eFOZyZMns3XrVs6fP8+uXbsYPHgwGo2Gp59+2uLnFxLgxaIRHfB0LjxU5eGkpU4tG5Iz8xizPJrM3IISahBCCFHTOTs7Y2Njg729PZ6ennh6epquCMyePZs+ffrQuHFjXF1dadu2Lf/+978JCAigadOmzJkzh8aNG7NmzZq7HmPUqFE8/fTTNGnShHfffZfMzMx7rttVERSdEzJ06FCSkpKYPn068fHxtGvXjvDwcNNk1djY2EILovj4+LBhwwZeffVV2rRpQ7169Zg4cSJTpkwxlbl06RJPP/00V69epW7duvTo0YPdu3dTt25di58fGINIH3/PIiumxqZk88SiXRy5nM64Vfv4alRnbKwUXztOCCFqFDtrDTGzg0tVNvpcCqO//vue5ZaP6UyXUsz1s7O+980L99KpU6dC7zMzM5k5cyZr164lLi6OgoICrl+/Tmxs7F3rad26telrBwcHnJycSExMvO/23YviE1MnTJhQ4uWXLVu2FNnWtWtXdu/eXWJ9P/zwQ0U1rcJo1Cq6Ni48Y9rPzYFlozvz9JLdbD+VzJSfD/HRv9qiriLzQ4QQojpQqVSluiQC0LNp3bvO9VMBns629GxaujkhFcHBwaHQ+8mTJxMREcGHH35IkyZNsLOz48knn7znnUB3zuNQqVT3dQtzacl/vRXUzqc2n4/ogEat4td/LvP+huJvTRZCCKG8m3P9wBg4bnfz/Yz+/mYJIDY2Nuh0955Au3PnTkaPHs3gwYNp3bo1np6enD9/vsLbU1EkhCjs4ebuvDfEOAz2xdazLNtxTuEWCSGEKElJc/08nW3N+igOX19f9uzZw/nz50lOTi5xlKJp06b88ssvHDhwgIMHD/LMM89YZESjvBS/HCPgX518SMzI5YMNJ5izNgZ3Jy2Pt/FWullCCCGKUdJcP3Negpk8eTKjRo3C39+f69ev8/XXXxdbbv78+Tz33HN069YNNzc3pkyZUqZ1OyxNQkgl8XKvxiSk57Ay6gKhqw/i6mBDt8ZuSjdLCCFEMYqb62dOzZo1K/JIk9GjRxcp5+vry+bNmwttu/0OUqDI5Zlr164VWQQtNTW13G0tC7kcU0moVCpm9G9FvwBP8nR6/r1yHzFXKm96FUIIIe6XhJBKRKNW8fHQdnTxcyUjt4DRX0dz6Vrp1+AXQgghqhIJIZWMrbWGpc92oplHLRIzchm5LJprWeV7yJIQQghRmUkIqYSc7a1Z8VwXvJxtOZuUxfMr/uZ6XumebSCEEEJUFRJCKikvZztWPNcFJ1sr9sem8sr3/1Cgq7y3WQkhhBBlJSGkEmvm4chXo43LuW86lsDbvx/BYCjpmbxCCCFE1SIhpJLr7OvKp8Pao1bB99EX+STylNJNEkIIISqEhJAqICTAk1kDAwBYsOkU3+25+4OIhBBCiKpAQkgV8ewDDXnlkSYAvPXbYSJiEhRukRBCCHF/JIRUIaF9mvFUp/roDTDhu/3su5CidJOEEKJm0uvg3HY4/JPxT33lvoPR19eXBQsWKN2MImTZ9ipEpVLx7uDWJGfmsfl4Is+v2MtPL3WjiXstpZsmhBA1R8waCJ8C6VdubXPyhpD3wX+Acu2qgmQkpIqx0qj57Jn2tPWpTWp2PqOWRZOQnqN0s4QQomaIWQM/jiwcQADS44zbY9Yo064qSkJIFWRvY8XXozvTyM2By6nXGbUsmvScfKWbJYQQVY/BAHlZpXvlpMP614Hilkq4sS18irFcaeor5ZILS5YswdvbG72+8FpRAwcO5LnnnuPMmTMMHDgQDw8PatWqRefOndm0adP99YuFyOWYKsrVwYYVz3VhyKJdHI/P4MWVe1nxXBe0VhqlmyaEEFVHfja8611BlRmMIyTv+ZSu+BtXwMbhnsX+9a9/8corr/DXX3/Ru3dvAFJSUggPD2fdunVkZmby6KOP8s4776DValm5ciX9+/fnxIkTNGjQ4H5OyOxkJKQK83G15+vRnamltWL32RRCfzyIXi+LmQkhRHXi4uJCv379+O6770zbfvrpJ9zc3Hj44Ydp27Yt//73vwkICKBp06bMmTOHxo0bs2ZN5b80JCMhVVxAPWcWj+jImOXRrD0Uh7ujlumP+6NSqZRumhBCVH7W9sYRidK4sAu+ffLe5Yb/BA27le7YpTR8+HDGjh3L559/jlar5dtvv2XYsGGo1WoyMzOZOXMma9euJS4ujoKCAq5fv05sbOVfU0pGQqqBHk3d+PBfbQH4eud5lmw7q3CLhBCiilCpjJdESvNq/IjxLhhK+k+eCpzqGcuVpr4y/Gexf//+GAwG1q5dy8WLF9m+fTvDhw8HYPLkyfz666+8++67bN++nQMHDtC6dWvy8ir/E9hlJKSaGNiuHkkZucxde4yw9cep66hlSIf6SjdLCCGqD7XGeBvujyMxBpHbL3/fCBQh7xnLVTBbW1uGDBnCt99+y+nTp2nevDkdOnQAYOfOnYwePZrBgwcDkJmZyfnz5yu8DeYgIyHVyAs9G/FCDz8AXv/pENtOJincIiGEqGb8B8BTK8HJq/B2J2/jdjOuEzJ8+HDWrl3LsmXLTKMgAE2bNuWXX37hwIEDHDx4kGeeeabInTSVlYyEVDNvPNqSxIxc1hy8wkur9rH6xa60ru+sdLOEEKL68B8ALR4zzhHJTIBaHsY5IGYYAbndI488gqurKydOnOCZZ54xbZ8/fz7PPfcc3bp1w83NjSlTppCenm7WtlQUxUdCFi5ciK+vL7a2tgQGBhIdHX3X8qmpqYwfPx4vLy+0Wi3NmjVj3bp191VndaJWq/jwX23p3qQO2Xk6xiyP5sLVLKWbJYQQ1YtaA349ofWTxj/NHEAA1Go1V65cwWAw0KhRI9N2X19fNm/eTHZ2NrGxsYwfP54tW7YUWqb9/PnzTJo0yextLCtFQ8jq1asJDQ1lxowZ7N+/n7Zt2xIcHExiYmKx5fPy8ujTpw/nz5/np59+4sSJEyxdupR69eqVu87qyMZKzeIRHfH3ciI5M4+Ry6JJzsxVullCCCFEIYqGkPnz5zN27FjGjBmDv78/ixcvxt7enmXLlhVbftmyZaSkpPDbb7/RvXt3fH19eeihh2jbtm2566yuHG2tWf5cZ+q72HHhajbPLf+brNwCpZslhBBCmCg2JyQvL499+/Yxbdo00za1Wk1QUBBRUVHF7rNmzRq6du3K+PHj+f3336lbty7PPPMMU6ZMQaPRlKtOgNzcXHJzb40U3LyWlp+fT35+1V0O3cVWw7KRHRi6NJpDl9IYt2ovi4e3x1pTtux5sw+qcl9URdLvypB+V4al+j0/Px+DwYBer68ykzfNyXBj6fibfVJaer0eg8FAfn4+Gk3hS1Fl+TtULIQkJyej0+nw8PAotN3Dw4Pjx48Xu8/Zs2fZvHkzw4cPZ926dZw+fZqXX36Z/Px8ZsyYUa46AcLCwpg1a1aR7Rs3bsTevvSLyVRWoxvBwhgN205dZdTCjQxvrC/L7ekmERERFd84cU/S78qQfleGufvdysoKT09PMjMzq8Q6GpaSkZFRpvJ5eXlcv36dbdu2UVBQeJQ9Ozu71PVUqbtj9Ho97u7uLFmyBI1GQ8eOHbl8+TIffPABM2bMKHe906ZNIzQ01PQ+PT0dHx8f+vbti5OTU0U0XXEtTyQx7rsD/J2kpmPLxvy3T9NS75ufn09ERAR9+vTB2trajK0Ut5N+V4b0uzIs1e+5ubnExsbi4OCAnZ2d2Y5TVRgMBjIyMnB0dCzTStvXr1/Hzs6Ohx56CK1WW+izstyZo1gIcXNzQ6PRkJCQUGh7QkICnp6exe7j5eWFtbV1oaGfli1bEh8fT15eXrnqBNBqtUU6EcDa2rra/BDqG+BN2GAdr/98iMXbzuFV255R3XzLVEd16o+qRPpdGdLvyrBEv6tUKgoKClCrFb9BVHE3L8GoVKoy9UdOTg4qlQo7O7sil2PK8venWAixsbGhY8eOREZGMmjQIMDYGZGRkUyYMKHYfbp37853332HXq83ddbJkyfx8vLCxsYGoMx11iRPdfYhIT2HjyJOMvOPo9R11PJoa6977yiEENWElZUV9vb2JCUlYW1tXeODiF6vJy8vj5ycnFL1hcFgIDs7m8TERGrXrl0kgJSVopdjQkNDGTVqFJ06daJLly4sWLCArKwsxowZA8DIkSOpV68eYWFhAIwbN47PPvuMiRMn8sorr3Dq1Cneffdd/vOf/5S6zppuwiNNSMjIYdXuWCb9cABXBxseaFRH6WYJIYRFqFQqvLy8OHfuHBcuXFC6OYozGAymSytluRxTu3btu15hKC1FQ8jQoUNJSkpi+vTpxMfH065dO8LDw00TS2NjYwslMx8fHzZs2MCrr75KmzZtqFevHhMnTmTKlCmlrrOmU6lUzBoQQFJGLhuOJjB25V7+76WutPCsHnNfhBDiXmxsbGjatKlMTMU4F2fbtm08+OCDpb6Mcue0iPuh+MTUCRMmlHipZMuWLUW2de3ald27d5e7TkXodRZf3vduNGoVnwxrz4gv97D3wjVGL/ubn1/uRr3aMklLCFEzqNVqbG1tlW6G4jQaDQUFBdja2ioyB6pmXwyzhJg1sCAAVjwOPz9v/HNBgHG7gmytNXw5qhNN3WsRn57DqGXRpGbL/wqEEEJYjoQQc4pZY3zkc/qVwtvT44zbFQ4ite1tWPFcFzydbDmdmMkLK/aSk69TtE1CCCFqDgkh5qLXQfgUwFDMhze2hU81llOQd207VjzXBUdbK/ZeuMZ/vv8Hnb64NgshhBAVS0KIuVzYVXQEpBADpF82llNYc09HvhzZCRsrNRtjEpj++xHTUr5CCCGEuUgIMZfMhHuXKUs5MwtsVIdPhrZDpYJv98Ty2ebTSjdJCCFENSchxFxqlfKW4ORTUEkeotSvtRezBrQC4KOIk6z+Oxad3sCecynsS1ax51yKXKoRQghRYRS/RbfaatgNnLyNk1CLnRdyw9b34NgaeOh1aDkQFF69b2RXXxLSc1j41xmm/XKY99Yf51p2PqBh5am9eDnbMqO/PyEBstKqEEKI+yMjIeai1kDI+zfe3LkKncr48h8EWidIjIH/Gw2LusGRXxQfGZnctzldG9VBb+BGALklPi2Hcav2E34kTqHWCSGEqC4khJiT/wB4aiU43TFq4ORt3P7UCph0CB6aClpnSDoGP425EUZ+VuzOGb0BziVnFfvZzTGdWX/EyKUZIYQQ90Uux5ib/wBo8VjJK6baucDD0+CBcbBnMUR9fiOMPAdu7xsv07QabNEVVqPPpRCfnlPi5wYgLi2H6HMpdG0sz50RQghRPjISYglqDfj1hNZPGv8sLlDY1YZeU40jI73eAFtnSD5hXGX18wfg8E8WGxlJzCg5gJSnnBBCCFEcCSGVjV1t6DUFJh2Gh98E29qQfPJWGDn0f2YPI+6OpXueQmnLCSGEEMWREFJZ2TobL8VMOgyPvHUrjPzyAiwMhEM/mi2MdPFzxcvZtsh02tt5OGnp4udqluMLIYSoGSSEVHa2TvDgazfCyNvGOSRXT8EvY2FhFzi4GnQFFXpIjVrFjP7+QNH7em5Sq1TywDshhBD3RUJIVWHrBA9ONoaR3tNvhJHT8OuLxjBy4PsKDSMhAV4sGtEBT+fCl1zcHbU421kRl5bD8C/3kJIlQUQIIUT5SAiparSO0PO/N8LIDLBzhZQz8NtLsLAzHPiuwsJISIAXO6Y8wqrnOjGyqY5Vz3Uialpvfn25O3UdtRyPz2DEl3tkREQIIUS5SAipqrSO0DPUeDdN0EywrwMpZ+G3cfBZJ/jn2woJIxq1ikA/Vzq6GQj0c0WjVtGobi2+HxuIWy0bYuLSefaraNKu59+7MiGEEOI2EkKqOq0j9HgVJh6CoFnGMHLtHPz+8o0wsgp0FR8Qmrg78t3YB3B1sOHw5TRGLosmPUeCiBBCiNKTEFJdaGtBj0nGMNJnNti73Qgj441hZP83FR5Gmnk48u0LgdS2t+bgxVRGL4smM7diJ8kKIYSoviSEVDfaWtB9ovEyTZ854FAXrp2HNRPgfx1h/8oKDSMtvZxY9XwgznbW7I9NZczX0WRJEBFCCFEKEkKqKxsH6P4fmHgQ+s41hpHUC7DmFfhfB9i3AgoqZkJpQD1nVj0fiKOtFX+fv8aY5X+TnSdBRAghxN1JCKnubByg2yvGyzR93wEHd0iNhT/+YxwZ2be8QsJI6/rOfPN8II5aK6LPpfDCir1cz1PmAXxCCCGqBgkhNYWNPXSbYBwZCQ4zPkgvLRb+mGgcGdn79X2HkXY+tVn+XBccbDTsOnOVF7/ZS06+BBEhhBDFkxBS09jYQ9eXjWEk5L0bYeQi/DnJGEb+/goKcm+V1+tQXdhBvZQoVBd23HOp+I4NXVj+XBfsbTRsP5XMv7/ZR26BBBEhhBBFSQipqazt4IFxN8LI+1DL0xhG1obCpx3g7y/hyM+wIACrVYPodGERVqsGwYIAiFlz16o7+7ry9ejO2Flr2HoyiXGr9ksQEUIIUUSlCCELFy7E19cXW1tbAgMDiY6OLrHs8uXLUalUhV62toWXFh89enSRMiEhIeY+jarJ2g4eeAkmHoB+84xhJP0SrP0v/PQcpF8pXD49Dn4cec8gEtioDl+N6oTWSs3m44lM+O4f8nV6852HEEKIKkfxELJ69WpCQ0OZMWMG+/fvp23btgQHB5OYmFjiPk5OTsTFxZleFy5cKFImJCSkUJnvv//enKdR9VnbQeC/b42MqEr61jAY/wifes9LM92auPHlqE7YWKmJiEngP99LEBFCCHGL4iFk/vz5jB07ljFjxuDv78/ixYuxt7dn2bJlJe6jUqnw9PQ0vTw8PIqU0Wq1hcq4uLiY8zSqD2tb8GgFhruFBQOkX4YLu+5ZXc+mdVnybEdsNGrWH4ln0uoDFEgQEUIIAVgpefC8vDz27dvHtGnTTNvUajVBQUFERUWVuF9mZiYNGzZEr9fToUMH3n33XVq1alWozJYtW3B3d8fFxYVHHnmEuXPnUqdOnWLry83NJTf31mTM9PR0APLz88nPr3lLkavSLpfqG6Mg7TKGUvRP90YufPZ0W8Z/f4C1h+JQY+CDJ1qjUavuv7HV2M3vvZr4Pagk6XdlSL8rwxz9Xpa6FA0hycnJ6HS6IiMZHh4eHD9+vNh9mjdvzrJly2jTpg1paWl8+OGHdOvWjaNHj1K/fn3AeClmyJAh+Pn5cebMGd544w369etHVFQUGo2mSJ1hYWHMmjWryPaNGzdib29fAWdatdTJOE+PUpTbfeQ8Vy+sK3W9o5qoWHZSzR+H4om/coVnmuiRHHJvERERSjehRpJ+V4b0uzIqst+zs7NLXVZlMBgMFXbkMrpy5Qr16tVj165ddO3a1bT99ddfZ+vWrezZs+eedeTn59OyZUuefvpp5syZU2yZs2fP0rhxYzZt2kTv3r2LfF7cSIiPjw/Jyck4OTmV48yqOL0Oq8/aQ0YcKop+exhQgZM3BeP3g7poqLubDUcTmPjjIXR6A0908Obdga1QSxIpVn5+PhEREfTp0wdra2ulm1NjSL8rQ/pdGebo9/T0dNzc3EhLS7vn71BFR0Lc3NzQaDQkJCQU2p6QkICnp2ep6rC2tqZ9+/acPn26xDKNGjXCzc2N06dPFxtCtFotWq222Lpr5j8Ga+j3vvEuGFRwRxBRYYCQ97DW2ha799083q4+KrWG//zwDz/vv4K1RsO7g1tLELmLmvt9qCzpd2VIvyujIvu9LPUoOjHVxsaGjh07EhkZadqm1+uJjIwsNDJyNzqdjsOHD+Pl5VVimUuXLnH16tW7lhF38B8AT60EpxL6rJZ7uat+rI0X859qi1oFP/x9kelrjqDggJwQQgiFKH53TGhoKEuXLmXFihUcO3aMcePGkZWVxZgxYwAYOXJkoYmrs2fPZuPGjZw9e5b9+/czYsQILly4wAsvvAAYJ62+9tpr7N69m/PnzxMZGcnAgQNp0qQJwcHBipxjleU/ACYdoWDEb+xtOI6CEb9B+2eNn6177Z636N7NwHb1+PBfbVGpYNXuWGb9ESNBRAghahhFL8cADB06lKSkJKZPn058fDzt2rUjPDzcNFk1NjYWtfpWVrp27Rpjx44lPj4eFxcXOnbsyK5du/D39wdAo9Fw6NAhVqxYQWpqKt7e3vTt25c5c+YUe8lF3INag6FhDy4fTadtwx7g1dq4UFn8Idi/EjqNKXfVQzrUR6c38PrPh1i+6zxqlYq3H2+JSiWXZoQQoiZQPIQATJgwgQkTJhT72ZYtWwq9//jjj/n4449LrMvOzo4NGzZUZPPE7Rzc4OFpxsXKNs+BVoPArvxrsPyrkw86vYGpvxxm2c5zWGtUTO3XQoKIEELUAIpfjhFVUOcXoG4LyL4KW9677+qGdWnA3EEBAHyx7SwfbDghl2aEEKIGkBAiyk5jbXwCL0D0UkiIue8qRzzQkFkDjAvOfb7lDB9vOnXfdQohhKjcJISI8mn8MLTsDwYdhE+BChi5GNXNl7cfN87t+TTyFJ9IEBFCiGpNQogov77vgJUtnNsGx+7+VN3Ser6HH2882gKAjzedZOFfJa//IoQQomqTECLKz6UhdJ9o/HrDW5B/vUKqffHBxrwe0hyADzac4IutZyqkXiGEEJWLhBBxf7pPAqf6kBYLOz+tsGpf7tWE//ZpBkDY+uN8uf1shdUthBCicpAQIu6PjT30vfHMnh3zITW2wqp+pXdT/tO7KQBz1x5j+c5zFVa3EEII5UkIEfev1WBo2AMKcmDj2xVa9atBTRn/cGMAZv4Rwze7L1Ro/UIIIZQjIUTcP5XK+MA7lRpifjNOVK2wqlVM7tucfz/UCIC3fzvC99EVN9oihBBCORJCRMXwDIBOzxu/Xj8FdAUVVrVKpWJqSAue7+EHwLRfDvPj3osVVr8QQghlSAgRFefhN4xLuCfGwN5lFVq1SqXircdaMrqbLwBTfj7EL/svVegxhBBCWJaEEFFx7F3hkRtzQv6aC1lXK7R6lUrFjP7+jHigAQYDTP6/g/x+4HKFHkMIIYTlSAgRFavjaPBoDTlpxiBSwVQqFbMHBPB0lwboDfDq6gP8cfBKhR9HCCGE+UkIERVLrTFOUgXY+zXEHaz4Q6hVvDMogKc61UdvgEmrD7D+cFyFH0cIIYR5SQgRFc+3OwQ8ARiMk1TN8ERctVpF2JA2DOlQD53ewCvf/8PGo/EVfhwhhBDmIyFEmEef2WBtD7FRcORnsxxCo1bxwZNtGdjOmwK9gfHf7SfyWIJZjiWEEKLiSQgR5uFcH3qGGr/e+DbkZprlMBq1io/+1ZbH23iRrzMwbtV+tpxINMuxhBBCVCwJIcJ8ur4CtRtCxhXjku5mYqVR8/HQdvQL8CRPp+fFb/ax/VQSOr2BqDNX+f3AZaLOXEWnr/jLQkIIIcrPSukGiGrM2haC34XVw2HX/6D9CHBtZJ5DadR8+nR7xn+7n40xCYz5+m+c7KxJycozlfFytmVGf39CArzM0gYhhBBlIyMhwrxaPAaNHgZdHmx4y6yHstao+eyZDrSu50SB3lAogADEp+UwbtV+wo/InTRCCFEZSAgR5nXzuTJqKzixFk5vMuvhNGoVSRm5xX5282LMrD9i5NKMEEJUAhJChPnVbQ5d/m38ev1UKMi7e/n7EH0uhfj04kMIGINIXFoO0edSzNYGIYQQpSMhRFhGryngUBeunoLoJWY7TGJGToWWE0IIYT4SQoRl2DpD7xnGr7e8BxnmWc/D3dG2QssJIYQwHwkhwnLaDQfv9pCXAZGzzXKILn6ueDnborpLGS9nW7r4uZrl+EIIIUqvUoSQhQsX4uvri62tLYGBgURHR5dYdvny5ahUqkIvW9vC/6s1GAxMnz4dLy8v7OzsCAoK4tSpU+Y+DXEvajX0m2f8+sAquLSvwg+hURuftAuUGERm9PdHo75bTBFCCGEJioeQ1atXExoayowZM9i/fz9t27YlODiYxMSSV710cnIiLi7O9Lpw4UKhz+fNm8enn37K4sWL2bNnDw4ODgQHB5OTI/MAFOfTBdo+bfx6/eug11f4IUICvFg0ogOezsVfcjHDo2yEEEKUg+KLlc2fP5+xY8cyZswYABYvXszatWtZtmwZU6dOLXYflUqFp6dnsZ8ZDAYWLFjAW2+9xcCBAwFYuXIlHh4e/PbbbwwbNqzIPrm5ueTm3rqjIj09HYD8/Hzy8/Pv6/yqg5t9UGF98dCbWB1bg+ryXgr++RZDm6J/J/erd3M3ejXtyd4L10jMyMXdUcuO01dZvO0cb/9+hE4NnKltb13hx61IFd7volSk35Uh/a4Mc/R7WepSNITk5eWxb98+pk2bZtqmVqsJCgoiKiqqxP0yMzNp2LAher2eDh068O6779KqVSsAzp07R3x8PEFBQabyzs7OBAYGEhUVVWwICQsLY9asWUW2b9y4EXt7+/s5xWolIiKiwupq4vY4ra6spmD9m0ResKZAY1dhdd9JA1wFmurBw05DQmYe47+MZHiTih+FMYeK7HdRetLvypB+V0ZF9nt2dnapyyoaQpKTk9HpdHh4eBTa7uHhwfHjx4vdp3nz5ixbtow2bdqQlpbGhx9+SLdu3Th69Cj169cnPj7eVMeddd787E7Tpk0jNDTU9D49PR0fHx/69u2Lk5PT/ZxitZCfn09ERAR9+vTB2rqCRg90QRiW7MU25Qwh9ofQ9y4aAs2hfptUhn0ZTXSSmpce7UTPJm4WOW55mKXfxT1JvytD+l0Z5uj3m1cTSkPxyzFl1bVrV7p27Wp6361bN1q2bMkXX3zBnDlzylWnVqtFq9UW2W5tbS3/GG5Tof1hbW1cSfXbJ9FEf4Gm42io26xi6r6LwMZ1GdXVl+W7zvP278fY+OqDOGgr9z8D+T5UhvS7MqTflVGR/V6WehSdmOrm5oZGoyEhofCaEQkJCSXO+biTtbU17du35/Tp0wCm/e6nTmEhTftA02DQF8CGaRabMfpacHPq1bbjcup1PthwwiLHFEIIUZSiIcTGxoaOHTsSGRlp2qbX64mMjCw02nE3Op2Ow4cP4+VlfDKqn58fnp6ehepMT09nz549pa5TWFBIGKitjc+UObnBIod00FoRNqQ1ACuizrPvgizhLoQQSlD8Ft3Q0FCWLl3KihUrOHbsGOPGjSMrK8t0t8zIkSMLTVydPXs2Gzdu5OzZs+zfv58RI0Zw4cIFXnjhBcB458ykSZOYO3cua9as4fDhw4wcORJvb28GDRqkxCmKu6nTGLqON34dPhUKSn7uS0V6sFldnuxYH4MBXv/pEDn5OoscVwghxC2KXwwfOnQoSUlJTJ8+nfj4eNq1a0d4eLhpYmlsbCxq9a2sdO3aNcaOHUt8fDwuLi507NiRXbt24e/vbyrz+uuvk5WVxYsvvkhqaio9evQgPDy8yKJmopJ4cDIc/AGunYOohdAz9N77VIC3HmvJlhNJnEnKYuFfp/lv3+YWOa4QQggjxUdCACZMmMCFCxfIzc1lz549BAYGmj7bsmULy5cvN73/+OOPTWXj4+NZu3Yt7du3L1SfSqVi9uzZxMfHk5OTw6ZNm2jWzPyTHkU5aR2hz41l3Ld9COlXLHLY2vY2zBlovLV70ZYzxFwp/YxuIYQQ969ShBAhaPMU1O8C+VkQMcNih+3X2ouQVp4U6A1M+fkQBbqqsXaIEEJUBxJCROWgUsGj8wAVHP4RYndb7NCzB7bCydaKw5fT+GrHOYsdVwghajoJIaLy8G4PHZ41fr3+ddBbZrKou5Mtbz1unFM0P+Ik55KzLHJcIYSo6SSEiMrlkemgdYa4g/DPNxY77L861qdHEzdyC/RM/fkQer085U4IIcxNQoioXGrVhYdv3JIdORuuX7PIYVUqFWFDWmNnrWHPuRS+/zvWIscVQoiaTEKIqHw6vwB1W0D2VdjynsUO6+Nqz2vBxtt0w9YdJy7tusWOLYQQNZGEEFH5aKwh5Eb4iF4KCTEWO/Sobr60b1CbzNwC3vz1CAYLLSUvhBA1kYQQUTk1fhha9geDDsKnWOy5Mhq1inlPtMFGo2bz8UTWHLTMmiVCCFETSQgRlVffuaDRwrltcGyNxQ7b1MORCY80AWDWHzFczbTMUvJCCFHTSAgRlZeLL3SfaPx6w1uQb7k5Gi891JgWno6kZOUx+0/LXQ4SQoiaREKIqNx6vApO9SEtFnZ+arHD2lipef+JNqhV8PuBK0QeS7DYsYUQoqaQECIqNxt76DvH+PWO+ZBquVtn2/rU5oWejQB489cjZOTkW+zYQghRE0gIEZVfq8HQsAcU5MDGty166FeDmtGwjj3x6Tm8t/64RY8thBDVnYQQUfmpVNDvfVCpIeY340RVC7Gz0RA2pDUA3+6JZffZqxY7thBCVHflCiEXL17k0qVLpvfR0dFMmjSJJUuWVFjDhCjEMwA6PWf8ev0U0BVY7NDdGrvxdJcGAEz9+RA5+ZZ5po0QQlR35QohzzzzDH/99RcA8fHx9OnTh+joaN58801mz55doQ0UwuThN8HOBRJjYN/XFj30tEdb4OGk5fzVbD7edNKixxZCiOqqXCHkyJEjdOnSBYAff/yRgIAAdu3axbfffsvy5csrsn1C3GLvCo+8Zfx681zIstylESdba94ZZLwss3TbWQ5dSrXYsYUQoroqVwjJz89Hq9UCsGnTJgYMGABAixYtiIuLq7jWCXGnjmPAozXkpMJfcy166CB/D/q39UZvgNd/OkS+Tm/R4wshRHVTrhDSqlUrFi9ezPbt24mIiCAkJASAK1euUKdOnQptoBCFqDXGSaoAe7+GuIMWPfyM/v642FtzPD6DL7aeseixhRCiuilXCHn//ff54osv6NWrF08//TRt27YFYM2aNabLNEKYjW93CHgCMBgnqVrwIXNutbTM6N8KgE8jT3M6McNixxZCiOqmXCGkV69eJCcnk5yczLJly0zbX3zxRRYvXlxhjROiRH1mg7U9xEbBkZ8teuiB7bx5uHld8nR6Xv/pEDq9PGlXCCHKo1wh5Pr16+Tm5uLi4gLAhQsXWLBgASdOnMDd3b1CGyhEsZzrQ49Q49cb34a8LIsdWqVS8c7g1jjYaNgfm8o3UectdmwhhKhOyhVCBg4cyMqVKwFITU0lMDCQjz76iEGDBrFo0aIKbaAQJer2CtRuCBlXYPt8ix7au7YdUx9tCcC8DSe4mJJt0eMLIUR1UK4Qsn//fnr27AnATz/9hIeHBxcuXGDlypV8+qnlHjImajhrWwh+1/j1rk8h5axFDz+8SwO6+LqSnafjjV8PY7Dg3BQhhKgOyhVCsrOzcXR0BGDjxo0MGTIEtVrNAw88wIULF8pc38KFC/H19cXW1pbAwECio6NLtd8PP/yASqVi0KBBhbaPHj0alUpV6HXzDh5RzbR4DBo9DLo82PCWRQ+tVqt474nW2Fip2X4qmZ/3X7bo8YUQoqorVwhp0qQJv/32GxcvXmTDhg307dsXgMTERJycnMpU1+rVqwkNDWXGjBns37+ftm3bEhwcTGJi4l33O3/+PJMnTzaNyNwpJCSEuLg40+v7778vU7tEFXHzuTJqKzixFk5vsujhG9WtxatBzQCY82cMiRk5Fj2+EEJUZeUKIdOnT2fy5Mn4+vrSpUsXunbtChhHRdq3b1+muubPn8/YsWMZM2YM/v7+LF68GHt7+0J33dxJp9MxfPhwZs2aRaNGjYoto9Vq8fT0NL1uTqIV1VDd5tDl38av10+FgjyLHn5sTz8C6jmRdj2fmWuOWvTYQghRlVmVZ6cnn3ySHj16EBcXZ1ojBKB3794MHjy41PXk5eWxb98+pk2bZtqmVqsJCgoiKiqqxP1mz56Nu7s7zz//PNu3by+2zJYtW3B3d8fFxYVHHnmEuXPnlriQWm5uLrm5uab36enpgHFl2Pz8/FKfT3V1sw8qdV90D8Xq0GpUV0+h270IfeDLFj38OwP9GbJ4D+sOx/PngUsEt/K47zqrRL9XQ9LvypB+V4Y5+r0sdZUrhACmEYabT9OtX79+mRcqS05ORqfT4eFR+Ae2h4cHx48fL3afHTt28NVXX3HgwIES6w0JCWHIkCH4+flx5swZ3njjDfr160dUVBQajaZI+bCwMGbNmlVk+8aNG7G3ty/TOVVnERERSjfhrhq4DaR97FfoN4cRGe9CrrWzRY//iJeaiMtq3vj5ABlndNiX+19XYZW936sr6XdlSL8royL7PTu79HcLluvHpF6vZ+7cuXz00UdkZmYC4OjoyH//+1/efPNN1OpyXeW5p4yMDJ599lmWLl2Km5tbieWGDRtm+rp169a0adOGxo0bs2XLFnr37l2k/LRp0wgNDTW9T09Px8fHh759+5Z5jkt1lJ+fT0REBH369MHa2lrp5pTMEIL+631Yxx2gr2Y3ukc/sejhe+frGPB5FGeTs9mna0jYgFb3VV+V6fdqRvpdGdLvyjBHv9+8mlAa5Qohb775Jl999RXvvfce3bt3B4wjFDNnziQnJ4d33nmnVPW4ubmh0WhISEgotD0hIQFPT88i5c+cOcP58+fp37+/aZteb3yImJWVFSdOnKBx48ZF9mvUqBFubm6cPn262BCi1WpND+S7nbW1tfxjuE2V6I9HP4Cv+qA++C3qzs9D/Y4WO7S1tTXznmzLv76I4qf9lxnUvj49mpYclstSb6Xv92pI+l0Z0u/KqMh+L0s95RqyWLFiBV9++SXjxo2jTZs2tGnThpdffpmlS5eyfPnyUtdjY2NDx44diYyMNG3T6/VERkaaJrverkWLFhw+fJgDBw6YXgMGDODhhx/mwIED+Pj4FHucS5cucfXqVby8vMp8rqKK8ekCbZ82fr3uNTi7DQ7/BOe2g15n9sN38nVl5AMNAZj6yyGy8wrMfkwhhKiqyjUSkpKSQosWLYpsb9GiBSkpKWWqKzQ0lFGjRtGpUye6dOnCggULyMrKYsyYMQCMHDmSevXqERYWhq2tLQEBAYX2r127NoBpe2ZmJrNmzeKJJ57A09OTM2fO8Prrr9OkSROCg4PLcbaiygmaCUd/hSv7YOWtUTOcvCHkffAfYNbDvxbSgk3HErl07TofbjjJ9P7+Zj2eEEJUVeUaCWnbti2fffZZke2fffYZbdq0KVNdQ4cO5cMPP2T69Om0a9eOAwcOEB4ebpqsGhsbS1xcXKnr02g0HDp0iAEDBtCsWTOef/55OnbsyPbt24u95CKqoYvRUFDMeh3pcfDjSIhZY9bD19Ja8c5gYyj+etc59sdeM+vxhBCiqirXSMi8efN47LHH2LRpk+mySVRUFBcvXmTdunVlrm/ChAlMmDCh2M+2bNly133vvPxjZ2fHhg0bytwGUU3odRA+pYQPDYAKwqcaV1pVF71TqqL0au7OkA71+GX/Zab8dIg//9MDrZX5jieEEFVRuUZCHnroIU6ePMngwYNJTU0lNTWVIUOGcPToUb755puKbqMQpXdhF6RfuUsBA6RfNpYzs7cf88etlg2nEjNZ+NcZsx9PCCGqmnKvZODt7V3kLpiDBw/y1VdfsWTJkvtumBDlkplw7zJlKXcfXBxsmDUggPHf7efzv07TL8CTll5yy7cQQtxkngU9hFBKrVKuVGpnmWX8H23tSV9/Dwr0Bqb8fIgCnd4ixxVCiKpAQoioXhp2M94Fg+ru5dZPhUt7zd4clUrFnEEBONpacehSGl/vPG/2YwohRFUhIURUL2qN8TZcoGgQufFe6wRXT8JXfSBiOuSb98m3Hk62vPVYSwA+ijjB+eQssx5PCCGqijLNCRkyZMhdP09NTb2ftghRMfwHwFMrjXfJ3D5J1ckbQt4D3x6wfgoc/hF2fgIn1sPAhcaFzszkqU4+/H7gCrvOXGXqL4f4fuwDqFT3GK0RQohqrkwhxNn57g8Ec3Z2ZuTIkffVICEqhP8A4224F3YZJ6HW8jBeqrl5W+4TS6HVIPjzVUg+CV/1ha7j4ZG3wNquwpujUql4b0gb+i7Yyu6zKfzw90We7tKgwo8jhBBVSZlCyNdff22udghR8dQa8OtZ8uctHoMGXWHDG3Dwe4j6DE6GG0dFGjxQ4c1pUMeeyX2bM3ftMd5de4yHm7vj6Wxb4ccRQoiqQuaEiJrN3hUGL4anV4OjF1w9DctCIHwa5JX+cdSlNaa7H219apORW8Bbvx3GYDBU+DGEEKKqkBAiBEDzEHg5CtoNBwyw+3NY3L3CFzXTqFXMe6IN1hoVm44l8ueh0j+SQAghqhsJIULcZOcCgz6H4T+BozeknIWvHzVOYs2ruDtamns6Mv7hJgDMXHOUlKy8CqtbCCGqEgkhQtypaR8YvxvaPwsYYM9iWNQNzu+osEO83KsJzT0cuZqVx5w/YyqsXiGEqEokhAhRHFtnGPgZjPgZnOrBtfOw/DFYOxlyM++7ehsrNe8/2Qa1Cn795zJ/HU+8/zYLIUQVIyFEiLtpEgQv74aOo43v/14Ki7rC2a33XXU7n9o8190PgDd/PUxGTv591ymEEFWJhBAh7sXWCfp/As/+Cs4+kBoLKwfAn6GQm3FfVYf2bUYDV3uupOUwL/xEBTVYCCGqBgkhQpRW40eMd9B0es74fu9X8Hk3OPNXuau0t7HivSGtAfhm9wWiz6VUREuFEKJKkBAiRFloHeHxj2HkGqjdANJi4ZtB8MdEyEkvV5XdmrgxrLMPAFN+PkROvq4CGyyEEJWXhBAhyqPRQzAuCjqPNb7ftxw+7wqnI8tV3bRHW+LuqOVcchafRJ6quHYKIUQlJiFEiPLS1oLHPoRRf4KLL6RfglVD4PcJkJNWpqqc7ayZOygAgCXbznLwYip7zqWwL1nFnnMp6PSysqoQovqRECLE/fLrCeN2QeBLxvf/fGMcFTkVUaZq+rby5LE2Xuj0Bp5YtIsRy/ay8pSGEcv20uP9zYQfkdVVhRDVi4QQISqCjQP0ex/GrAfXRpB+Gb59En4bD9dTS13Ng03rAlBwx8hHfFoO41btlyAihKhWJIQIUZEadoOXdsID4wEVHFgFnz8AJzfcc1ed3sCCTSeL/exmJJn1R4xcmhFCVBsSQoSoaDb2EPIuPBcOro0hIw6+ewp+fQmuXytxt+hzKcSl5ZT4uQGIS8uR23iFENWGhBAhzKXBAzBuJ3SdAKjg4Pew8AE4vq7Y4okZJQeQ8pQTQojKTkKIEOZkbQfB78DzG6FOU8iMhx+ehp/HQnbhEQ13R9tSVVnackIIUdlVihCycOFCfH19sbW1JTAwkOjo6FLt98MPP6BSqRg0aFCh7QaDgenTp+Pl5YWdnR1BQUGcOiVrLwgF+XSBl7ZD94mgUsPhH2FhIBz701Ski58rXs62qO5SjZOdFZ19XczfXiGEsADFQ8jq1asJDQ1lxowZ7N+/n7Zt2xIcHExi4t2fKnr+/HkmT55Mz549i3w2b948Pv30UxYvXsyePXtwcHAgODiYnBwZxhYKsraDPrPh+Qhwaw5ZibB6OPz0PGRdRaNWMaO/P0CJQST9egFv/nqE3AJZVVUIUfUpHkLmz5/P2LFjGTNmDP7+/ixevBh7e3uWLVtW4j46nY7hw4cza9YsGjVqVOgzg8HAggULeOuttxg4cCBt2rRh5cqVXLlyhd9++83MZyNEKdTvBP/eBj1CjaMiR36CzwMh5ndCArxYNKID3k7WPKCOYYB6Fw+oY6jnZM2QDvVQq2D13os8vWQ3iekSqoUQVZuVkgfPy8tj3759TJs2zbRNrVYTFBREVFRUifvNnj0bd3d3nn/+ebZv317os3PnzhEfH09QUJBpm7OzM4GBgURFRTFs2LAi9eXm5pKbm2t6n55ufAZIfn4++fnyePWbfSB9UZE08NAbqJqGoPnzP6iSjsOPI9G3HEhQ494Ea99DlXfFVNqg9UbX8l0eD3iAST8eYn9sKv3/t4OFz7SjbX1nBc+j+pHvd2VIvyvDHP1elroUDSHJycnodDo8PDwKbffw8OD48ePF7rNjxw6++uorDhw4UOzn8fHxpjrurPPmZ3cKCwtj1qxZRbZv3LgRe3v7e51GjRERUbYVQEXpqL1fo5n6d5om/In62O+ojv1etFDGFTQ/j6aW3yv8p0VnvjyhIT4jl2FLdjO0kZ4u7rJ2SEWT73dlSL8royL7PTs7u9RlFQ0hZZWRkcGzzz7L0qVLcXNzq7B6p02bRmhoqOl9eno6Pj4+9O3bFycnpwo7TlWVn59PREQEffr0wdraWunmVFMD0V3eh2rlY6j0BUU+VQEGVHS++gvtx7/FE/kGXvvpMJuOJ/HtGQ1W7g2YGtwMK43iV1irPPl+V4b0uzLM0e83ryaUhqIhxM3NDY1GQ0JCQqHtCQkJeHp6Fil/5swZzp8/T//+/U3b9Ho9AFZWVpw4ccK0X0JCAl5eXoXqbNeuXbHt0Gq1aLXaItutra3lH8NtpD/MzJAPxQSQm1QYIP0y1tvew6VZMEsG+/LJHmc+2XyaFVGxnErMYuEzHXBxsLFgo6sv+X5XhvS7Miqy38tSj6IhxMbGho4dOxIZGWm6zVav1xMZGcmECROKlG/RogWHDx8utO2tt94iIyODTz75BB8fH6ytrfH09CQyMtIUOtLT09mzZw/jxo0z9ykJUX6ZCfcuA7DzY9j5MWrgVSs7XnCvx940J85fqMuKBfV5oncPfBr5g0tD4x05QghRSSl+OSY0NJRRo0bRqVMnunTpwoIFC8jKymLMmDEAjBw5knr16hEWFoatrS0BAQGF9q9duzZAoe2TJk1i7ty5NG3aFD8/P95++228vb2LrCciRKVSy+PeZQA820JOKqRdgoLrOKaf5mEVxn/N+UD4V7fV6QmufuDie8fLD2q5g+puq5KUk14HF3YZQ1UtD+PzdNSaij+OEKLKUzyEDB06lKSkJKZPn058fDzt2rUjPDzcNLE0NjYWtbps17lff/11srKyePHFF0lNTaVHjx6Eh4djaysrTYpKrGE3cPKG9DhuPbLudirj5y/+ZfylrsuHtItw7TxcO09O4lkOHf4H+6xLNFAl4KS6blyhNTMeYou528zKrnAwuT2s1G5QvlGUmDUQPgXSb93Zg5M3hLwP/gPKXp8QolpTGQwGmVZ/h/T0dJydnUlLS5OJqRgnLq1bt45HH31UrtWaW8wa+HHkjTe3/9O8MWLx1Mq7/jIv0Ol5P/w4S7efxZksnvDLZ3IXG+wzb4UVUs5D+iUw6O/eFkcv44hJkVEU3+JHUUxtv/NHSunaXlnI97sypN+VYY5+L8vvUMVHQoQQt/EfYPxlXexownv3/CVupVHz5mP++Hs7MeXnwyw7p2drpgNLRj5K47q1bhUsyCs0isK1c4VDSl6G8em/GXEQu6vogaztC4eS2g1g2wcUP4JjAFQQPhVaPCaXZoQQJhJChKhs/AdAi8coOLuNA9s30K5nMFaNHizTL+/B7evTuG4t/v3NPs4kZTHos518+nR7Hm7hbixgZQN1GhtfdzIY4Po1SDlXOJzcfKVdgvxsSIwxvkrFeGcPx/+ElgPMMxdFCFHlSAgRojJSazA07MHlo+m0bdijXKMHberXZs2EHoxbtY+9F67x3Iq/eS24OeMeaozqbiFApQJ7V+Orfsein5tGUW4ElJRzcGEnXPnn3o36ceSNuSgNb4ygNLzjUk9DsHEo87kKZEKwKDu9DtWFHdRLiUJ1wQnK+J+diiAhRIhqrK6jlu/GPsDMP47y3Z5Y5oWfIOZKOh882RY7m3L+sCluFOXcdljxeCl2VkHBdUg6bnwVx6HuHZd6bgsqTt7m/SFZCX4ol0tVnxBcVfu9KrvxPWOVfoVOABcWKfI9IyFEiGrOxkrNu4Nb4+/lxMw1R/nzUBxnk7L44tmO+LhW0GMJSntnz4R9kBl3xyWeC7e+zkmFrCTj69LfRatRWxvnn7g0LD6o2NUu/zlUkh/KZVbShOD0OOP2yj4huKr2e1VWib5nJIQIUUOMeKAhzTwcefnbfcTEpTNw4U4WPtOBro3r3H/lao3xl8aPI7m5yPwtNy79hLwHNnbg2sj4Ks71VEi9UHQeyrULkBoL+nxIOWN8Fce2duFLO7cHFWcf0JQw+78S/VAuE73OOAJSVScEV9V+r8oq2feMhBAhapAufq6smdCDF7/Zy5HL6Yz4ag/TH/dnZNeGd58nUhr3eWcPYBzJsKsNXm2LfqbXGeu9dr6YoHIBshKNIylxB4yvO6nU4FS/+HCy7jXu64eywQC6PCjIgYLcEv6822d3/plXun1yMyA/6y4demNC8Ow6xgCm0oDaynge6ptfW93Yftv72z8vaR+1lbFP77rPXY6lUsP2j+7R71Mqb4C6qTLOxdEVQHYyZCYaX1mJxvZlJkH84cL/Pou48T1zYRf49TR7UyWECFHDeNe246eXujH150P8duAKM9Yc5eiVNOYMCkBrdZ8/PG/c2WOWH8pqDdT2Mb4o5odjXlbhSzt3BpWCHEiLNb7Oby/DgW/8UP78AdBoCwcBXe6tryu1GyGpSjEYf1nO9TSuS2PvCvZ17ni5Fv+1VdFngZmFJefi6HWQnWL8d5WVeCtgZCYYL1/eDBmZCZB9leLDXRmU9jES90lCiBA1kK21ho+HtqOVtzNh64/x495LnErM5IsRHXF3us+VhdUai/wPqggbB/DwN77uZDAYf2DfHkpuhpTEGOMtyfeSfLL0bbGyM/4itLI1TuS1sr3t/e1fl/fPG1/HH4HfXrp3e576Bup1BIPO+JBEfTF/mj67+dLf+rrE/QqMi96Var/b69cZL6kVt5LvnfR5xsX10i+Vvv9tapUitNQBO9db20u6VFeSiriUpNcbv/duH6koEjJujGRkJd17gcHbqdRg72b8j0CtusY/Heoaw/rer+69f2kfI3GfJIQIUUOpVCrGPtiI5p6OTPhuP//EptL/sx0sHtGR9g1clG5exVKpwNHD+GoQWPiz0t7Z8/DbUK/9vYOExtpy66C4+8Pm2feeEFwZL2mUtt+f+NI4hyg7xfg//CKva4XfG3SQl2l8pcaWvj1a52KCS3FBpo5x7tG95lWsmwxaJ+NlkTtHKm6GjKykuz45uyiV8fi13I0vB/dbX98MGbU8bowc1Sn+71yvg5Pr7/0907BbGdpVfhJChKjhHmxWlzUTejB25V5OJWYy9IvdvDM4gH918lG6aZZR2jt7er5a+X6Rl3ZCcGVrN5S+31sNKX37DQbISbsRSEoILdfvCC3ZKcbj56YZX9fOVcDJGYxh45uBpStu51I0RJhCxm0jGfZuoLnPX9uV7HtGQogQAl83B34d353Q1QfYGJPAaz8d4uiVdN58rCXWmrI9QLLKqWQ/lMusIiYEK8Ec/a5S3ZrcXNxqwMXR624LLsW9UooGmpzU0tVdyxPqNCl8OeTOkOFQ13jJzpIq0feMPMCuGPIAu8LkwVLKUKLf9XoDn24+xYJNpwDo2qgOC4d3wNXBwj8klVDsJMN6lfsX+e0q410apVEV+/3MltKNcoz6U5n5UaWl193X4yFKIg+wE0KUi1qtYlJQM1p6ORG6+gBRZ68y4LMdLB3ZiZZe1TyQV8AzexSl1ITg+1UV+92vZ+kuJVloXkW5VcDjIe67CRY/ohCi0gtu5cmv47vTsI49l65dZ8jnu1h7KE7pZpnfzR/Krl0xKPRDuUaqav1+81ISYLp0ZFIFLuFVIhJChBDFaubhyO/ju9OzqRvX83WM/24/H2w4jl4vV3CFMM2rcPIqvN3JW1Z6LQO5HCOEKFFtexu+Ht2ZeRtOsGTbWRb+dYbjcRl8PKwdTrYyP0jUcOZcnK+GkJEQIcRdWWnUvPFoSxYMbYfWSk3k8UQGLdzJmaRMpZsmhPJuzsVp/aTxTwkgZSIhRAhRKoPa1+Onl7rh5WzL2aQsBn22k7+OJyrdLCFEFSYhRAhRaq3rO7NmQg86+7qQkVvAcyv+ZuFfp5E7/YUQ5SEhRAhRJnUdtXz7wgMMD2yAwQAfbDjBK9//Q3aecflpnd5A1Jmr/H7gMlFnrqKTiaxCiBLIxFQhRJnZWKl5Z3Br/L2dmPH7Uf48FMeZpCyGBzZg4V+niUu79VRZL2dbZvT3JyTA6y41CiFqIhkJEUKU2/DAhnz/4gO41bLhWFw6b/12pFAAAYhPy2Hcqv2EH6kB64wIIcpEQogQ4r509nXl15e7Y60u/smxNy/GzPojRi7NCCEKqRQhZOHChfj6+mJra0tgYCDR0dEllv3ll1/o1KkTtWvXxsHBgXbt2vHNN98UKjN69GhUKlWhV0hIiLlPQ4ga69K16+TfJWAYgLi0HKLPpViuUUKISk/xOSGrV68mNDSUxYsXExgYyIIFCwgODubEiRO4u7sXKe/q6sqbb75JixYtsLGx4c8//2TMmDG4u7sTHBxsKhcSEsLXX39teq/Vai1yPkLURIkZOfcuVIZyQoiaQfGRkPnz5zN27FjGjBmDv78/ixcvxt7enmXLlhVbvlevXgwePJiWLVvSuHFjJk6cSJs2bdixY0ehclqtFk9PT9PLxcXFEqcjRI3k7mhbqnJuteQ/A0KIWxQdCcnLy2Pfvn1MmzbNtE2tVhMUFERUVNQ99zcYDGzevJkTJ07w/vvvF/psy5YtuLu74+LiwiOPPMLcuXOpU6dOsfXk5uaSm5trep+eng4YH6Wen59fnlOrVm72gfSFZVWlfm9f3xFPJy0J6bnFPlP0ptl/HGVqSHN6NCn+32JlUJX6vTqRfleGOfq9LHWpDAquMnTlyhXq1avHrl276Nq1q2n766+/ztatW9mzZ0+x+6WlpVGvXj1yc3PRaDR8/vnnPPfcc6bPf/jhB+zt7fHz8+PMmTO88cYb1KpVi6ioKDSaokvqzpw5k1mzZhXZ/t1332Fvb18BZypE9XfwqoplJ28Ort4+SdX4I8ZGDXl64/YWznoGNNRTz8GybRRCmF92djbPPPMMaWlpODk53bWs4nNCysPR0ZEDBw6QmZlJZGQkoaGhNGrUiF69egEwbNgwU9nWrVvTpk0bGjduzJYtW+jdu3eR+qZNm0ZoaKjpfXp6Oj4+PvTt2/eeHVgT5OfnExERQZ8+fbC2loeWWUpV6/dHgQ5HE5i77jjx6bdGFr2cbXmzXwu6+Lnw+ZazfBt9keNpak4cVvNE+3pM7N0YT6fSXc6xhKrW79WF9LsyzNHvN68mlIaiIcTNzQ2NRkNCQkKh7QkJCXh6epa4n1qtpkmTJgC0a9eOY8eOERYWZgohd2rUqBFubm6cPn262BCi1WqLnbhqbW0t/xhuI/2hjKrU74+3q0+/NvWIPpdCYkYO7o62dPFzRXPj9t2ZA1szpkcj5m04wdpDcfy0/zJ/Ho5jbM9G/PuhxtTSVp7/F1Wlfq9OpN+VUZH9XpZ6FJ2YamNjQ8eOHYmMjDRt0+v1REZGFro8cy96vb7QnI47Xbp0iatXr+LlJSs2CmFuGrWKro3rMLBdPbo2rmMKIDc1rOPAwmc68MvL3ejU0IWcfD3/23yaXh/8xardFyjQ6RVquRDC0hS/OyY0NJSlS5eyYsUKjh07xrhx48jKymLMmDEAjBw5stDE1bCwMCIiIjh79izHjh3jo48+4ptvvmHEiBEAZGZm8tprr7F7927Onz9PZGQkAwcOpEmTJoVu4RVCKKtDAxf+76WuLB7RAT83B5Iz83jrtyMEL9jGppgEeSieEDWA4mOfQ4cOJSkpienTpxMfH0+7du0IDw/Hw8MDgNjYWNTqW1kpKyuLl19+mUuXLmFnZ0eLFi1YtWoVQ4cOBUCj0XDo0CFWrFhBamoq3t7e9O3blzlz5shaIUJUMiqVipAAL3q39OC7PbF8EnmKM0lZvLByL4F+rrz5WEva1K+tdDOFEGaieAgBmDBhAhMmTCj2sy1bthR6P3fuXObOnVtiXXZ2dmzYsKEimyeEMDNrjZpR3XwZ3KEei7acYdmOc+w5l8KAz3YysJ03k/s2x8dV7lQTorpR/HKMEELc5GRrzZSQFmye3Ish7euhUsHvB67Q+6OtvLvuGGnZsoaEENWJhBAhRKVTr7Yd84e2448JPejWuA55Oj1Ltp3loQ//4qsd58grkMmrQlQHEkKEEJVWQD1nvn0hkK9Hd6aZRy1Ss/OZ82cMQfO3svZQnExeFaKKkxAihKjUVCoVD7dwZ91/evLekNbUddQSm5LN+O/2M2TRLvaelyfzClFVSQgRQlQJVho1w7o0YMvkXkwKaoq9jYZ/YlN5cnEUL32zj3PJWUo3UQhRRhJChBBVioPWiklBzdgyuRdPd/FBrYLwo/H0mb+VGb8f4WpmyQsXCiEqFwkhQogqyd3JlrAhbQif9CCPtHCnQG9gRdQFen2whc+3nCYnX6d0E4UQ9yAhRAhRpTXzcGTZ6M5890IgrbydyMgtYF74CR75cAu/7L+EXi+TV4WorCSECCGqhW5N3PhjQg/mP9UWb2dbrqTlEPrjQfp/toOdp5OVbp4QohgSQoQQ1YZarWJIh/psntyLKSEtcNRacfRKOsO/3MOYr6M5mZChdBOFELeRECKEqHZsrTWM69WYra8/zOhuvlipVfx1IomQBduY+vMhEtNzlG6iEAIJIUKIaszVwYaZA1oREfoQIa080Rvgh78v8tAHW/g44iRZuQWFyuv0BvacS2Ffsoo951LQyXwSIcyqUjzATgghzMnPzYHFz3Zk7/kU3ll3jH9iU/kk8hTfRccS2qcZ/+pYn03HEpj1RwxxaTmAhpWn9uLlbMuM/v6EBHgpfQpCVEsyEiKEqDE6+bryy7hufD68Aw1c7UnKyGXaL4fp+f5fvLRq/40Ackt8Wg7jVu0n/EicQi0WonqTECKEqFFUKhWPtvZiU+hDTH/cH2c7K+JKmCNy82LMrD9i5NKMEGYgIUQIUSPZWKl5rocfHz3V7q7lDEBcWg7R5+QZNUJUNAkhQoga7c7JqSW5eC3bzC0RouaRECKEqNHcHW1LVe7NXw7z4sq9/PbPZdJz8s3cKiFqBrk7RghRo3Xxc8XL2Zb4tBxKmvWhUavI1xvYGJPAxpgEbDRqejR1o1+AJ338Pahtb2PRNgtRXUgIEULUaBq1ihn9/Rm3aj8qKBREVDf+/Ozp9vi6ObD+cBxrD8dxJimLzccT2Xw8ESu1im5N3Hg0wJO+rTxxdZBAIkRpSQgRQtR4IQFeLBrR4bZ1Qow871gnpKWXE6F9m3MqIYN1h+NZfySO4/EZbDuZxLaTSbz52xEeaORKvwAvglt5UtdRq9QpCVElSAgRQgiMQaSPvydRpxPZuH0PfXsG0rWJOxq1qkjZph6OTPRwZGJQU84mZbL+iDGQHLmczs7TV9l5+ipv/36ELr6u9AvwJCTAC0/n0s09EaImkRAihBA3aNQqAv1cuXrMQKCfa7EB5E6N6tZi/MNNGP9wE2KvZrP+SBzrjsRz8GIqe86lsOdcCjP/iKFjQxf6BXjSr7UX9WrbWeBshKj8JIQIIUQFaVDHnn8/1Jh/P9SYS9eyCT8Sz/oj8ey7cM30mrv2GG19avNogCf9ArxoUMde6WYLoRgJIUIIYQb1Xex5oWcjXujZiPi0HMJvjJD8fT6FgxdTOXgxlbD1xwmo50S/AC/6BXjSqG4tpZsthEVVinVCFi5ciK+vL7a2tgQGBhIdHV1i2V9++YVOnTpRu3ZtHBwcaNeuHd98802hMgaDgenTp+Pl5YWdnR1BQUGcOnXK3KchhBDF8nS2ZXR3P378d1f2vNGbuYMC6N6kDmoVHLmczgcbTvDIR1sJWbCNTzad4lRChtJNFsIiFB8JWb16NaGhoSxevJjAwEAWLFhAcHAwJ06cwN3dvUh5V1dX3nzzTVq0aIGNjQ1//vknY8aMwd3dneDgYADmzZvHp59+yooVK/Dz8+Ptt98mODiYmJgYbG1lcpgQQjnujraMeKAhIx5oyNXMXCJiElh3JJ5dp5M5Hp/B8fgMPt50kibutYyXbFp70cLTEZXq3vNThKhqFA8h8+fPZ+zYsYwZMwaAxYsXs3btWpYtW8bUqVOLlO/Vq1eh9xMnTmTFihXs2LGD4OBgDAYDCxYs4K233mLgwIEArFy5Eg8PD3777TeGDRtm9nMSQojSqFNLy7AuDRjWpQGp2XlExCQQfiSe7aeSOZ2YyaebT/Pp5tP41rGnX2svHg3wIqCeU7GBRKc3EH0uhcSMHNwdbelSyom1QihJ0RCSl5fHvn37mDZtmmmbWq0mKCiIqKioe+5vMBjYvHkzJ06c4P333wfg3LlzxMfHExQUZCrn7OxMYGAgUVFRxYaQ3NxccnNzTe/T09MByM/PJz9flme+2QfSF5Yl/a4MpfrdwVrFoLaeDGrrSUZOPptPJLPhaAJbTyVz/mo2i7acYdGWM9SvbUtwKw9CWnnQtr4zKpWKDUcTmLvuOPHpt36OeTppeevRFgS38rDoeZSXfL8rwxz9Xpa6FA0hycnJ6HQ6PDwK/yPx8PDg+PHjJe6XlpZGvXr1yM3NRaPR8Pnnn9OnTx8A4uPjTXXcWefNz+4UFhbGrFmzimzfuHEj9vYyc/2miIgIpZtQI0m/K0PpfrcGHq8NQR0g5pqKg1dVHE1VcSk1h692XuCrnReobWPA295ATOrNEY9bIx/x6TlM+OEAzzXT07ZOSQvSVz5K93tNVZH9np1d+oc9Kn45pjwcHR05cOAAmZmZREZGEhoaSqNGjYpcqimtadOmERoaanqfnp6Oj48Pffv2xcnJqYJaXXXl5+cTERFBnz59sLa2Vro5NYb0uzIqY78PufFndl4B205dJfxoAltOJJGapyM1r6RLLipUwPoEe14f/mClvzRTGfu9JjBHv9+8mlAaioYQNzc3NBoNCQkJhbYnJCTg6elZ4n5qtZomTZoA0K5dO44dO0ZYWBi9evUy7ZeQkICXl1ehOtu1a1dsfVqtFq226PLK1tbW8o/hNtIfypB+V0Zl7Hdna2v6t6tP/3b1ycnX8eX2s3y48WSJ5Q1AXFou/1zKoGvjOpZr6H2ojP1eE1Rkv5elHkVv0bWxsaFjx45ERkaatun1eiIjI+natWup69Hr9aY5HX5+fnh6ehaqMz09nT179pSpTiGEqMxsrTX4uJbucnHY+mP8sv8Sadky30JULopfjgkNDWXUqFF06tSJLl26sGDBArKyskx3y4wcOZJ69eoRFhYGGOdvdOrUicaNG5Obm8u6dev45ptvWLRoEQAqlYpJkyYxd+5cmjZtarpF19vbm0GDBil1mkIIUeHcHUu35MChS2mE/ngQK7WKwEauBLfypK+/pzzPRihO8RAydOhQkpKSmD59OvHx8bRr147w8HDTxNLY2FjU6lsDNllZWbz88stcunQJOzs7WrRowapVqxg6dKipzOuvv05WVhYvvvgiqamp9OjRg/DwcFkjRAhRrXTxc8XL2Zb4tByKm3qqAurUsmFYZx8iYhI5kZBhesDe9N+P0ra+M31beRLcypMm7rJaq7A8lcFgqDrTpi0kPT0dZ2dn0tLSZGIqxolL69at49FHH5VrtRYk/a6Mqtbv4UfiGLdqP0ChIHJzGuqiER0ICTDOjzufnMXGmHg2HE1gf+w1bv/p36iuw40REg/a1q+N2sITWatav1cX5uj3svwOVXwkRAghRPmFBHixaEQHZv0RQ1xajmm7p7MtM/r7mwIIgK+bAy8+2JgXH2xMYkYOm2IS2XA0nl1nkjmblGVai8TDSUtff0/6tvLggUZ1sNZUiid8iGpIQogQQlRxIQFe9PH3LNOKqe6OtjwT2IBnAhuQkZPPXyeS2HA0ni3HE0lIz+Wb3Rf4ZvcFnGyteKSFO8GtPHmoeV3sbeTXhqg48t0khBDVgEatKvdtuI621gxo682Att7kFujYdfoqG2PiiYhJIDkzj98OXOG3A1fQWqnp2dSNvq08CWrpgauDTQWfhahpJIQIIYQw0VppeLiFOw+3cGfuIAP7Y6+x8ahxHklsSjabjiWy6VgiahV09r1xp00rD+q7yOrSouwkhAghhCiWRq2is68rnX1deePRlpxIyGDDkQQ2HI0nJi6dPedS2HMuhdl/xtDK28kUSJp7yFN/RelICBFCCHFPKpWKFp5OtPB0YmJQUy6mZLMxxhhI9p5P4eiVdI5eSWd+xEka1rE33WnToYHLPe+00ekN7DmXwr5kFXXOpdC1iXulX2ZeVAwJIUIIIcrMx9We53v48XwPP65m5hJ5LJGNMfFsO5XMhavZLNl2liXbzuJWS0sff3f6tvKkW+M6aK00heoJPxJ32509Glae2otXMXf2iOpJQogQQoj7UqeWlqc6+/BUZx+ycgvYejKJjUfjiTyeSHJmLt9HX+T76IvU0lrRq3ldglt50qt5XXaeTmbcqv1FFlqLT8th3Kr9hdY4EdWThBAhhBAVxkFrxaOtvXi0tRd5BXr2nLvKhqPxbDyaQGJGLn8eiuPPQ3FYq1Wo1apiV3o1YFxsbdYfMfTx95RLM9WYhBAhhBBmYWOlpmfTuvRsWpfZAwI4eCmVDUcT2Hg0nrPJWaAvecFu4xOAc9hxOomHmrlbrtHCoiSECCGEMDu1WkX7Bi60b+DC1H4tWLLtDO+uO37P/UYt+xtHWyvcHbW4O9ri7qQt9HXd27521FpZ/K4cnd5QpkXiRGESQoQQQlhc63q1S102I6eAjJwCziRl3bWcrbXaGEgctTfCiu2NkKLF3enGdkctLvY2FfJsnMKTao1kUm3ZSAgRQghhcaV5ArCnsy3rJvbkamYeiRk5JGXkkpieS2JGDok3vk7IyCEpPZeM3AJy8vXEpmQTm5J912NbqVWmcFL3ztGV2wKMWy0brEp4bs7NBwfKpNr7IyFECCGExWnUKmb092fcqv2oKP4JwDP6++Nib4OLvQ1N3Gvdtb7rebpC4eTOr5MycknMyCUlK48CvYG4tJwbIxhpJdapUkEdBxtjUDGNqGhxq6Xlk8hTMqm2AkgIEUIIoYiyPAH4XuxsNDSs40DDOg53LZdXoCc5M/dGQLkRVDJyScrIuRFYjKElOTMPnd5AcmYeyZl5HIsr/XndnFS7++xVujdxK/2ONZCEECGEEIq5+QTgqNOJbNy+h749A826YqqNlRrv2nZ417a7azmd3kBKVp5pRCXpttGVAxdTOXSp5BGUm0Z/HY2/lxMtb7z8vZ1o4emIo611RZ1OlSchRAghhKI0ahWBfq5cPWYgsJLcXaK5MW+krqOWVnd8FnXmKk8v3X3POvJ1Bg5eSuPgHYHFx9WOlp63gom/lxP1Xexq5PN2JIQIIYQQZVDaSbUrn+vCyYRMjsWlExOXzrG4dOLScriYcp2LKdfZGJNg2sdRa0ULL0djMLkxctLc0xFba00xR6g+JIQIIYQQZVDaSbVNPRxp6uHIY21uzW25lpXHsfh0jsVlEHPFGExOJ2aSkVvA3+ev8ff5a6ayahX4uTng7+1My9sCirujttqMmkgIEUIIIcqovJNqXRxs6NbYjW6Nb01YzdfpOZN0Y8TkijGgHItL52pWHmeSsjiTlMUfB2/V4epgc2O0xNE036SJey2sS7iduCSV4enFEkKEEEKIcrg5qfZ+V0y11qhp4elEC08nBrc3bjMYDCRl5BJjupRjDCZnkzJJycpjx+lkdpxONtVho1HTxL3WjVDiaLqk4+JgU+wxK8vTiyWECCGEEOWkUavo2rhOhderUqmMq7w62dKr+a1n5+Tk6ziZcOtSzs1wkpFbYAost/NytjUFk5ujJifiMhj/XeVYaE1CiBBCCFFF2FpraFO/Nm3q1zZtMxgMXLp23TT59WY4iU3JNi3Ktvl44j3rVmKhNQkhQgghRBWmUqnwcbXHx9We4Faepu0ZOfmciM8whZOYuAxirqSRr7v304ujz6WYZYTnTmWbxWImCxcuxNfXF1tbWwIDA4mOji6x7NKlS+nZsycuLi64uLgQFBRUpPzo0aNRqVSFXiEhIeY+DSGEEKLScLS1ppOvKyO7+hI2pA2/j+/OvCfblmrfxIycexeqAIqHkNWrVxMaGsqMGTPYv38/bdu2JTg4mMTE4oeOtmzZwtNPP81ff/1FVFQUPj4+9O3bl8uXLxcqFxISQlxcnOn1/fffW+J0hBBCiErL08m2VOXcHUtX7n4pHkLmz5/P2LFjGTNmDP7+/ixevBh7e3uWLVtWbPlvv/2Wl19+mXbt2tGiRQu+/PJL9Ho9kZGRhcpptVo8PT1NLxcXF0ucjhBCCFFp3VxoraTZHiqMk1m7+LlapD2KzgnJy8tj3759TJs2zbRNrVYTFBREVFRUqerIzs4mPz8fV9fCHbZlyxbc3d1xcXHhkUceYe7cudSpU/z1rdzcXHJzc03v09ONs4vz8/PJz88v62lVOzf7QPrCsqTflSH9rgzpd8t5s19zXvnhYIkLrb3Zrzl6XQF6XfnqL8vfoaIhJDk5GZ1Oh4eHR6HtHh4eHD9+vFR1TJkyBW9vb4KCgkzbQkJCGDJkCH5+fpw5c4Y33niDfv36ERUVhUZTdAncsLAwZs2aVWT7xo0bsbe3L+NZVV8RERFKN6FGkn5XhvS7MqTfLWNMMxW/nFeTmndrTMTZxsAQXz26C/tYd6H8dWdnZ5e6bJW+O+a9997jhx9+YMuWLdja3rp+NWzYMNPXrVu3pk2bNjRu3JgtW7bQu3fvIvVMmzaN0NBQ0/v09HTTXBMnJyfznkQVkJ+fT0REBH369MHaWp7+aCnS78qQfleG9LtlPQq8rjew+0wSm6P28UjXjjzQuG6F3JZ782pCaSgaQtzc3NBoNCQkJBTanpCQgKenZwl7GX344Ye89957bNq0iTZt2ty1bKNGjXBzc+P06dPFhhCtVotWqy2y3draWv4x3Eb6QxnS78qQfleG9LvlWAPdm7qTdspA96buFdbvZalH0YmpNjY2dOzYsdCk0puTTLt27VrifvPmzWPOnDmEh4fTqVOnex7n0qVLXL16FS8vyy1FK4QQQoi7U/zumNDQUJYuXcqKFSs4duwY48aNIysrizFjxgAwcuTIQhNX33//fd5++22WLVuGr68v8fHxxMfHk5mZCUBmZiavvfYau3fv5vz580RGRjJw4ECaNGlCcHCwIucohBBCiKIUnxMydOhQkpKSmD59OvHx8bRr147w8HDTZNXY2FjU6ltZadGiReTl5fHkk08WqmfGjBnMnDkTjUbDoUOHWLFiBampqXh7e9O3b1/mzJlT7CUXIYQQQihD8RACMGHCBCZMmFDsZ1u2bCn0/vz583ety87Ojg0bNlRQy4QQQghhLopfjhFCCCFEzSQhRAghhBCKqBSXYyobg8G4hlxZ7nWuzvLz88nOziY9PV1unbMg6XdlSL8rQ/pdGebo95u/O2/+Lr0bCSHFyMjIAMDHx0fhlgghhBBVU0ZGBs7OznctozKUJqrUMHq9nitXruDo6IhKdf+rx1V1N1eQvXjxoqwga0HS78qQfleG9LsyzNHvBoOBjIwMvL29C93dWhwZCSmGWq2mfv36Sjej0nFycpIfDgqQfleG9LsypN+VUdH9fq8RkJtkYqoQQgghFCEhRAghhBCKkBAi7kmr1TJjxgxZcdbCpN+VIf2uDOl3ZSjd7zIxVQghhBCKkJEQIYQQQihCQogQQgghFCEhRAghhBCKkBAihBBCCEVICBElCgsLo3Pnzjg6OuLu7s6gQYM4ceKE0s2qUd577z1UKhWTJk1Suik1wuXLlxkxYgR16tTBzs6O1q1bs3fvXqWbVa3pdDrefvtt/Pz8sLOzo3HjxsyZM6dUzx0Rpbdt2zb69++Pt7c3KpWK3377rdDnBoOB6dOn4+XlhZ2dHUFBQZw6dcrs7ZIQIkq0detWxo8fz+7du4mIiCA/P5++ffuSlZWldNNqhL///psvvviCNm3aKN2UGuHatWt0794da2tr1q9fT0xMDB999BEuLi5KN61ae//991m0aBGfffYZx44d4/3332fevHn873//U7pp1UpWVhZt27Zl4cKFxX4+b948Pv30UxYvXsyePXtwcHAgODiYnJwcs7ZLbtEVpZaUlIS7uztbt27lwQcfVLo51VpmZiYdOnTg888/Z+7cubRr144FCxYo3axqberUqezcuZPt27cr3ZQa5fHHH8fDw4OvvvrKtO2JJ57Azs6OVatWKdiy6kulUvHrr78yaNAgwDgK4u3tzX//+18mT54MQFpaGh4eHixfvpxhw4aZrS0yEiJKLS0tDQBXV1eFW1L9jR8/nscee4ygoCClm1JjrFmzhk6dOvGvf/0Ld3d32rdvz9KlS5VuVrXXrVs3IiMjOXnyJAAHDx5kx44d9OvXT+GW1Rznzp0jPj6+0M8bZ2dnAgMDiYqKMuux5QF2olT0ej2TJk2ie/fuBAQEKN2cau2HH35g//79/P3330o3pUY5e/YsixYtIjQ0lDfeeIO///6b//znP9jY2DBq1Cilm1dtTZ06lfT0dFq0aIFGo0Gn0/HOO+8wfPhwpZtWY8THxwPg4eFRaLuHh4fpM3ORECJKZfz48Rw5coQdO3Yo3ZRq7eLFi0ycOJGIiAhsbW2Vbk6Notfr6dSpE++++y4A7du358iRIyxevFhCiBn9+OOPfPvtt3z33Xe0atWKAwcOMGnSJLy9vaXfawC5HCPuacKECfz555/89ddf1K9fX+nmVGv79u0jMTGRDh06YGVlhZWVFVu3buXTTz/FysoKnU6ndBOrLS8vL/z9/Qtta9myJbGxsQq1qGZ47bXXmDp1KsOGDaN169Y8++yzvPrqq4SFhSndtBrD09MTgISEhELbExISTJ+Zi4QQUSKDwcCECRP49ddf2bx5M35+fko3qdrr3bs3hw8f5sCBA6ZXp06dGD58OAcOHECj0SjdxGqre/fuRW5BP3nyJA0bNlSoRTVDdnY2anXhX0UajQa9Xq9Qi2oePz8/PD09iYyMNG1LT09nz549dO3a1azHlssxokTjx4/nu+++4/fff8fR0dF0bdDZ2Rk7OzuFW1c9OTo6Fplz4+DgQJ06dWQujpm9+uqrdOvWjXfffZennnqK6OholixZwpIlS5RuWrXWv39/3nnnHRo0aECrVq34559/mD9/Ps8995zSTatWMjMzOX36tOn9uXPnOHDgAK6urjRo0IBJkyYxd+5cmjZtip+fH2+//Tbe3t6mO2jMxiBECYBiX19//bXSTatRHnroIcPEiROVbkaN8McffxgCAgIMWq3W0KJFC8OSJUuUblK1l56ebpg4caKhQYMGBltbW0OjRo0Mb775piE3N1fpplUrf/31V7E/z0eNGmUwGAwGvV5vePvttw0eHh4GrVZr6N27t+HEiRNmb5esEyKEEEIIRcicECGEEEIoQkKIEEIIIRQhIUQIIYQQipAQIoQQQghFSAgRQgghhCIkhAghhBBCERJChBBCCKEICSFCCCGEUISEECFEjaFSqfjtt9+UboYQ4gYJIUIIixg9ejQqlarIKyQkROmmCSEUIg+wE0JYTEhICF9//XWhbVqtVqHWCCGUJiMhQgiL0Wq1eHp6Fnq5uLgAxkslixYtol+/ftjZ2dGoUSN++umnQvsfPnyYRx55BDs7O+rUqcOLL75IZmZmoTLLli2jVatWaLVavLy8mDBhQqHPk5OTGTx4MPb29jRt2pQ1a9aY96SFECWSECKEqDTefvttnnjiCQ4ePMjw4cMZNmwYx44dAyArK4vg4GBcXFz4+++/+b//+z82bdpUKGQsWrSI8ePH8+KLL3L48GHWrFlDkyZNCh1j1qxZPPXUUxw6dIhHH32U4cOHk5KSYtHzFELcYPbn9AohhMFgGDVqlEGj0RgcHBwKvd555x2DwWAwAIaXXnqp0D6BgYGGcePGGQwGg2HJkiUGFxcXQ2ZmpunztWvXGtRqtSE+Pt5gMBgM3t7ehjfffLPENgCGt956y/Q+MzPTABjWr19fYecphCg9mRMihLCYhx9+mEWLFhXa5urqavq6a9euhT7r2rUrBw4cAODYsWO0bdsWBwcH0+fdu3dHr9dz4sQJVCoVV65coXfv3ndtQ5s2bUxfOzg44OTkRGJiYnlPSQhxHySECCEsxsHBocjlkYpiZ2dXqnLW1taF3qtUKvR6vTmaJIS4B5kTIoSoNHbv3l3kfcuWLQFo2bIlBw8eJCsry/T5zp07UavVNG/eHEdHR3x9fYmMjLRom4UQ5ScjIUIIi8nNzSU+Pr7QNisrK9zc3AD4v//7Pzp16kSPHj349ttviY6O5quvvgJg+PDhzJgxg1GjRjFz5kySkpJ45ZVXePbZZ/Hw8ABg5syZvPTSS7i7u9OvXz8yMjLYuXMnr7zyimVPVAhRKhJChBAWEx4ejpeXV6FtzZs35/jx44DxzpUffviBl19+GS8vL77//nv8/f0BsLe3Z8OGDUycOJHOnTtjb2/PE088wfz58011jRo1ipycHD7++GMmT56Mm5sbTz75pOVOUAhRJiqDwWBQuhFCCKFSqfj1118ZNGiQ0k0RQliIzAkRQgghhCIkhAghhBBCETInRAhRKciVYSFqHhkJEUIIIYQiJIQIIYQQQhESQoQQQgihCAkhQgghhFCEhBAhhBBCKEJCiBBCCCEUISFECCGEEIqQECKEEEIIRfw/+YDO5QvTjVAAAAAASUVORK5CYII=\n"
           },
           "metadata": {}
         },
@@ -1413,7 +1622,7 @@
             "text/plain": [
               "<Figure size 600x400 with 1 Axes>"
             ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiEAAAGJCAYAAABcsOOZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaL5JREFUeJzt3Xd4k+X6wPFvku4JpbuUtqyyQVYFAQcbLYIogihDDx5RFOzxCMh2oR5FnKD+AAcgOBBRFKhVQGRUQUbZlLK6S6GTtmny/v5IW4ht6SDN23F/ritX0ydP3tx5aJubZ2oURVEQQgghhLAyrdoBCCGEEKJhkiRECCGEEKqQJEQIIYQQqpAkRAghhBCqkCRECCGEEKqQJEQIIYQQqpAkRAghhBCqkCRECCGEEKqQJEQIIYQQqpAkRAghhBCqkCRECFElH374IRqNhrCwMLVDEULUcRo5O0YIURW33XYbCQkJnD17llOnTtGyZUu1QxJC1FHSEyKEqLS4uDh27drF4sWL8fLyYvXq1WqHVKacnBy1QxBCVIIkIUKISlu9ejWNGzfm7rvv5v777y8zCbly5QrPPvsswcHB2Nvb07RpU8aPH09aWlpJnby8PBYsWEDr1q1xcHDAz8+P++67j9jYWAC2bduGRqNh27ZtZtc+e/YsGo2GTz/9tKRs4sSJuLi4EBsby7Bhw3B1dWXcuHEA/P777zzwwAM0a9YMe3t7AgMDefbZZ7l69WqpuI8fP87o0aPx8vLC0dGR0NBQZs+eDcBvv/2GRqPhu+++K/W8NWvWoNFo2L17d5XbU4iGzkbtAIQQdcfq1au57777sLOzY+zYsSxdupQ///yTHj16AJCdnU3fvn05duwYjz76KF27diUtLY2NGzdy8eJFPD09MRgM3HPPPURFRTFmzBimTZtGVlYWkZGRxMTE0KJFiyrHVVhYyODBg+nTpw9vvvkmTk5OAHz99dfk5uYyZcoUmjRpQnR0NO+99x4XL17k66+/Lnn+oUOH6Nu3L7a2tjz++OMEBwcTGxvLDz/8wCuvvMIdd9xBYGAgq1evZuTIkaXapEWLFvTq1esmWlaIBkoRQohK+OuvvxRAiYyMVBRFUYxGo9K0aVNl2rRpJXXmzZunAMr69etLPd9oNCqKoigrVqxQAGXx4sXl1vntt98UQPntt9/MHo+Li1MAZeXKlSVlEyZMUABl5syZpa6Xm5tbqmzRokWKRqNRzp07V1LWr18/xdXV1azs+ngURVFmzZql2NvbK1euXCkpS0lJUWxsbJT58+eXeh0hRMVkOEYIUSmrV6/Gx8eHO++8EwCNRsODDz7I2rVrMRgMAHz77bd07ty5VG9Bcf3iOp6enjz99NPl1qmOKVOmlCpzdHQsuZ+Tk0NaWhq9e/dGURT+/vtvAFJTU9mxYwePPvoozZo1Kzee8ePHk5+fzzfffFNStm7dOgoLC3n44YerHbcQDZkkIUKIChkMBtauXcudd95JXFwcp0+f5vTp04SFhZGcnExUVBQAsbGxdOjQ4YbXio2NJTQ0FBsby40G29jY0LRp01Ll58+fZ+LEiXh4eODi4oKXlxe33347ABkZGQCcOXMGoMK427RpQ48ePczmwaxevZpbb71VVggJUU0yJ0QIUaFff/2VxMRE1q5dy9q1a0s9vnr1agYNGmSx1yuvR6S4x+Wf7O3t0Wq1peoOHDiQ9PR0ZsyYQZs2bXB2diY+Pp6JEydiNBqrHNf48eOZNm0aFy9eJD8/nz179vD+++9X+TpCCBNJQoQQFVq9ejXe3t588MEHpR5bv3493333HcuWLaNFixbExMTc8FotWrRg79696PV6bG1ty6zTuHFjwLTS5nrnzp2rdMyHDx/m5MmTfPbZZ4wfP76kPDIy0qxe8+bNASqMG2DMmDFERETw5ZdfcvXqVWxtbXnwwQcrHZMQwpwMxwghbujq1ausX7+ee+65h/vvv7/UberUqWRlZbFx40ZGjRrFwYMHy1zKqhTtizhq1CjS0tLK7EEorhMUFIROp2PHjh1mj3/44YeVjlun05lds/j+O++8Y1bPy8uLfv36sWLFCs6fP19mPMU8PT0ZOnQoq1atYvXq1QwZMgRPT89KxySEMCc9IUKIG9q4cSNZWVkMHz68zMdvvfXWko3L1qxZwzfffMMDDzzAo48+Srdu3UhPT2fjxo0sW7aMzp07M378eD7//HMiIiKIjo6mb9++5OTk8Msvv/Dkk09y77334u7uzgMPPMB7772HRqOhRYsW/Pjjj6SkpFQ67jZt2tCiRQuee+454uPjcXNz49tvv+Xy5cul6r777rv06dOHrl278vjjjxMSEsLZs2fZtGkTBw4cMKs7fvx47r//fgBeeumlyjekEKI0NZfmCCFqv/DwcMXBwUHJyckpt87EiRMVW1tbJS0tTbl06ZIydepUJSAgQLGzs1OaNm2qTJgwQUlLSyupn5ubq8yePVsJCQlRbG1tFV9fX+X+++9XYmNjS+qkpqYqo0aNUpycnJTGjRsr//73v5WYmJgyl+g6OzuXGdfRo0eVAQMGKC4uLoqnp6cyefJk5eDBg6WuoSiKEhMTo4wcOVJp1KiR4uDgoISGhipz584tdc38/HylcePGiru7u3L16tVKtqIQoixydowQQlRBYWEh/v7+hIeHs3z5crXDEaJOkzkhQghRBRs2bCA1NdVssqsQonqkJ0QIISph7969HDp0iJdeeglPT0/279+vdkhC1HnSEyKEEJWwdOlSpkyZgre3N59//rna4QhRL0hPiBBCCCFUIT0hQgghhFCFJCFCCCGEUIVsVlYGo9FIQkICrq6uN3WqpxBCCNHQKIpCVlYW/v7+pc50+idJQsqQkJBAYGCg2mEIIYQQddaFCxfKPN36epKElMHV1RUwNaCbm5vK0ahPr9ezdetWBg0aVO6BY8LypN3VIe2uDml3ddREu2dmZhIYGFjyWXojkoSUoXgIxs3NTZIQTD+kTk5OuLm5yR8HK5J2V4e0uzqk3dVRk+1emekMMjFVCCGEEKqQJEQIIYQQqpAkRAghhBCqkDkh1aQoCoWFhRgMBrVDqXF6vR4bGxvy8vIs9n5tbW3R6XQWuZYQQoi6SZKQaigoKCAxMZHc3Fy1Q7EKRVHw9fXlwoULFts3RaPR0LRpU1xcXCxyPSGEEHWPJCFVZDQaiYuLQ6fT4e/vj52dXb3f0MxoNJKdnY2Li0uFG89UhqIopKamcvHiRVq1aiU9IkII0UBJElJFBQUFGI1GAgMDcXJyUjscqzAajRQUFODg4GCRJATAy8uLs2fPotfrJQkRQggVGIwKe+PS2ZemoUlcOr1aeqPTWvc/1ZKEVJOlPowbqvreeySEELXZ5phEFv5wlMSMPEDH56f+ws/dgfnh7RjSwc9qccgnqRBCCNGAbI5JZMqq/UUJyDVJGXlMWbWfzTGJVotFkhAhhBCigTAYFRb+cBSljMeKyxb+cBSDsawalidJiEoMRoXdsZf4/kA8u2MvWe0f3FKCg4NZsmSJ2mEIIYSohLTsfLadSGHW+kOlekCupwCJGXlEx6VbJS6ZE6IC87E4E2uMxd1xxx106dLFIsnDn3/+ibOz880HJYQQwmIURSElK5/DFzOIScggJj6TmPgMkjLLTzzKkpJVtfrVJUmIlRWPxf2z36N4LG7pw12tOinoeoqiYDAYsLGp+MfCy8vLChEJIYQoj6IoxF+5Skx8JkcSMjgcb0o60rLzS9XVaKC5pzO+bg78EXupwmt7uzrURMilSBJiAYqicFVf8U6iBqPC/I1Hyh2L0wALNh7ltpaelVom5Wirq/Qqk4kTJ7J9+3a2b9/OO++8A8DKlSuZNGkSP/30E3PmzOHw4cNs3bqVwMBAIiIi2LNnDzk5ObRt25bZs2czfPjwkusFBwczffp0pk+fDphWu3zyySds2rSJLVu2EBAQwFtvvWX2HCGEENWjKArn03OJic/kcHwGRxIyiInP4HKuvlRdrQZaebvSPsCNjgHudAhwp62fGy72NhiMCn1e/5WkjLwyP4s0gK+7Az1DPGr8PYEkIRZxVW+g3bwtN30dBUjKzKPjgq2Vqn/0xcE42VXun/Cdd97h5MmTdOjQgRdffBGAI0eOADBz5kzefPNNmjdvTuPGjblw4QLDhg3jlVdewd7ens8++4yxY8dy7NgxgoODy32NhQsX8sYbb/C///2P9957j3HjxnHu3Dk8PKzzwyyEEPWB0agQdymHmPiMolsmMQkZZOUVlqpro9XQ2se1KNlwo32AO2193XC0K3v/JZ1Ww/zwdkxZtR8NmCUixf+lnR/ezmr7hUgS0kC4u7tjZ2eHk5MTvr6+ABw/fhyAF198kYEDB5bU9fDwoHPnziXfv/jii3z77bf88MMPPP300+W+xsSJExk7diwAr776Ku+++y7R0dEMGTKkJt6SEEKozmBUiI5LJyUrD29XUw9CVT7ACw1GYlOLEo6i3o2jCZnkFJTuXbez0dLW15X2Ae508HenY4A7rX1dsLep2oaPQzr4sfThrqXmJvqqsE+IJCEW4Gir4+iLgyusFx2XzsSVf1ZY79NJPSrVFeZoa5mdRrt37272fXZ2NgsWLGDTpk0kJiZSWFjI1atXOX/+/A2v06lTp5L7zs7OuLm5kZKSYpEYhRCitqnqIoOCQiOnUrI4UjSkEpOQwbHETPL0xlJ1HWy1tPMzDacUJx2tfFyw1VlmUeuQDn4MbOfL7tMpbP19L4P6hsmOqXWVRqOp1LBI31Ze+Lk7VDgW17eVl1V/EP65yuW5554jMjKSN998k5YtW2Jvb8+oUaMoKCi44XVsbW3NvtdoNBiNpX+5hBCirqtokcE7Y7oQ7OlcMln0SEIGxxOzKDCU/pvoYm9DO383OvibhlQ6BrjT3Mulxj8HdFoNYSEeXDqmEFbFHhxLkSTEitQei7Ozs8NgqHgC7R9//MHEiRMZOXIkAJmZmRX2ggghRHXVhjNMqqIyG349s/ZAmc91c7ChQ9Fk0Q4B7nTwdyO4iTPaWvx+a5IkIVam5lhccHAwe/fu5ezZs7i4uJTbS9GqVSvWr19PeHg4Go2GOXPmoCh1azM1IUTdoOYZJgajQnZeIZl5ejLz9GTlFRbd9GZfM/9RlpyZd8MNv4q5OtjQJbBRyQqVDv7uBHo4ytlZ15EkRAXFY3E3M5mpOp577jkmTJhAu3btuHr1KitXriyz3uLFi3n00Ufp3bs3np6ePP/881y+fLlGYxNCNDw3s29SocFIdn5hUZJQ+QTi+nplTf60pJfv7cC9twTU6GvUdZKEqESn1dCrRROrvmbr1q3ZvXu3WdnEiRNL1QsODubXX38t+d5oNPLwww/j5uZWUnb27Fmz55TVU3LlypWbilcIUX9VZkgj4quDbDyYQHa+oVQikWvBBMLeRourgy1uDja4OtiY7jva4GpvW/K963WPXUzP5eWfjlV4XW8362z4VZdJEiKEEMKqFEXhm30XKhzSyC0w8NPhpBvWcbDVXpckXJdIlJNAuJVRZmdTtRUnBqPC8j/ias2GX3WZJCFCCCFqXFJGHjtPp7HzVCo7T18qc2vxstzXNYDeLTxLkgY3B/PkwlJLVqtC7UUG9YkkIUIIISwuO7+QPbGXTInH6TROp2SbPW6r06A3VDzh/YFugVYfuq6M2rThV10mSYgQQoibpjcYOXjhSlFvRxoHLlyh0HgtydBqoGPTRvRp2YQ+Lb3oHOhO/7e21+khDbUWGdQnkoQIIYSoMkVRiE3NKRpeSWPPmXSy883PNglq4kSflp70beVJr+aeuDuZb2hYH4Y01FhkUJ9IEiKEEKJSUrPy+aNoeOWP02mlJpY2drKld0tP+hTdAj2cbng9GdIQkoQIIYQoU25BIdFx6ew8ZUo8jidlmT1uZ6OlR3Bj+rT0om8rT9r5uVV558/acoaJUIckIUIIIQDT0tPD8RklQyz7z10pddZJe383U09HK096BHvgYIGDNGvDGSZCHaonIR988AH/+9//SEpKonPnzrz33nv07NmzzLp6vZ5Fixbx2WefER8fT2hoKK+//rrZUfELFixg4cKFZs8LDQ0tObZeCCHqo+ocKa8oCucu5ZZMJt0Vm0Zmnvm8joBGjiVJR+8WTWjiYl+Tb0M0MKomIevWrSMiIoJly5YRFhbGkiVLGDx4MCdOnMDb27tU/Tlz5rBq1So++eQT2rRpw5YtWxg5ciS7du3illtuKanXvn17fvnll5LvbWxUz7VKMxrg3C7ITgYXHwjqDdqb/x9FTWrevDnTp09n+vTpaocihLhOVY6Uv5xTwB+xpjkdv59K4+Llq2aPuzrY0LtFk6LEw4vgJk5y1omoMap+Oi9evJjJkyczadIkAJYtW8amTZtYsWIFM2fOLFX/iy++YPbs2QwbNgyAKVOm8Msvv/DWW2+xatWqkno2Njb4+vpa501Ux9GNsHkGZCZcK3PzhyGvQ7vh6sUlhKhzKnOkvIezfdF+HakcScjk+lMWbHUabmnWmL5FvR0dA9yxUWEDMNEwqZaEFBQUsG/fPmbNmlVSptVqGTBgQKnzTYrl5+fj4GC+F7+joyM7d+40Kzt16hT+/v44ODjQq1cvFi1aRLNmzcqNJT8/n/z8a7v3ZWZmAqbhH71eb1ZXr9ejKApGo7HcU2hv6NgPaL6eAChc/38LJTMRvhqP8sBn0Da86tetQdefC1P83m+W0WhEURT0ej06Xe3uAVJL8c/eP38GRc2qS+1uMCos2HikykfKt/Z24baWTejdwoMeQY1xtr/2UaAYDeiNNXuwW1nqUrvXJzXR7lW5lmpJSFpaGgaDAR8fH7NyHx+fcudvDB48mMWLF9OvXz9atGhBVFQU69evx2C49gsTFhbGp59+SmhoKImJiSxcuJC+ffsSExODq6trmdddtGhRqXkkAFu3bsXJyXyJWXEvS3Z2NgUFBaZCRYHCq6WeX4rRgNtPz/PPBARAg2Iq/fl5Mj27Vm5oxsYRKtlN+umnn/L6669z5MgRtNpr/8t56KGH8PDw4D//+Q+zZ8/mr7/+Ijc3l9atWzNv3jzuuOOOa+EbjeTl5ZUkaTejoKCAq1evsmPHDgoLCyt+QgMWGRmpdggNUl1o91MZGpIyK/5b4aRTaO+hEOqu0Npdwd3uCihXyD0dy/bTNR9nVdSFdq+PLNnuubm5la5bCydLlO+dd95h8uTJtGnTBo1GQ4sWLZg0aRIrVqwoqTN06NCS+506dSIsLIygoCC++uorHnvssTKvO2vWLCIiIkq+z8zMJDAwkEGDBpmdHAuQl5fHhQsXcHFxudYrU5CD9rW2N/3+NChospNotLRDpeobZ14EO+dK1X3kkUeYMWMG+/bto3///gCkp6cTFRXFjz/+CEB4eDivvfYa9vb2fPHFF4wdO5Zjx44RGBhIVlYWWq0WBweHUm1SHXl5eTg6OtKvX79SvVvCRK/XExkZycCBA7G1ta34CcIi6kq7X8nVs+eXU8DFCuu+PLIj4Z39az6om1BX2r2+qYl2r8p/VFVLQjw9PdHpdCQnJ5uVJycnlzufw8vLiw0bNpCXl8elS5fw9/dn5syZNG/evNzXadSoEa1bt+b06fLTfXt7e+ztS8/4trW1LfWPYjAY0Gg0aLXaaz0KWnXGT7VabaVfu0mTJgwdOpS1a9cycOBAANavX4+npyf9+/dHq9WaTe59+eWX2bBhAz/++CNPPvlkSXnxe7dE7BqNpsw2FuakjdRRG9s9KSOPrUeT2HIkiT1n0jEYKz57BcCvsUutey/lqY3t3hBYst2rch3VkhA7Ozu6detGVFQUI0aMAEzd/VFRUUydOvWGz3VwcCAgIAC9Xs+3337L6NGjy62bnZ1NbGwsjzzyiCXDN2frBC8kVFzv3C5YfX/F9cZ9Y1otU5nXrYJx48YxefJkPvzwQ+zt7Vm9ejVjxoxBq9WSnZ3NggUL2LRpE4mJiRQWFnL16lXOnz9fpdcQQljW2bQcNh8xJR5/n79i9liojwvxV/JKbZderC6cvyIaNlWHYyIiIpgwYQLdu3enZ8+eLFmyhJycnJLVMuPHjycgIIBFixYBsHfvXuLj4+nSpQvx8fEsWLAAo9HI888/X3LN5557jvDwcIKCgkhISGD+/PnodDrGjh1bc29Eo6ncsEiLu0yrYDITobwjm9z8TfVqYLlueHg4iqKwadMmevTowe+//87bb78NmNotMjKSN998k5YtW+Lo6Mj9999/bd6LEMIqFEXhWGIWm48ksfVIUqldSrs2a8SQDr4Mbu9LUBPnktUxUHfPXxENl6pJyIMPPkhqairz5s0jKSmJLl26sHnz5pLJqufPnzfr+s/Ly2POnDmcOXMGFxcXhg0bxhdffEGjRo1K6ly8eJGxY8dy6dIlvLy86NOnD3v27MHLy8vab680rc60DPer8VDekU1DXqux/UIcHBy47777WL16NadPnyY0NJSuXbsC8McffzBx4kRGjhwJmHqQzp49WyNxCCHMGY0K+89fZsuRJDYfSeJC+rWJ7jqthl7NmzC4gy+D2vng42Y+h0rOXxF1meoTU6dOnVru8Mu2bdvMvr/99ts5evToDa+3du1aS4VWM9oNh9Gfl7NPyGs1vk/IuHHjuOeeezhy5AgPP/xwSXmrVq1Yv3494eHhaDQa5s6da5GluEKIshUUGtlz5hJbjiSx9WgyqVnXtgmwt9HSr7UXQ9r70r+tN42c7G54LTlSXtRVqichDVK74dDmblV2TL3rrrvw8PDgxIkTPPTQQyXlixcv5tFHH6V37954enoyY8YMiyzFFUJcc7XAwPaTqWw5kkTUsWSzLdJd7W3o39abwe19uT3UCye7qv15liPlRV0kSYhatDoI6Wv9l9VqSUgoPYk2ODiYX3/91azsqaeeAijpETlz5oxFVsYI0ZBkXNXz6/FkNscksf1kKnn6az2Mni52DGzny5AOvvRq3gQ7G/n9Eg2LJCFCCGFhKVl5bD2SzJYjSeyOvUThdUtpmzZ2ZHB7U+LRtVljGTIRDZokIUIIYQHnL+WypWgp7b7zl83OZ2nt48KQ9r4Mau9Le383ORBOiCKShAghRBGDUWFvXDr70jQ0iUunV0vvcnsqFEXhZHI2m2NMK1qOJZrPoeoc2Igh7X0Z3N6H5l4u1ghfiDpHkhAhhMB0Gu21Za46Pj/1F37/WOZqNCocuHjF1OMRk8TZS9fOyNBpNfQM9mBIB18GtffBz91RpXciRN0hSUg1XX+yrKg6aT9RmxRv+PXPn8qkjDymrNrPtP6tSM8tYMuRJJIzry2ltbPR0q+VJ4Pa+zKgrQ8ezjdeSiuEMCdJSBUV74mfm5uLo6P8T6e6indi1elqflmyEDdiMCos/OFomXsYF5ctiTpVUuZib8OdbbwZUrSU1sVe/owKUV3y21NFOp2ORo0akZKSAoCTk1O9n2RmNBopKCggLy/PIkt0jUYjqampODk5YWMjP4JCXdFx6WY7jZbnztZejO8dTO+WTbC3keRZCEuQT4BqKD7ltzgRqe8UReHq1as4OjpaLOHSarU0a9as3idwovZLyaw4AQEY0TWAO9t413A0QjQskoRUg0ajwc/PD29vb/R6vdrh1Di9Xs+OHTvo16+fxY56trOzk43PhKoMRoUtR5J497qhlhvxdnWouJIQokokCbkJOp2uQcxp0Ol0FBYW4uDgYLEkRAi15OkNrN8fzye/nyEuLafC+hpMh8H1DPGo+eCEaGAkCRFCNAiZeXpW7TnHyj/OlhwW5+5oy4ReQQR6OPH8N4eAMs+2Zn54O9nZVIgaIEmIEKJeS87MY8XOOFbvPU92vunAOH93Bx7r25wxPQJxLlrd4upgc90+ISa+/9gnRAhhWZKECCHqpdjUbD7efobv/o6nwGA6NK61jwv/7teC4V38sdWZz0ka0sGPge182X06ha2/72VQ37Ab7pgqhLh5koQIIeqVv89fZtn2WLYeTS45v6VHcGOeuL0Fd4Z6o71BUqHTaggL8eDSMYWwEA9JQISoYZKECCHqPEVR2HYylWXbYtkbl15SPqCtD1PuaE63IJlUKkRtJEmIEKLO0huM/HgogY+2n+F4UhYAtjoNI7oE8O/bm9PS21XlCIUQNyJJiBCizsktKGTdnxf4v9/jiL9yFQBnOx0PhTXj0T4hcnicEHWEJCFCiDojPaeAz3ad5fPdZ7mca9oo0NPFjkm3hfBwWBDuTrKPjRB1iSQhQoha70J6Lst3xrH2z/Pk6U0rXYKaODG5b3Pu79YUB9v6v2mgEPWRJCFCiFrrWGImy7bH8uOhRAxG01KXDgFuPHF7C4Z28JPVK0LUcZKECCFqFUVR2HMmnWXbY9l+MrWkvG8rT564vQW9WzSRgw+FqCckCRFC1ApGo8LWo0ks3X6GgxeuAKDVwLCOfjxxews6BLirG6AQwuIkCRFCqCq/0MB3++P5eMcZzhQdKGdvo+WB7k2Z3Lc5QU2cVY5QCFFTJAkRQqgiM0/Pmr3nWbEzjpSiA+XcHGwY3yuYibcF4+lir3KEQoiaJkmIEMKiDEaF6Lh0UrLy8HZ1oOc/tj9PycxjxR9nWb3nHFlFB8r5ujnwr74hjOnZDBd7+bMkREMhv+1CCIvZHJNY6iRav6KTaFv7uPLJ72f4dt+1A+Vaervw737NubdLAHY22vIuK4SopyQJEUJYxOaYRKas2o/yj/LEjDyeWLXfrKxbkOlAuf5tbnygnBCifpMkRAhx0wxGhYU/HC2VgPxT/zZeTLmjJd2D5UA5IQRI/6cQ4qZFx6WbDcGU5199W0gCIkRtYTSgObeTgPTdaM7tBKPB6iFIT4gQ4qalZFWcgFSlnhB1htEA53ZBdjK4+EBQb9DWgWMEjm6EzTOwyUygO8C5peDmD0Neh3bDrRaG6j0hH3zwAcHBwTg4OBAWFkZ0dHS5dfV6PS+++CItWrTAwcGBzp07s3nz5pu6phDi5ilKRQMxJt6uDjUciRBWdHQjLOkAn90D3z5m+rqkg6m8Nju6Eb4aD5kJ5uWZiaZyK8avahKybt06IiIimD9/Pvv376dz584MHjyYlJSUMuvPmTOHjz76iPfee4+jR4/yxBNPMHLkSP7+++9qX1MIUX2KovDFnnPM/PbwDetpMK2S6RkiQzGinqhFH+RVYjTA5hlQ5gyuorLNM602NKPqcMzixYuZPHkykyZNAmDZsmVs2rSJFStWMHPmzFL1v/jiC2bPns2wYcMAmDJlCr/88gtvvfUWq1atqtY1hRDVk3DlKjO+PcTvp9IAaO3jwsnkbDSY/3krXvsyP7ydHDgn6ofKfJD/+CzYuYBGA4oBjMair4brvhr/8X1Vy403uHY55dkppROnf8afGW8aYgrpWwONZ061JKSgoIB9+/Yxa9askjKtVsuAAQPYvXt3mc/Jz8/HwcG8O9fR0ZGdO3dW+5rF183Pzy/5PjMzEzAN/+j1+qq/uXqmuA2kLayrtra7oih8dyCBlzadIDu/EHsbLf8d1IpHwpoReSyFl386TlLmtd8nX3d7Zg9tQ/9Qz1r3XspSW9u9vqvV7a4okJOKJj0WLp1GE7cd3Q0/yIHcNFg10jrx1YDCjHiUav5bVOXfULUkJC0tDYPBgI+Pj1m5j48Px48fL/M5gwcPZvHixfTr148WLVoQFRXF+vXrMRgM1b4mwKJFi1i4cGGp8q1bt+Lk5FTVt1ZvRUZGqh1Cg1Sb2j2zAL46o+XwZdNIbpCLwriWBXhdPsLmzUcAmNEOYjM1ZOrBzRZauOVgOLePn86pGXnV1aZ2b0jUbHedIR+X/ESc85NwyUvCJf/azdaQW+Xr5do2Rq9zQdFoAC2KpuhGWV81KGihpI6m7LpmZaY65tcu+3nFdZzyk2mZuqXC2PfEnOXSuZ+q/J4BcnMr31Z1anXMO++8w+TJk2nTpg0ajYYWLVowadIkVqxYcVPXnTVrFhERESXfZ2ZmEhgYyKBBg3Bzc7vZsOs8vV5PZGQkAwcOxNbWVu1wGoza1u4/xySx+IdjXM7VY6vTMO2uljx2WxA2OtXnt1tUbWv3SjMa0FzYXbJKQwnsVTdWaRSxWrsbC+HKeTSXTpt6NtJjS+5rshLLfZqCBho1Q/FogWLrhO7EjxW+lN2DK7EN6mPJ6G+e0YDy/i2QlYimjOEkBQ24+RP2wPRq//wUjyZUhmpJiKenJzqdjuTkZLPy5ORkfH19y3yOl5cXGzZsIC8vj0uXLuHv78/MmTNp3rx5ta8JYG9vj7196cOybG1t69YfoRom7aEOtdv9Sm4B874/wsaDpu7ntn5uLB7dmbZ+9TtBV7vdq6RouaXZWL8Kyy2rzWhAc24vAem7sUtww6Z5v5tLoBTFNPfh0umi2ym4ZBpKIT0OjDcYLnBqAk1aQZOW0KQFeJruaxqHgK2DaY6T0WBaBZOZSNnzQkwf5Df9PmqELQx93TR5towZXBqAIa9ha1/9lWxV+b1RLQmxs7OjW7duREVFMWLECACMRiNRUVFMnTr1hs91cHAgICAAvV7Pt99+y+jRo2/6mkKI0n49nszMbw+TkpWPTqvhyTta8PRdrervOS9mmze5Qa38EPmH4lUa//wwLF6lMfrz2p2I3Mx+FfnZkB4LacVJxqmipCMW8m/wv3EbR1OC0aTltZtnK/BoDk6VWMGl1ZniK+eDHIAhr9Xen512w00/F2Umrq9Z9edF1eGYiIgIJkyYQPfu3enZsydLliwhJyenZGXL+PHjCQgIYNGiRQDs3buX+Ph4unTpQnx8PAsWLMBoNPL8889X+ppCiIpl5el5+cdjrPvrAgAtvJx5a3QXugQ2UjewmlRLNm+qkgpXaWhMyy3b3F07PxArk0CFDoMr50zJRdqp63o3TsMNhk/QaKFRM/NEozjZcPUH7U0m0rXog7xa2g2HNndTeGYHB37fQpe+g1XpuVE1CXnwwQdJTU1l3rx5JCUl0aVLFzZv3lwysfT8+fNor/tBycvLY86cOZw5cwYXFxeGDRvGF198QaNGjSp9TSHEje2KTeO/Xx8i/spVNBp47LYQnhscioNtLfwQsxS1ehMUBQx6KMwz3fRXy/iaD4VXQZ9X+uul05VbbrlqlOnDUaM1fchodP/4Wla5tox6NyjXaKpwbZ3pvW+KKN3mxXEDfDPJVE+5wZ4VTp5FQybFPRtFQykeIWBTepjdooo+yOvkjqkAWh1KUB/ij2TSOaiPKnFrlMpuddiAZGZm4u7uTkZGhkxMxTRh7KeffmLYsGF1Z4y8HrB2u18tMPD65uN8uussAIEejrx5f2fCmjep8ddWVcn4/g0+zJ29YORHRQlDUWJQZsJQnExcnzBUkEwoRuu917rKxrHUHA1TstEcHBurHV2dVhN/Z6ryGVqnVscIIWrGvnOXee7rg8Sl5QAwLqwZLwxri7N9Pf4TUZALaSfh2A8V9CYAOamw6r6aj8nGwXSzdbzuvoPpQ/ifX23sIfcSHN1Q8XW7TTINTVRm0yyzDbGqsAlWVa+Rnw1X0yuOfegb0GPyzQ+fiFqpHv+FEUJUJL/QwJJfTvHR9liMCvi6OfD6/Z24vbWX2qFZztXLkHoS0k5AatEt7QRcOV+167j6g6tP6UTB7Kv9dYnCjR7759eim6aKO8oaDbAkusJVGtz9Vu0bIoj73XTWSkW820kCUo9JEiJEAxUTn8F/vjrIieQsAO67JYD54e1xd6qDQ26KYhqTvz7JSD1h6unITi7/eY4e4OoHKUcqfo37PrbKNtZVUpdXaQT1NiVIFSVQQb2tHZmwIklChGhgCg1GPtwWy7tRpyg0KjRxtuOVkR0Z0qH8vXRqDaMRMs6bejZSjxclGydNCUd+RvnPcwsAz9bgFVr0tY3pvrNnpfd8qLUfhnV1lUZdTqCExUgSIkQDcjoli/98dZCDF00f2EPa+/LKyA40cbHgKgKj4eZXCxj0kH6mjJ6NU6bJnGXRaKFxMHiGgldRouEZaprI6HCDyXH14cOwrq7SqKsJlLAYSUKEaAAMRoWVf8TxxpYTFBQacXOw4cV7O3BvF380VZ2HcCNV3bmzINe0wZRZsnHStAGVsbDs19DZFe33UNyj0dqUbDRpaZpfUR314cNQq6t9w0WVUUv2qxDqkCREiHru3KUc/vv1IaLPmlYi3N7ai9dHdcLXvfrbMpepor02+s81LXUtnquRehyuXChdv5it87UEw6vo5hlq6u3Q1cCfLvkwVE8t2K9CqEOSECHqKUVRWL33PK/+dIzcAgPOdjrm3NOOMT0CLdv7AZXYuROIerHs5zp6/GOuRlHi4d606qtFbpZ8GAphVZKECFEPJWZc5flvDvH7qTQAwkI8ePOBzgR6OFnmBRQFMi5CcgwkxUDsrxXvtQHg1xma9bo2SdSrjWlyqBCiQZIkRIh6RFEU1u+PZ8EPR8jKK8TeRsuMIW2Y2DsYrbaavQr6PNPQSXHCkXTYdD/vStWv1fsZ6Hh/9eIQQtQ7koQIUU+kZuUz+7vDbD1q2hejS2Aj3hrdmRZeLpW/SHbKtSQjKcb0NfVE2Wd3aG1Mwya+HUzzN/atqPj6LnKGkxDiGklChKgHfjqcyJwNMaTnFGCr0zB9QGv+3a85Nrpydpo0FJoOP0s6DMmHryUc5W3s5dgYfDqAb8eirx1MQynFB4QZDXBqc93da0MIoQpJQoSojYwGNOd2EpC+G805NyhnlcaV3ALmbzzC9wdM8zHa+LqyeHQX2vlfty/G1SuQfMQ84Ug9bjpYrRQNeDQ3JRu+HcCn6KtbwI0nidaHvTaEEFYnSYgQtU3RXhs2mQl0Bzi3tMy9Nn47nsKMbw+RkpWPVgNP3t6cZ7raYZe2DU4Uzd1IijHtMFoWW2fwaW+ecPi0Azvn6sVdH/baEEJYlSQhQtQmFe21MfpzspoP5Y0f/ubw/t30154jzDWBAY1Tcdl/AvZklX1d98BrwyjFQyqNQyx/MFhd3blTCKEKSUKEqC0qsdeG4dvJpBs8WKgkorUvqqcHUoqq6ezBu821YZTixMOxsRXeQJG6unOnEMLqJAkRorY4t6vCvTZ0hjyCSAANFDg0wS6gs/mEUc9WoKuDp+AKIRokSUKEqC0y4itVbZvXOHqMmY1zk4AaDkgIIWqWJCFCqC3nEuxbgbLrAyqznVjfoWPQSQIihKgHJAkRQi0px2DPUji0Dgrz0AAGRYMWpczVsEYFkmjCOUMbelk9WCGEsDxJQoSwJqMRTv8Cez6EM79dK/frwj7/sazYfZH3bN9DUeD6XdaNRXNQF+ofYViO3roxCyFEDZEkRAhrKMiBA2tg7zLTTqUAGi20uQdufRKa3UrBmXQ2/bGHQr2O+baf4096ydOTaMJC/SNsMfZkoquDSm9CCCEsS5IQIWrSlQvw5yew71PIyzCV2btB1/HQ83FoHFRStWeIBz5u9mzJ7Elkfnd6ao/jzRVSaES0sQ0KWvzcHegZ4qHOexFCCAuTJEQIS1MUuPinacjl6MZrh795NIewKdBlLNi7lnqaTqshsLETyZn5GNGyx9iu5LHikZn54e3QVfc0XCGEqGUkCRHCUgx6OPq9KfmI33etPKSfacil1eAb7lD6/YF4/jp3Ga0GGjvZcSmnoOQxX3cH5oe3Y0gHv5p8B0IIYVWShAhxs3LTTcMt0Z9AVtFmYzp76PSAqefDt0OFl7h4OZc538UAMK1/a6be1ZLdp1PY+vteBvUNo1dLb+kBEULUO5KECFFdqSdMS2wProXCq6YyZ2/oORm6TQIXr0pdxmBUiPjqIFn5hXRt1oin7myBTqshLMSDS8cUwkI8JAERQtRLkoQIURWKAqejTEMusVHXyn07mYZcOtwHNvZVuuRHO2KJjkvH2U7H2w92wUZn4UPlhBCilpIkRIjKKMiFQ2thzzJIO1FUqDGdGHvrk6aTYsvaYawCMfEZLN56EoD5w9sT1MTZgkELIUTtJkmIEDeSEW9aYvvXSsi7Yiqzcy1aYjsZPEKqfemrBQamrf2bQqPC0A6+PNCtqWViFkKIOkKSECHKcvEv05DLkQ3Xltg2DoawJ6DLOHBwu+mXePWnY8Sm5uDtas+rIzuiqUZPihBC1GWShAhRzFAIx743TTa9+Oe18uC+cOsUaD0EtDqLvNRvx1P4Ys85AN4a3ZnGznYWua4QQtQlqs+A++CDDwgODsbBwYGwsDCio6NvWH/JkiWEhobi6OhIYGAgzz77LHl5eSWPL1iwAI1GY3Zr06ZNTb8NUZddvQw7l8A7neGbR00JiM7O1OPx799h4o+muR8WSkDSsvP57zcHAXj0thD6tqrcKhohhKhvVO0JWbduHRERESxbtoywsDCWLFnC4MGDOXHiBN7e3qXqr1mzhpkzZ7JixQp69+7NyZMnmThxIhqNhsWLF5fUa9++Pb/88kvJ9zY20uHTIBkNcG4XZCeDi49p8uj1iUTqSdNZLge/BH2uqczZC7o/Bj0eA5fSP4M3S1EUZn57iLTsAkJ9XHl+SKjFX0MIIeoKVT+dFy9ezOTJk5k0aRIAy5YtY9OmTaxYsYKZM2eWqr9r1y5uu+02HnroIQCCg4MZO3Yse/fuNatnY2ODr69vzb8BUXsd3QibZ0BmwrUyN38Y8pppy/TdH8LpyGuP+XQ0Dbl0GAW2NXdA3Jro8/xyLAU7nZYlY7rgYGuZ3hUhhKiLVEtCCgoK2LdvH7NmzSop02q1DBgwgN27d5f5nN69e7Nq1Sqio6Pp2bMnZ86c4aeffuKRRx4xq3fq1Cn8/f1xcHCgV69eLFq0iGbNmpUbS35+Pvn5+SXfZ2ZmAqDX69Hr5dj04jaoK22hOf4jum8nAQrXT/VUMhPgq/ElZQoalNZDMPb8N0qz264tsa2h93kmNYeXfjwKwH8GtqSlp+MN27SutXt9Ie2uDml3ddREu1flWhpFURSLvXIVJCQkEBAQwK5du+jVq1dJ+fPPP8/27dtL9W4Ue/fdd3nuuedQFIXCwkKeeOIJli5dWvL4zz//THZ2NqGhoSQmJrJw4ULi4+OJiYnB1bX0oWFgmkeycOHCUuVr1qzBycnpJt+psCrFyKAjETjo0ylvrYkCnPEcyBnvQeTa+1glLIMR3o7RcSFHQ2t3I1PaGpFNUIUQ9VFubi4PPfQQGRkZuLndeCVhnZossW3bNl599VU+/PBDwsLCOH36NNOmTeOll15i7ty5AAwdOrSkfqdOnQgLCyMoKIivvvqKxx57rMzrzpo1i4iIiJLvMzMzCQwMZNCgQRU2YEOg1+uJjIxk4MCB2Nraqh3ODWnO7cTmQPqN6wBBQ56iWVAf6wQFLP7lFBdy4nB3tOH/JvfGz73iIZ+61O71ibS7OqTd1VET7V48mlAZVU5CgoODefTRR5k4ceINhzgq4unpiU6nIzk52aw8OTm53Pkcc+fO5ZFHHuFf//oXAB07diQnJ4fHH3+c2bNnoy3jhNJGjRrRunVrTp8+XW4s9vb22NuX3mrb1tZWfhmuUyfa4+qlSlWzuXoJrPRe/jybzkc74gB4dWQnmnmW3SNXnjrR7vWQtLs6pN3VYcl2r8p1qrxEd/r06axfv57mzZszcOBA1q5dazaforLs7Ozo1q0bUVHXzt8wGo1ERUWZDc9cLzc3t1SiodOZJvaVN6qUnZ1NbGwsfn5yBHqD4FLJ4ZXK1rtJmXl6nl13AKMCo7o25e5O8nMohBDFqpWEHDhwgOjoaNq2bcvTTz+Nn58fU6dOZf/+/VW6VkREBJ988gmfffYZx44dY8qUKeTk5JSslhk/frzZxNXw8HCWLl3K2rVriYuLIzIykrlz5xIeHl6SjDz33HNs376ds2fPsmvXLkaOHIlOp2Ps2LFVfauiLgrqXUGCoQG3AFM9K1iw8QgXL18l0MORBcPbWeU1hRCirqj2nJCuXbvStWtX3nrrLT788ENmzJjB0qVL6dixI8888wyTJk2qcBvqBx98kNTUVObNm0dSUhJdunRh8+bN+PiYPkTOnz9v1vMxZ84cNBoNc+bMIT4+Hi8vL8LDw3nllVdK6ly8eJGxY8dy6dIlvLy86NOnD3v27MHLSzaEahg04NTEtDdIWY+BaZmuhTYeu5EfDyWwfn88Wg28PboLrg7SxSyEENerdhKi1+v57rvvWLlyJZGRkdx666089thjXLx4kRdeeIFffvmFNWvWVHidqVOnMnXq1DIf27Ztm3mwNjbMnz+f+fPnl3u9tWvXVul9iHom+iNIOQpaO3BqBNkp1x4r3iek3fAaDyMx4yqzv4sB4Kk7W9I92KPGX1MIIeqaKich+/fvZ+XKlXz55ZdotVrGjx/P22+/bbY1+siRI+nRo4dFAxWiQinHIbIoQR26CLpNuvGOqTXEaFT4z1cHybiqp3NTd57p36rGX1MIIeqiKichPXr0YODAgSxdupQRI0aUOQs2JCSEMWPGWCRAISqlsADWTwZDPrQcYNp6XaOBkL5WD2X5zjh2xV7C0VbH2w92wVan+hFNQghRK1U5CTlz5gxBQUE3rOPs7MzKlSurHZQQVbb9dUg6BI6NYfj713Y/tbKjCZn8b8sJAObe047mXi6qxCGEEHVBlf+LlpKSUuZupnv37uWvv/6ySFBCVMn5vbCz6ADDe5aAmzrLYPP0Bqav+5sCg5EBbX0Y2zNQlTiEEKKuqHIS8tRTT3HhwoVS5fHx8Tz11FMWCUqISsvPhu8eB8UIncZA+xGqhfL65uOcTM7G08We10d1rHB1mBBCNHRVTkKOHj1K165dS5XfcsstHD161CJBCVFpW2fD5bPg1hSGvaFaGDtOprLyj7MA/O+BTjRxKb0DrxBCCHNVTkLs7e1LbbUOkJiYiI1NnTqKRtR1JzbDvk9N90cuBQd3VcJIzyngua8PAjC+VxB3hnqrEocQQtQ1VU5CBg0axKxZs8jIyCgpu3LlCi+88AIDBw60aHBClCsnDTYW7S/TayqE9FMlDEVReGH9YVKy8mnh5cysoW1ViUMIIeqiKnddvPnmm/Tr14+goCBuueUWAA4cOICPjw9ffPGFxQMUohRFgR+mQU4qeLWFu+aqFsrX+y6y+UgStjoN74y5BUe7mt+HRAgh6osqJyEBAQEcOnSI1atXc/DgQRwdHZk0aRJjx46Vkw+FdRxYA8d/BK0t3PcR2DqoEsa5Szks3HgEgIiBoXQIUGc4SAgh6qpqTeJwdnbm8ccft3QsQlTs8jn4eYbp/p0vgF9nVcIoNBiZvu4AOQUGwkI8eLxfc1XiEEKIuqzaM0mPHj3K+fPnKSgoMCsfPrzmz+UQDZTRAN89AQVZEHgr3DZNtVDe/+00f5+/gquDDYsf7IJOK8txhRCiqqq1Y+rIkSM5fPgwGo0GRVEASvZEMBgMlo1QiGK734fzu8DOBUYus8o5MGXZf/4y7/16GoCXR3QgoJGjKnEIIURdV+XVMdOmTSMkJISUlBScnJw4cuQIO3bsoHv37qVOvRXCYpJi4NeXTfeHLAKPEFXCyM4v5Nl1BzAYFe7t4s+9XQJUiUMIIeqDKveE7N69m19//RVPT0+0Wi1arZY+ffqwaNEinnnmGf7++++aiFM0ZIX5sP5xMBRA66FwyyOqhfLSD0c5dymXgEaOvHhvB9XiEEKI+qDKPSEGgwFXV1cAPD09SUhIACAoKIgTJ05YNjohwNQDknIEnDxh+LuqHU63OSaJdX9dQKOBt0Z3xt1RVoMJIcTNqHJPSIcOHTh48CAhISGEhYXxxhtvYGdnx8cff0zz5rJCQFjY2Z2w6z3T/eHvgos6u5EmZ+Yxa/0hAP7drwW3Nm+iShxCCFGfVDkJmTNnDjk5OQC8+OKL3HPPPfTt25cmTZqwbt06iwcoGrC8TPhuCqDALQ9Dm7tVCcNoVHju64NcztXT3t+NiIGtVYlDCCHqmyonIYMHDy6537JlS44fP056ejqNGzeWU0OFZW2eCRnnoVEQDHlNtTA+232W30+lYW+j5Z0xXbCzqfIophBCiDJU6a+pXq/HxsaGmJgYs3IPDw9JQIRlHfsBDqwGNDDyI7B3VSWMk8lZLPr5OACz725LS2914hBCiPqoSkmIra0tzZo1k71ARM3KSjadDQOmDcmCeqkSRn6hgWlrD1BQaOSOUC8euTVIlTiEEKK+qnK/8uzZs3nhhRdIT0+viXhEQ6cosPFpyL0EPh1NW7Or5K2tJzmWmImHsx1v3N9JevuEEMLCqjwn5P333+f06dP4+/sTFBSEs7Oz2eP79++3WHCiAdr3KZzaAjo7uO9jsLFXJYxdp9P45PczALw+qhPeruockieEEPVZlZOQESNG1EAYQgCXYmHLbNP9/vPAp50qYWTk6vnP1wdRFBjbsxkD2/moEocQQtR3VU5C5s+fXxNxiIbOUGg6nE6fA8F94danVAlDURRe2HCYxIw8QjydmXtPW1XiEEKIhkDWGora4Y8lcDEa7N1gxIegVedHc8OBeDYdSkSn1bDkwS442VX7oGkhhBAVqPJfWK1We8MJerJyRlRZwgHYtsh0f+gb0KiZKmFcSM9l3oYjAEzv34rOgY1UiUMIIRqKKich3333ndn3er2ev//+m88++4yFCxdaLDDRQOivmg6nMxZC2+HQeYwqYRiMChFfHSArv5DuQY158s6WqsQhhBANSZWTkHvvvbdU2f3330/79u1Zt24djz32mEUCEw1E1IuQdgJcfOCeJaodTrdseyx/nr2Mi70Nbz/YBZ1WluMKIURNs9jA+6233kpUVJSlLicagjPbYM+Hpvv3fgDO6hwKd+jiFd6OPAnAwuHtCfRwUiUOIYRoaCyShFy9epV3332XgIAAS1xONARXr8CGJ033uz8KrQaqEkZuQSHT1x6g0Khwd0c/7usqP8NCCGEtVR6O+edBdYqikJWVhZOTE6tWrbJocKIe++m/kBkPHs1h0MuqhfHKpmOcScvB182BV0Z2kF1RhRDCiqrcE/L222+b3d59911+/PFHzp07x/Dhw6scwAcffEBwcDAODg6EhYURHR19w/pLliwhNDQUR0dHAgMDefbZZ8nLy7upawori/kWDn8FGi2M/BjsnCt+Tg2IOpbM6r3nAXhrdGcaOdmpEocQQjRUVe4JmThxosVefN26dURERLBs2TLCwsJYsmQJgwcP5sSJE3h7e5eqv2bNGmbOnMmKFSvo3bs3J0+eZOLEiWg0GhYvXlytawory0yAHyNM9/s+B4E9VAkjNSuf5785BMC/+oRwW0tPVeIQQoiGrMo9IStXruTrr78uVf7111/z2WefVelaixcvZvLkyUyaNIl27dqxbNkynJycWLFiRZn1d+3axW233cZDDz1EcHAwgwYNYuzYsWY9HVW9prAiRYHvn4K8K+DXBW5/XqUwFGZ8e4hLOQW08XXlv0NCVYlDCCEauir3hCxatIiPPvqoVLm3tzePP/44EyZMqNR1CgoK2LdvH7NmzSop02q1DBgwgN27d5f5nN69e7Nq1Sqio6Pp2bMnZ86c4aeffuKRRx6p9jUB8vPzyc/PL/k+MzMTMO2BotfrK/V+6rPiNrjZttD+tRxd7K8oNg4UDl8KRsBo/fZdHX2BX4+nYGej5c1RHdAqRvR6o9XjqIil2l1UjbS7OqTd1VET7V6Va1U5CTl//jwhISGlyoOCgjh//nylr5OWlobBYMDHx/xwMB8fH44fP17mcx566CHS0tLo06cPiqJQWFjIE088wQsvvFDta4IpsSpro7WtW7fi5CTLNYtFRkZW+7kueYncfnwuAId97ycu+hRwykKRVV7yVfjfIR2g4e6memL3/06s1aOomptpd1F90u7qkHZXhyXbPTc3t9J1q5yEeHt7c+jQIYKDg83KDx48SJMmNbvPw7Zt23j11Vf58MMPCQsL4/Tp00ybNo2XXnqJuXPnVvu6s2bNIiIiouT7zMxMAgMDGTRoEG5ubpYIvU7T6/VERkYycOBAbG1tq34Bgx7dZ8PQKgUYQ+6g7djFtNVY/2yYgkIjoz/Zi96YxW0tmvDa+K5oa/GmZDfd7qJapN3VIe2ujppo9+LRhMqochIyduxYnnnmGVxdXenXrx8A27dvZ9q0aYwZU/kttz09PdHpdCQnJ5uVJycn4+vrW+Zz5s6dyyOPPMK//vUvADp27EhOTg6PP/44s2fPrtY1Aezt7bG3ty9VbmtrK78M16l2e+x8ExL/Bgd3tCOXorUr3dbW8HbUcY4kZNHIyZbFD3bB3r5urIaRn0N1SLurQ9pdHZZs96pcp8r/HX3ppZcICwujf//+ODo64ujoyKBBg7jrrrt49dVXK30dOzs7unXrZrbLqtFoJCoqil69epX5nNzcXLT/OF1Vp9MBpsmG1bmmqGEX98GO/5nu370Y3Pyt9tIGo8Lu2Et8fyCelX/E8eE208DLa/d1xMfNwWpxCCGEKFuVe0Ls7OxYt24dL7/8MgcOHMDR0ZGOHTsSFBRU5RePiIhgwoQJdO/enZ49e7JkyRJycnKYNGkSAOPHjycgIIBFi0wnrIaHh7N48WJuueWWkuGYuXPnEh4eXpKMVHRNYUUFObB+MigG6HA/dLzfai+9OSaRhT8cJTHDfA+ZXs2bMKSDn9XiEEIIUb4qJyHFWrVqRatWrW7qxR988EFSU1OZN28eSUlJdOnShc2bN5dMLD1//rxZz8ecOXPQaDTMmTOH+Ph4vLy8CA8P55VXXqn0NYUVRc6D9Fhw9Ye737Tay26OSWTKqv0oZTy258wlNsckSiIihBC1QJWTkFGjRtGzZ09mzJhhVv7GG2/w559/lrmHyI1MnTqVqVOnlvnYtm3bzL63sbFh/vz5zJ8/v9rXFFZy6hf48/9M90d8CI6NrfKyBqPCwh+OlpmAFFv4w1EGtvOVk3KFEEJlVZ4TsmPHDoYNG1aqfOjQoezYscMiQYk6LjfdtCkZQNgT0OJOq710dFx6qSGY6ylAYkYe0XHpVotJCCFE2aqchGRnZ2NnV3pVga2tbZWW5Yh6SlHgx+mQnQSerWHAAqu+fEpW+QlIdeoJIYSoOVVOQjp27Mi6detKla9du5Z27dpZJChRhx36Co5+D1obuO9jsHW06st7u1Zu1Utl6wkhhKg5VZ4TMnfuXO677z5iY2O56667AIiKimLNmjV88803Fg9Q1CFXLsBP/zXdv30m+N9i9RCc7HRooNw5IRrA192BniEeVoxKCCFEWaqchISHh7NhwwZeffVVvvnmGxwdHencuTO//vorHh7yh73BMhphwxTIz4CmPaDPs1YP4XhSJhNXRpckIP9MRoqnoc4PbyeTUoUQohao1t7Zd999N3/88Qc5OTmcOXOG0aNH89xzz9G5c2dLxyfqir1L4ezvYOsEIz8CXbVXf1fLqeQsxn2yl8u5ejoHNmLx6M74upsPufi6O7D04a6yPFcIIWqJan9S7Nixg+XLl/Ptt9/i7+/PfffdxwcffGDJ2ERdkXIMfik6AHDwK9CkhVVf/nRKNmM/2culnAI6BLjx+aM9cXe05d4uAUTHpZOSlYe3q2kIRnpAhBCi9qhSEpKUlMSnn37K8uXLyczMZPTo0eTn57NhwwaZlNpQFRaYdkU15EOrQdDNujvTxqXl8NAne0jLzqetnxurHgvD3dF0boFOq6FXi5o9VFEIIUT1VXo4Jjw8nNDQUA4dOsSSJUtISEjgvffeq8nYRF2wbREkHQZHDxj+Pmis19Nw/lIuD32yh5SsfEJ9XFn9rzAaOdWNQ+mEEEJUoSfk559/5plnnmHKlCk3vV27qCfO74E/lpjuh78DrtbbGv/i5VzGfrKHxIw8Wnq7sHpyGB7OkoAIIURdUumekJ07d5KVlUW3bt0ICwvj/fffJy0trSZjE7VZfhZ8929QjND5IWg33GovnZhxlbGf7CH+ylWaezqz5l9heLrYW+31hRBCWEalk5Bbb72VTz75hMTERP7973+zdu1a/P39MRqNREZGkpWVVZNxitpmywtw+Sy4B8LQ16z2ssmZeYz9eA8X0q8S1MSJNZNvxdtNNh4TQoi6qMpLdJ2dnXn00UfZuXMnhw8f5j//+Q+vvfYa3t7eDB9uvf8NCxWd+Bn2fw5oYOQycHC3ysumZOUx9pM9nL2US9PGjqyZfGupZbhCCCHqjmrtE1IsNDSUN954g4sXL/Lll19aKiZRm+WkwcanTfd7T4XgPlZ52bTsfMZ9spczqTn4uzvw5eRbCWhk3S3hhRBCWJZFdpTS6XSMGDGCESNGWOJyojYxGtCc20lA+m40Z93gr08gJxW828Gdc6wSwuWcAh7+v72cSsnG182BLx+/lUAPJ6u8thBCiJpj3W0tRd1ydCNsnoFNZgLdAc4tNZVrdEWH09X8UEhGrp6Hl+/leFIW3q72rJkcRlAT5xp/XSGEEDXvpoZjRD12dCN8NR4yE0o/phggPa7GQ8i4queRFXs5kpCJp4sdayaH0dzLpcZfVwghhHVIEiJKMxpg8wxueBbt5pmmejUkK0/PxJXRHLqYgYezHav/dSstvV1r7PWEEEJYnyQhorRzu8ruASmhQGa8qV4NyMkvZNLKP/n7/BUaOdmy6rEwQn0lARFCiPpG5oQIk6wkSDxoup34qXLPyU62eBi5BYU8+umf/HXuMm4ONqx6LIx2/m4Wfx0hhBDqkySkoVEUyLh4LeEovmUnVf1aLpbdpj1Pb+Bfn/3F3rh0XO1t+OKxMDoEWGcPEiGEENYnSUh9pihwOa50wpF7qXRdjRY8W4NfZ/DtCDuXFNUra16IBtz8Iai3xULN0xuY/Plf7Iq9hLOdjk8f7UnnwEYWu74QQojaR5KQ+sJogEuxRYnGgaKvhyA/o3RdrQ14tTUlHMU33w5gd93S10ZBptUxaDBPRIpOyR3yGmh1Fgk9v9DAk6v38/upNBxtdayc1JNuQY0tcm0hhBC1lyQhdZGhENJOXOvZSDgASYdBn1O6rs4OfNqbJxze7Sve46PdcBj9uWmVzPWTVN38TQmIhQ6s0xuMTF3zN78eT8HBVsuKiT3oGeJhkWsLIYSo3SQJsQajwbSSJDvZNI8iqHflexEK8yHlmHkPR/IRKMwrXdfG0TSUcn3C4dUGbKp5xH274dDmbgrP7ODA71vo0ncwNs37WawHRG8w8syXfxN5NBk7Gy3/N74HvVo0sci1hRBC1H6ShNS0ol1HS/cmvF66N0F/1ZRgJPx9rZcj5RgY9aWva+cKfp3ME44mrUBn4X9SrQ4lqA/xRzLpHNTHYglIocFIxFcH+TkmCTudlo8f6UafVp4WubYQQoi6QZKQmlS86+g/J3dmJprK75wN9i7XEo7UE6bdSP/JoZF5suF/CzQOAW3d3ObFYFT47zeH+OFgArY6DUsf7sodod5qhyWEEMLKJAmpKTfcdbSo7LeXSz/k5An+XcCvy7Wko1Ez0GhqLlYrMhoVZnx7iO/+jsdGq+H9h7rSv61ll/oKIYSoGyQJqSkV7jpapGlPaNn/WsLh6ldvEo5/MhoVZm84zDf7LqLTanh37C0Mbu+rdlhCCCFUIklITansbqJh/4aO99dsLLWAoijM33iEL6MvoNXA4tGdGdbRT+2whBBCqKhuTiqoCyq7m6iFdx2tjRRF4cUfj/LFnnNoNPDmA525t0uA2mEJIYRQmSQhNSWot2kVDOUNrWjALcCiu47WRoqisOjn46z84ywAr9/Xifu6NlU3KCGEELVCrUhCPvjgA4KDg3FwcCAsLIzo6Ohy695xxx1oNJpSt7vvvrukzsSJE0s9PmTIEGu8lWu0OtMyXKB0ImL5XUdrI0VR+N+WE3y84wwAr47syOgegSpHJYQQorZQPQlZt24dERERzJ8/n/3799O5c2cGDx5MSkpKmfXXr19PYmJiyS0mJgadTscDDzxgVm/IkCFm9b788ktrvB1zxbuOuv1j7oObv6ncQruO1lZLfjnFh9tiAXjx3vY8FNZM5YiEEELUJqpPTF28eDGTJ09m0qRJACxbtoxNmzaxYsUKZs6cWaq+h4f5lt5r167FycmpVBJib2+Pr28tWHlRtOtotXdMraPe//UU70SdAmDuPe0Y3ytY3YCEEELUOqomIQUFBezbt49Zs2aVlGm1WgYMGMDu3bsrdY3ly5czZswYnJ2dzcq3bduGt7c3jRs35q677uLll1+mSZOytwTPz88nPz+/5PvMzEwA9Ho9en0Zu5VWR9Nbr903GE23OqK4DSrbFh//HsebW00JyPODWzE+rKnl2rEBqWq7C8uQdleHtLs6aqLdq3ItjaIoZe2mZRUJCQkEBASwa9cuevXqVVL+/PPPs337dvbu3XvD50dHRxMWFsbevXvp2bNnSXlx70hISAixsbG88MILuLi4sHv3bnS60j0QCxYsYOHChaXK16xZg5OT0028w4bntwQNG86Z2vjuQAODmqr24yWEEEIFubm5PPTQQ2RkZODm5nbDuqoPx9yM5cuX07FjR7MEBGDMmDEl9zt27EinTp1o0aIF27Zto3///qWuM2vWLCIiIkq+z8zMJDAwkEGDBlXYgA2BXq8nMjKSgQMHYmtrW269L/acZ8Pu4wA8fWdznrmrpbVCrJcq2+7CsqTd1SHtro6aaPfi0YTKUDUJ8fT0RKfTkZxsvrFXcnJyhfM5cnJyWLt2LS+++GKFr9O8eXM8PT05ffp0mUmIvb099vb2pcptbW3ll+E6N2qP1XvP8eImUwLy1J0tiBgUiqae7vxqbfJzqA5pd3VIu6vDku1eleuoujrGzs6Obt26ERUVVVJmNBqJiooyG54py9dff01+fj4PP/xwha9z8eJFLl26hJ+f7NBZE7768wKzv4sB4N/9mvOcJCBCCCEqQfUluhEREXzyySd89tlnHDt2jClTppCTk1OyWmb8+PFmE1eLLV++nBEjRpSabJqdnc1///tf9uzZw9mzZ4mKiuLee++lZcuWDB482CrvqSH5dt9FZqw/BMCk24KZObSNJCBCCCEqRfU5IQ8++CCpqanMmzePpKQkunTpwubNm/HxMW1nfv78ebT/OLL+xIkT7Ny5k61bt5a6nk6n49ChQ3z22WdcuXIFf39/Bg0axEsvvVTmkIuovu8PxPPfbw6iKDC+VxDz7mknCYgQQohKUz0JAZg6dSpTp04t87Ft27aVKgsNDaW8RT2Ojo5s2bLFkuGJMmw6lEjEVwcxKjC2ZzMWhLeXBEQIIUSVqD4cI+qeLUeSmLb2bwxGhQe6NeWVER3QaiUBEUIIUTW1oidE1F4Go8LeuHT2pWloEpfOVb3C1DX7KTQq3HdLAK+N6iQJiBBCiGqRJESUa3NMIgt/OEpiRh6g4/NTf5U8Ft7Zn/890BmdJCBCCCGqSZIQUabNMYlMWbWf8vY7HdLeRxIQIYQQN0XmhIhSDEaFhT8cLTcB0QAvbzqGwShbsgshhKg+SUJEKdFx6UVDMGVTgMSMPKLj0q0XlBBCiHpHkhBRSkpW+QlIdeoJIYQQZZEkRJTi7epg0XpCCCFEWSQJEaX0DPHAx6383WU1gJ+7Az1DPKwXlBBCiHpHkhBRik6rIbiJc5mPFa+HmR/eTlbHCCGEuCmShIhSfjuRwt6iSadNnO3MHvN1d2Dpw10Z0kFOJBZCCHFzZJ8QYSY7v5DZ6w8D8FifEF4Y1pbdp1PY+vteBvUNo1dLb+kBEUIIYRGShAgzr/98nISMPJp5OPGfQa3RaTWEhXhw6ZhCWIiHJCBCCCEsRoZjRIm9Zy7xxZ5zALx2X0ec7CRHFUIIUXMkCREA5OkNzCwahhnbM5DeLT1VjkgIIUR9J0mIAODtyJPEpeXg6+bArGFt1Q5HCCFEAyBJiODQxSt88vsZAF4e0QE3B1uVIxJCCNEQSBLSwBUUGnn+m0MYFRje2Z8B7XzUDkkIIUQDIUlIA7d0WyzHk7LwcLZjfng7tcMRQgjRgEgS0oCdSMri/d9OAbBgeHuauJS/VbsQQghhaZKENFAGo8Lz3x5Cb1AY0NaH8E6yA6oQQgjrkiSkgVqxM46DF67g6mDDKyM7oNHIJmRCCCGsS5KQBuhsWg5vRZ4AYPawtvi4OagckRBCiIZIkpAGxmhUmLn+EHl6I7e1bMKDPQLVDkkIIUQDJUlIA/Pln+fZcyYdR1sdr93XSYZhhBBCqEaSkAYk4cpVFv10HID/Dg4l0MNJ5YiEEEI0ZJKENBCKojD7u8Nk5xfStVkjJvQOVjskIYQQDZwkIQ3E9wcS+O1EKnY6LW/c3wmdVoZhhBBCqEuSkAYgLTufhT8cAeCZ/i1p6e2qckRCCCGEJCENwvyNR7icq6ednxv/vr2F2uEIIYQQgCQh9d6WI0lsOpSITqvhjfs7YauTf3IhhBC1g3wi1WMZuXrmbIgB4N/9mtMhwF3liIQQQohrakUS8sEHHxAcHIyDgwNhYWFER0eXW/eOO+5Ao9GUut19990ldRRFYd68efj5+eHo6MiAAQM4deqUNd5KrfLKT0dJzcqnuZczz/RvpXY4QgghhBnVk5B169YRERHB/Pnz2b9/P507d2bw4MGkpKSUWX/9+vUkJiaW3GJiYtDpdDzwwAMldd544w3effddli1bxt69e3F2dmbw4MHk5eVZ622p7vdTqXz110U0GnhjVCccbHVqhySEEEKYUT0JWbx4MZMnT2bSpEm0a9eOZcuW4eTkxIoVK8qs7+Hhga+vb8ktMjISJyenkiREURSWLFnCnDlzuPfee+nUqROff/45CQkJbNiwwYrvTD05+YXM/PYwABN6BdM92EPliIQQQojSbNR88YKCAvbt28esWbNKyrRaLQMGDGD37t2Vusby5csZM2YMzs7OAMTFxZGUlMSAAQNK6ri7uxMWFsbu3bsZM2ZMqWvk5+eTn59f8n1mZiYAer0evV5frfemptd+Pk78las0beTA9Lua3/R7KH5+XWyLukzaXR3S7uqQdldHTbR7Va6lahKSlpaGwWDAx8fHrNzHx4fjx49X+Pzo6GhiYmJYvnx5SVlSUlLJNf55zeLH/mnRokUsXLiwVPnWrVtxcqpbW5ufyYRVR3SAhnC/HLZHbbXYtSMjIy12LVF50u7qkHZXh7S7OizZ7rm5uZWuq2oScrOWL19Ox44d6dmz501dZ9asWURERJR8n5mZSWBgIIMGDcLNze1mw7SafL2Bdz7cjUIuo7r6EzGyg0Wuq9friYyMZODAgdja2lrkmqJi0u7qkHZXh7S7Omqi3YtHEypD1STE09MTnU5HcnKyWXlycjK+vr43fG5OTg5r167lxRdfNCsvfl5ycjJ+fn5m1+zSpUuZ17K3t8fe3r5Uua2tbZ36ZXg7KpYzabl4udoz754OFo+9rrVHfSHtrg5pd3VIu6vDku1eleuoOjHVzs6Obt26ERUVVVJmNBqJioqiV69eN3zu119/TX5+Pg8//LBZeUhICL6+vmbXzMzMZO/evRVesy6Lic/gox1nAHh5RAfcneSXWAghRO2m+nBMREQEEyZMoHv37vTs2ZMlS5aQk5PDpEmTABg/fjwBAQEsWrTI7HnLly9nxIgRNGnSxKxco9Ewffp0Xn75ZVq1akVISAhz587F39+fESNGWOttWZXeYOT5bw5hMCrc3cmPwe1v3IskhBBC1AaqJyEPPvggqampzJs3j6SkJLp06cLmzZtLJpaeP38erda8w+bEiRPs3LmTrVvLnnT5/PPPk5OTw+OPP86VK1fo06cPmzdvxsHBocbfjxo+2h7L0cRMGjnZsnB4e7XDEUIIISpF9SQEYOrUqUydOrXMx7Zt21aqLDQ0FEVRyr2eRqPhxRdfLDVfpD46lZzFu1GnAZgf3g5Pl9JzW4QQQojaSPXNykT1GYwKM749RIHByJ2hXozoEqB2SEIIIUSlSRJSh3226yz7z1/Bxd6GV0Z2RKPRqB2SEEIIUWmShNRR5y/l8r8tJwCYNawN/o0cVY5ICCGEqBpJQuogRVGY9d0hruoN3Nrcg7E9mqkdkhBCCFFlkoTUQev+vMAfpy/hYKvltfs6odXKMIwQQoi6R5KQOiYpI49XNh0D4D8DQwn2dFY5IiGEEKJ6JAmpQxRFYc6GGLLyC+kc2IhH+4SoHZIQQghRbZKE1CE/HErkl2PJ2Oo0/O/+TuhkGEYIIUQdJklIHXEpO58FG48AMPXOVrT2cVU5IiGEEOLmSBJSRyz84SjpOQW08XVlyh0t1A5HCCGEuGmShNQBvxxNZuPBBLQaeH1UJ+xs5J9NCCFE3SefZrVcZp6eORtiAJjctzmdAxupG5AQQghhIZKE1HKLfjpGUmYeIZ7OPDuwtdrhCCGEEBYjSUgttut0Gl9GXwDgtfs64mCrUzkiIYQQwnIkCamlcgsKmbH+EACP3BpEWPMmKkckhBBCWJYkIbXUm1tOciH9Kv7uDjw/JFTtcIQQQgiLkySkFtp//jIrd8UB8Op9HXF1sFU5IiGEEMLyJAmpZfILDTz/zSEUBe7rGsAdod5qhySEEELUCElCapn3fz3N6ZRsPF3smXdPO7XDEUIIIWqMJCG1yNGETJZuiwXgpXvb08jJTuWIhBBCiJojSUgtUWgw8vy3Byk0Kgxp78vQjn5qhySEEELUKElCaolPfo8jJj4Td0dbXhzRXu1whBBCiBonSUgtEJuazdu/nARg7j3t8HZ1UDkiIYQQouZJEqIyo1Fh5reHKCg0cntrL0Z1DVA7JCGEEMIqJAlR2Rd7zvHn2cs42+l4ZWQHNBqN2iEJIYQQViFJiIoupOfy+ubjAMwY2oamjZ1UjkgIIYSwHklCVKIoCi98d5jcAgM9gz14OCxI7ZCEEEIIq5IkRCXf7LvI76fSsLfR8tqojmi1MgwjhBCiYZEkRAUpmXm89ONRAJ4d2JrmXi4qRySEEEJYnyQhVqYoCnO/jyEzr5COAe78q0+I2iEJIYQQqrBRO4CGwGBUiI5LJyUrjzOpOWw5koyNVsProzpho5M8UAghRMMkSUgN2xyTyMIfjpKYkWdWPqidD+383VSKSgghhFCf6v8N/+CDDwgODsbBwYGwsDCio6NvWP/KlSs89dRT+Pn5YW9vT+vWrfnpp59KHl+wYAEajcbs1qZNm5p+G2XaHJPIlFX7SyUgAD/HJLE5JlGFqIQQQojaQdWekHXr1hEREcGyZcsICwtjyZIlDB48mBMnTuDt7V2qfkFBAQMHDsTb25tvvvmGgIAAzp07R6NGjczqtW/fnl9++aXkexsb679Ng1Fh4Q9HUW5QZ+EPRxnYzhedrIwRQgjRAKmahCxevJjJkyczadIkAJYtW8amTZtYsWIFM2fOLFV/xYoVpKens2vXLmxtbQEIDg4uVc/GxgZfX98ajb0i0XHpZfaAFFOAxIw8ouPS6dWiifUCE0IIIWoJ1ZKQgoIC9u3bx6xZs0rKtFotAwYMYPfu3WU+Z+PGjfTq1YunnnqK77//Hi8vLx566CFmzJiBTqcrqXfq1Cn8/f1xcHCgV69eLFq0iGbNmpUbS35+Pvn5+SXfZ2ZmAqDX69Hr9dV6f4lXcipdT6+v3XNDitugum0hqkfaXR3S7uqQdldHTbR7Va6lWhKSlpaGwWDAx8fHrNzHx4fjx4+X+ZwzZ87w66+/Mm7cOH766SdOnz7Nk08+iV6vZ/78+QCEhYXx6aefEhoaSmJiIgsXLqRv377ExMTg6upa5nUXLVrEwoULS5Vv3boVJ6fqbaV+JkMD6Cqud+QAP138u1qvYW2RkZFqh9AgSburQ9pdHdLu6rBku+fm5la6rkZRlBtNW6gxCQkJBAQEsGvXLnr16lVS/vzzz7N9+3b27t1b6jmtW7cmLy+PuLi4kp6PxYsX87///Y/ExLIneV65coWgoCAWL17MY489VmadsnpCAgMDSUtLw82ter0UBqPCHW/tIDkzv8x5IRrA192e3yL61fo5IXq9nsjISAYOHFgyDCZqnrS7OqTd1SHtro6aaPfMzEw8PT3JyMio8DNUtZ4QT09PdDodycnJZuXJycnlzufw8/PD1tbWbOilbdu2JCUlUVBQgJ2dXannNGrUiNatW3P69OlyY7G3t8fe3r5Uua2tbbX/UWyBBcPbM2XVfjRglogUpxzzw9vjYF865trqZtpDVJ+0uzqk3dUh7a4OS7Z7Va6j2hJdOzs7unXrRlRUVEmZ0WgkKirKrGfkerfddhunT5/GaDSWlJ08eRI/P78yExCA7OxsYmNj8fPzs+wbqIQhHfxY+nBXfN0dzMp93R1Y+nBXhnSwfkxCCCFEbaHq6piIiAgmTJhA9+7d6dmzJ0uWLCEnJ6dktcz48eMJCAhg0aJFAEyZMoX333+fadOm8fTTT3Pq1CleffVVnnnmmZJrPvfcc4SHhxMUFERCQgLz589Hp9MxduxYVd7jkA5+DGznW7JjqrerAz1DPGr9EIwQQghR01RNQh588EFSU1OZN28eSUlJdOnShc2bN5dMVj1//jxa7bXOmsDAQLZs2cKzzz5Lp06dCAgIYNq0acyYMaOkzsWLFxk7diyXLl3Cy8uLPn36sGfPHry8vKz+/orptBpZhiuEEEL8g+rbtk+dOpWpU6eW+di2bdtKlfXq1Ys9e/aUe721a9daKjQhhBBC1CDVt20XQgghRMMkSYgQQgghVCFJiBBCCCFUIUmIEEIIIVQhSYgQQgghVKH66pjaqHgn++KD7Bo6vV5Pbm4umZmZspOhFUm7q0PaXR3S7uqoiXYv/uyszKkwkoSUISsrCzDtSyKEEEKIqsvKysLd3f2GdVQ7wK42MxqNJCQk4OrqikYjO5sWH+h34cKFah/oJ6pO2l0d0u7qkHZXR020u6IoZGVl4e/vb7bhaFmkJ6QMWq2Wpk2bqh1GrePm5iZ/HFQg7a4OaXd1SLurw9LtXlEPSDGZmCqEEEIIVUgSIoQQQghVSBIiKmRvb8/8+fOxt7dXO5QGRdpdHdLu6pB2V4fa7S4TU4UQQgihCukJEUIIIYQqJAkRQgghhCokCRFCCCGEKiQJEUIIIYQqJAkR5Vq0aBE9evTA1dUVb29vRowYwYkTJ9QOq0F57bXX0Gg0TJ8+Xe1QGoT4+HgefvhhmjRpgqOjIx07duSvv/5SO6x6zWAwMHfuXEJCQnB0dKRFixa89NJLlTp3RFTejh07CA8Px9/fH41Gw4YNG8weVxSFefPm4efnh6OjIwMGDODUqVM1HpckIaJc27dv56mnnmLPnj1ERkai1+sZNGgQOTk5aofWIPz555989NFHdOrUSe1QGoTLly9z2223YWtry88//8zRo0d56623aNy4sdqh1Wuvv/46S5cu5f333+fYsWO8/vrrvPHGG7z33ntqh1av5OTk0LlzZz744IMyH3/jjTd49913WbZsGXv37sXZ2ZnBgweTl5dXo3HJEl1RaampqXh7e7N9+3b69eundjj1WnZ2Nl27duXDDz/k5ZdfpkuXLixZskTtsOq1mTNn8scff/D777+rHUqDcs899+Dj48Py5ctLykaNGoWjoyOrVq1SMbL6S6PR8N133zFixAjA1Avi7+/Pf/7zH5577jkAMjIy8PHx4dNPP2XMmDE1Fov0hIhKy8jIAMDDw0PlSOq/p556irvvvpsBAwaoHUqDsXHjRrp3784DDzyAt7c3t9xyC5988onaYdV7vXv3JioqipMnTwJw8OBBdu7cydChQ1WOrOGIi4sjKSnJ7O+Nu7s7YWFh7N69u0ZfWw6wE5ViNBqZPn06t912Gx06dFA7nHpt7dq17N+/nz///FPtUBqUM2fOsHTpUiIiInjhhRf4888/eeaZZ7Czs2PChAlqh1dvzZw5k8zMTNq0aYNOp8NgMPDKK68wbtw4tUNrMJKSkgDw8fExK/fx8Sl5rKZIEiIq5amnniImJoadO3eqHUq9duHCBaZNm0ZkZCQODg5qh9OgGI1GunfvzquvvgrALbfcQkxMDMuWLZMkpAZ99dVXrF69mjVr1tC+fXsOHDjA9OnT8ff3l3ZvAGQ4RlRo6tSp/Pjjj/z22280bdpU7XDqtX379pGSkkLXrl2xsbHBxsaG7du38+6772JjY4PBYFA7xHrLz8+Pdu3amZW1bduW8+fPqxRRw/Df//6XmTNnMmbMGDp27MgjjzzCs88+y6JFi9QOrcHw9fUFIDk52aw8OTm55LGaIkmIKJeiKEydOpXvvvuOX3/9lZCQELVDqvf69+/P4cOHOXDgQMmte/fujBs3jgMHDqDT6dQOsd667bbbSi1BP3nyJEFBQSpF1DDk5uai1Zp/FOl0OoxGo0oRNTwhISH4+voSFRVVUpaZmcnevXvp1atXjb62DMeIcj311FOsWbOG77//HldX15KxQXd3dxwdHVWOrn5ydXUtNefG2dmZJk2ayFycGvbss8/Su3dvXn31VUaPHk10dDQff/wxH3/8sdqh1Wvh4eG88sorNGvWjPbt2/P333+zePFiHn30UbVDq1eys7M5ffp0yfdxcXEcOHAADw8PmjVrxvTp03n55Zdp1aoVISEhzJ07F39//5IVNDVGEaIcQJm3lStXqh1ag3L77bcr06ZNUzuMBuGHH35QOnTooNjb2ytt2rRRPv74Y7VDqvcyMzOVadOmKc2aNVMcHByU5s2bK7Nnz1by8/PVDq1e+e2338r8ez5hwgRFURTFaDQqc+fOVXx8fBR7e3ulf//+yokTJ2o8LtknRAghhBCqkDkhQgghhFCFJCFCCCGEUIUkIUIIIYRQhSQhQgghhFCFJCFCCCGEUIUkIUIIIYRQhSQhQgghhFCFJCFCCCGEUIUkIUKIBkOj0bBhwwa1wxBCFJEkRAhhFRMnTkSj0ZS6DRkyRO3QhBAqkQPshBBWM2TIEFauXGlWZm9vr1I0Qgi1SU+IEMJq7O3t8fX1Nbs1btwYMA2VLF26lKFDh+Lo6Ejz5s355ptvzJ5/+PBh7rrrLhwdHWnSpAmPP/442dnZZnVWrFhB+/btsbe3x8/Pj6lTp5o9npaWxsiRI3FycqJVq1Zs3LixZt+0EKJckoQIIWqNuXPnMmrUKA4ePMi4ceMYM2YMx44dAyAnJ4fBgwfTuHFj/vzzT77++mt++eUXsyRj6dKlPPXUUzz++OMcPnyYjRs30rJlS7PXWLhwIaNHj+bQoUMMGzaMcePGkZ6ebtX3KYQoUuPn9AohhKIoEyZMUHQ6neLs7Gx2e+WVVxRFURRAeeKJJ8yeExYWpkyZMkVRFEX5+OOPlcaNGyvZ2dklj2/atEnRarVKUlKSoiiK4u/vr8yePbvcGABlzpw5Jd9nZ2crgPLzzz9b7H0KISpP5oQIIazmzjvvZOnSpWZlHh4eJfd79epl9livXr04cOAAAMeOHaNz5844OzuXPH7bbbdhNBo5ceIEGo2GhIQE+vfvf8MYOnXqVHLf2dkZNzc3UlJSqvuWhBA3QZIQIYTVODs7lxoesRRHR8dK1bO1tTX7XqPRYDQaayIkIUQFZE6IEKLW2LNnT6nv27ZtC0Dbtm05ePAgOTk5JY//8ccfaLVaQkNDcXV1JTg4mKioKKvGLISoPukJEUJYTX5+PklJSWZlNjY2eHp6AvD111/TvXt3+vTpw+rVq4mOjmb58uUAjBs3jvnz5zNhwgQWLFhAamoqTz/9NI888gg+Pj4ALFiwgCeeeAJvb2+GDh1KVlYWf/zxB08//bR136gQolIkCRFCWM3mzZvx8/MzKwsNDeX48eOAaeXK2rVrefLJJ/Hz8+PLL7+kXbt2ADg5ObFlyxamTZtGjx49cHJyYtSoUSxevLjkWhMmTCAvL4+3336b5557Dk9PT+6//37rvUEhRJVoFEVR1A5CCCE0Gg3fffcdI0aMUDsUIYSVyJwQIYQQQqhCkhAhhBBCqELmhAghagUZGRai4ZGeECGEEEKoQpIQIYQQQqhCkhAhhBBCqEKSECGEEEKoQpIQIYQQQqhCkhAhhBBCqEKSECGEEEKoQpIQIYQQQqji/wExd8FXv46ZJQAAAABJRU5ErkJggg==\n"
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiEAAAGJCAYAAABcsOOZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaflJREFUeJzt3Xd4VMX6wPHv7mbTGyE9BBJa6E0g0qw0xSiICohSVLxyQUGuV0HpFqyIFX56AQsgWBBRFIhBQAQSpEc6hBZSCCGdJJvd8/tjYWFJQgq7OSnv53nyZHd2zpx3h5B9M2fOjEZRFAUhhBBCiCqmVTsAIYQQQtRNkoQIIYQQQhWShAghhBBCFZKECCGEEEIVkoQIIYQQQhWShAghhBBCFZKECCGEEEIVkoQIIYQQQhWShAghhBBCFZKECCGEEEIVkoQIISrk008/RaPREBkZqXYoQogaTiN7xwghKqJHjx6cO3eOkydPcvToUZo2bap2SEKIGkpGQoQQ5ZaQkMDWrVuZO3cufn5+LF26VO2QSpSbm6t2CEKIcpAkRAhRbkuXLqVevXoMGDCAhx56qMQkJCMjg+eff56wsDCcnJxo0KABI0aMIC0tzVInPz+fmTNn0rx5c5ydnQkKCuLBBx/k+PHjAGzcuBGNRsPGjRut2j558iQajYYvvvjCUjZq1Cjc3d05fvw49957Lx4eHgwfPhyAP//8k4cffpiGDRvi5OREaGgozz//PJcuXSoW96FDh3jkkUfw8/PDxcWFiIgIXnnlFQD++OMPNBoNP/74Y7Hjli1bhkajYdu2bRXuTyHqOge1AxBC1BxLly7lwQcfxNHRkWHDhjF//nx27NhBly5dAMjJyaFXr14cPHiQJ554gk6dOpGWlsbq1as5e/Ysvr6+GI1G7rvvPmJiYhg6dCgTJkwgOzub6Oho4uPjadKkSYXjKioqol+/fvTs2ZN3330XV1dXAL777jvy8vIYO3Ys9evXJy4ujo8++oizZ8/y3XffWY7ft28fvXr1Qq/X8/TTTxMWFsbx48f5+eefef3117njjjsIDQ1l6dKlDBo0qFifNGnShG7dut1EzwpRRylCCFEOf//9twIo0dHRiqIoislkUho0aKBMmDDBUmf69OkKoKxcubLY8SaTSVEURVm0aJECKHPnzi21zh9//KEAyh9//GH1ekJCggIoixcvtpSNHDlSAZTJkycXay8vL69Y2Zw5cxSNRqOcOnXKUnbbbbcpHh4eVmXXxqMoijJlyhTFyclJycjIsJSlpqYqDg4OyowZM4qdRwhRNrkcI4Qol6VLlxIQEMCdd94JgEajYciQISxfvhyj0QjADz/8QPv27YuNFlypf6WOr68vzz77bKl1KmPs2LHFylxcXCyPc3NzSUtLo3v37iiKwu7duwE4f/48mzdv5oknnqBhw4alxjNixAgKCgr4/vvvLWUrVqygqKiIxx57rNJxC1GXSRIihCiT0Whk+fLl3HnnnSQkJHDs2DGOHTtGZGQkKSkpxMTEAHD8+HHatGlzw7aOHz9OREQEDg62uxrs4OBAgwYNipWfPn2aUaNG4ePjg7u7O35+ftx+++0AZGZmAnDixAmAMuNu0aIFXbp0sZoHs3TpUm699Va5Q0iISpI5IUKIMm3YsIGkpCSWL1/O8uXLi72+dOlS+vbta7PzlTYicmXE5XpOTk5otdpidfv06UN6ejovvfQSLVq0wM3NjcTEREaNGoXJZKpwXCNGjGDChAmcPXuWgoICtm/fzscff1zhdoQQZpKECCHKtHTpUvz9/fnkk0+KvbZy5Up+/PFHFixYQJMmTYiPj79hW02aNCE2NhaDwYBery+xTr169QDznTbXOnXqVLlj3r9/P0eOHOHLL79kxIgRlvLo6Gireo0bNwYoM26AoUOHMmnSJL755hsuXbqEXq9nyJAh5Y5JCGFNLscIIW7o0qVLrFy5kvvuu4+HHnqo2Nf48ePJzs5m9erVDB48mL1795Z4K6tyeV3EwYMHk5aWVuIIwpU6jRo1QqfTsXnzZqvXP/3003LHrdPprNq88viDDz6wqufn58dtt93GokWLOH36dInxXOHr68s999zDkiVLWLp0Kf3798fX17fcMQkhrMlIiBDihlavXk12djb3339/ia/feuutloXLli1bxvfff8/DDz/ME088wS233EJ6ejqrV69mwYIFtG/fnhEjRvDVV18xadIk4uLi6NWrF7m5ufz+++/8+9//5oEHHsDLy4uHH36Yjz76CI1GQ5MmTfjll19ITU0td9wtWrSgSZMmvPDCCyQmJuLp6ckPP/zAxYsXi9X98MMP6dmzJ506deLpp58mPDyckydPsmbNGvbs2WNVd8SIETz00EMAvPrqq+XvSCFEcWremiOEqP6ioqIUZ2dnJTc3t9Q6o0aNUvR6vZKWlqZcuHBBGT9+vBISEqI4OjoqDRo0UEaOHKmkpaVZ6ufl5SmvvPKKEh4eruj1eiUwMFB56KGHlOPHj1vqnD9/Xhk8eLDi6uqq1KtXT/nXv/6lxMfHl3iLrpubW4lxHThwQOndu7fi7u6u+Pr6KmPGjFH27t1brA1FUZT4+Hhl0KBBire3t+Ls7KxEREQo06ZNK9ZmQUGBUq9ePcXLy0u5dOlSOXtRCFES2TtGCCEqoKioiODgYKKioli4cKHa4QhRo8mcECGEqIBVq1Zx/vx5q8muQojKkZEQIYQoh9jYWPbt28err76Kr68vu3btUjskIWo8GQkRQohymD9/PmPHjsXf35+vvvpK7XCEqBVkJEQIIYQQqpCRECGEEEKoQpIQIYQQQqhCFisrgclk4ty5c3h4eNzUrp5CCCFEXaMoCtnZ2QQHBxfb0+l6koSU4Ny5c4SGhqodhhBCCFFjnTlzpsTdra8lSUgJPDw8AHMHenp6qhyN+gwGA+vXr6dv376lbjgmbE/6XR3S7+qQfleHPfo9KyuL0NBQy2fpjUgSUoIrl2A8PT0lCcH8Q+rq6oqnp6f8cqhC0u/qkH5Xh/S7OuzZ7+WZziATU4UQQgihCklChBBCCKEKSUKEEEIIoQqZE1JJiqJQVFSE0WhUOxS7MxgMODg4kJ+fb7P3q9fr0el0NmlLCCFEzSRJSCUUFhaSlJREXl6e2qFUCUVRCAwM5MyZMzZbN0Wj0dCgQQPc3d1t0p4QQoiaR5KQCjKZTCQkJKDT6QgODsbR0bHWL2hmMpnIycnB3d29zIVnykNRFM6fP8/Zs2dp1qyZjIgIIUQdJUlIBRUWFmIymQgNDcXV1VXtcKqEyWSisLAQZ2dnmyQhAH5+fpw8eRKDwSBJiBBCqMBoUohNSGdnmob6Cel0a+qPTlu1f1RLElJJtvowrqtq++iREEJUZ2vjk5j18wGSMvMBHV8d/ZsgL2dmRLWif5ugKotDPkmFEEKIOmRtfBJjl+y6nIBclZyZz9glu1gbn1RlsUgSIoQQQtQRRpPCrJ8PoJTw2pWyWT8fwGgqqYbtSRKiEqNJYdvxC/y0J5Ftxy9U2T+4rYSFhTFv3jy1wxBCCFEGg9HE4eRsVu1OZOLy3cVGQK6lAEmZ+cQlpFdJbDInRAXW1+LMquJa3B133EGHDh1skjzs2LEDNze3mw9KCCGEzaTnFnIoKYsDSVkcTMrmYFIWx1JzKDSaKtROanbpiYotSRJSxa5ci7t+3OPKtbj5j3Wq0klB11IUBaPRiIND2T8Wfn5+VRCREEKIkhQZTSSk5VqSjUPJWRxMyiIlq6DE+h5ODrQI8sDbxZHogylltu/v4WzrkEskSYgNKIrCJUPZK4kaTQozVv9T6rU4DTBz9QF6NPUt121SLnpdue8yGTVqFJs2bWLTpk188MEHACxevJjRo0fz66+/MnXqVPbv38/69esJDQ1l0qRJbN++ndzcXFq2bMkrr7zC/fffb2kvLCyMiRMnMnHiRMB8t8vnn3/OmjVrWLduHSEhIbz33ntWxwghhKi4jLxCy6jGwaQsDiZncSQlh8Kikkc3GtV3pWWgJy2DPGkZ5EHLIE8a1HNBo9FgNCn0fGsDyZn5JX4WaYBAL2e6hvvY9T1dIUmIDVwyGGk1fd1Nt6MAyVn5tJ25vlz1D8zuh6tj+f4JP/jgA44cOUKbNm2YPXs2AP/88w8AkydP5t1336Vx48bUq1ePM2fOcO+99/L666/j5OTEl19+ybBhwzh48CBhYWGlnmPWrFm8/fbbvPPOO3z00UcMHz6cU6dO4eNTNT/MQghR1YwmhbiEdFKz8/H3MH94V3atDaNJISEt15JsHEo2Jx6lzeFwc9TRIsiTFoEelxMO82M3p9I/F3RaDTOiWjF2yS40YJWIXIl6RlSrKlsvRJKQOsLLywtHR0dcXV0JDAwE4NChQwDMnj2bPn36WOr6+PjQvn17y/PZs2fzww8/8PPPP/Pss8+Weo5Ro0YxbNgwAN544w0+/PBD4uLi6N+/vz3ekhBCqOpm5vdlXjJw6MrIRlI2B5OzOJycTUEpoxuhPi7FRjdC67mirUSy0L9NEPMf61Qs9kAV1gmRJMQGXPQ6DszuV2a9uIR0Ri3eUWa9L0Z3KddQmIveNiuNdu7c2ep5Tk4OM2fOZM2aNSQlJVFUVMSlS5c4ffr0Ddtp166d5bGbmxuenp6kpqbaJEYhhKhOyju/z2hSOHUh13I5xTx3I5vEjEsltuvqqCMi0IMWgZ60upxsRAR64OGst2n8/dsE0adVINuOpbL+z1j69oqUFVNrKo1GU67LIr2a+RHk5Vzmtbhezfyq9Afh+rtcXnjhBaKjo3n33Xdp2rQpTk5ODB48mMLCwhu2o9db/yfRaDSYTBWbkS2EENVdedbamPTtXj7deJyjKTmlzhkM8XahZZA52Whx+XJKI5/KjW5Uhk6rITLchwsHFSJv4jLSzZAkpAqpfS3O0dERo7HsCbR//fUXo0aNYtCgQQBkZWWVOQoihBCVVR32MClJQZGRzDwDmZcMZFwykJFnICOvkL1nM2641gZAXqGRfWczAXDWa4kIuDpv48rohpeLbUc3aiJJQqqYmtfiwsLCiI2N5eTJk7i7u5c6StGsWTNWrlxJVFQUGo2GqVOnoig1azE1IUTNYO89TBRFIaegiIwryYQlqSi0PM7Mu+755XrluevxRkZ1b8Tj3cIIq+9WLZKq6kiSEBVcuRZnqxnV5fXCCy8wcuRIWrVqxaVLl1i8eHGJ9ebOncsTTzxB9+7d8fX15cUXX+TixYt2jU0IUfdUZN0kg9FklSBkXpM0XP1eSMalaxML8+ObWZFaqwEvF735y9URbxc9RUYTfx2/UOax/VoH0cTPvdLnrgskCVGJTquhW5P6VXrO5s2bs23bNquyUaNGFasXFhbGhg0bLM9NJhOPPfYYnp6elrKTJ09aHVPSSElGRsZNxSuEqL3KM69i/LLd+HscICu/iJyCops6n5ODFm9XPd4ujni5mpMKbxe9uczVEc9rn7s4Xk469Hg4ORSbo1Hd1tqoySQJEUIIUWWKjCYOJGXx7d9nypxXUWRSOHddHU9nB7xdHfG+nEh4XU4czEmFOcHwtpRfredso7sJQf35fbWJJCFCCCHsJt9gnqAZl3CBuJMX2XkyndzC8s+1mNSnOfe3D8bbVY+Hs77afLBXp7U2ajJJQoQQQthMTkERu05dJC4hnbiT6ew5k1FseXFPZwea+rmz60xGme11CfMhzLd6bpap1vy+2kSSECGEEJV2MbeQHSfTiUtIZ8fJdOLPZRWbCOrr7kRkuA9dL39FBHigQK2YV6HG/L7aRJIQIYQQ5ZaSlU9sQjo7EsyJx+GU7GJ1GtRzoWu4z+XEoz5h9V1L3GxT5lUISUKEEEKUSFEUTqfnXU06TqZz6kJesXpN/d0tSUeXMB+CvV3K1b7MqxCShAghhADAZFI4mppD3OXLK3EJF0jJKrCqo9VAq2BPuobVp2u4D13C6lHf3anS56wue5gIdaiehHzyySe88847JCcn0759ez766CO6du1aYl2DwcCcOXP48ssvSUxMJCIigrfeestql9aZM2cya9Ysq+MiIiIsO8YKIURtVJkt5a/cLhuXkG4e7TiZTkaewaqOXqehfQNvc8IR7sMtjerhaePN1KrDHiZCHaomIStWrGDSpEksWLCAyMhI5s2bR79+/Th8+DD+/v7F6k+dOpUlS5bw+eef06JFC9atW8egQYPYunUrHTt2tNRr3bo1v//+u+W5g4PquZYQQthNebeUv/Z22diEdHaduljsdlkXvY5bGtWjS5h5EmnHht42XWNDiGup+uk8d+5cxowZw+jRowFYsGABa9asYdGiRUyePLlY/a+//ppXXnmFe++9F4CxY8fy+++/895777FkyRJLPQcHBwIDA6vmTVSWyQintkJOCrgHQKPuoK3e/9EbN27MxIkTmThxotqhCCEuK2vp8/F3NUVRIC7h8u2yxuK3y15JOLqG+9AmxAu9Tlt1b0DUaaolIYWFhezcuZMpU6ZYyrRaLb179y62tPgVBQUFODs7W5W5uLiwZcsWq7KjR48SHByMs7Mz3bp1Y86cOTRs2LDUWAoKCigouHrdMysrCzBf/jEYrIcmDQYDiqJgMpkqv039wZ/RrJuMJuucpUjxDEbp9ya0jKpcm3Z07ZLsV977zTKZTCiKgsFgQKer3smXWq787F3/Myjsqyb1u9GkMHP1Pzdc+vyjDcesyn3dHenSqB5dwsxfzf3drZclNxkxmG5u47bKqEn9XpvYo98r0pZqSUhaWhpGo5GAgACr8oCAgFLnb/Tr14+5c+dy22230aRJE2JiYli5cqXV9vSRkZF88cUXREREkJSUxKxZs+jVqxfx8fF4eHiU2O6cOXOKzSMBWL9+Pa6urlZlV0ZZcnJyKCwsrOjbRn/sN1x/GQvX/9rISkLz3Ujy7puPoek9FW63KphMJvLz8y1J2s0oLCzk0qVLbN68maKim9sToraLjo5WO4Q6qSb0+5EMDclZZSfxEV4mOtZXaOKp4OdchEaTB+mJnEiHE1UQZ0XUhH6vjWzZ73l5xe+gKk2NmizxwQcfMGbMGFq0aIFGo6FJkyaMHj2aRYsWWercc8/VD/B27doRGRlJo0aN+Pbbb3nyySdLbHfKlClMmjTJ8jwrK4vQ0FD69u1rtWkbQH5+PmfOnMHd3f3qqIyigKEcnW4yotk0C1C4ftqVBgUFDa6bZqO0uqd8l2b0rlDCvfcl+eyzz5g9ezanT59Gq7061Dpw4EDq16/Pyy+/zH/+8x9iY2PJzc2lZcuWvP766/Tu3RtFUcjOzkar1eLs7FysTyojPz8fFxcXbrvttmKjW8LMYDAQHR1Nnz590OttOxFQlK6693u+wci2E+lsPHKeX0+mAGX/1fmvvu2Jale9b3et7v1eW9mj3yvyh6pqSYivry86nY6UlBSr8pSUlFLnc/j5+bFq1Sry8/O5cOECwcHBTJ48mcaNG5d6Hm9vb5o3b86xY8dKrePk5ISTU/FbzPR6fbF/FKPRiEajQavVXv0wL8yFNxuU2n55aVAg+xyatxuV74CXz4Fj+ZYzHjJkCBMmTGDTpk3cfffdAKSnp7Nu3Tp+/fVX8vLyGDBgAG+88QZOTk589dVXPPDAAxw+fJgGDa6+tyvv/WZptVo0Gk2JfSysSR+pozr1e2LGJTYcSuWPQ6n8dSyNgqKKXRIN8narNu+lLNWp3+sSW/Z7RdpRbfaRo6Mjt9xyCzExMZYyk8lETEwM3bp1u+Gxzs7OhISEUFRUxA8//MADDzxQat2cnByOHz9OUFD1/ivA3urVq8c999zDsmXLLGXff/89vr6+3HnnnbRv355//etftGnThmbNmvHqq6/SpEkTVq9erWLUQtRNRUYTO06m89baQ/Sft5keb25g2qp4NhxKpaDIRLCXM8MjG/K/EbcQ6OlUbGT1Cg3mu2Sq+9Lnou5S9XLMpEmTGDlyJJ07d6Zr167MmzeP3Nxcy90yI0aMICQkhDlz5gAQGxtLYmIiHTp0IDExkZkzZ2IymXjxxRctbb7wwgtERUXRqFEjzp07x4wZM9DpdAwbNsx+b0Tvah6VKMuprbD0obLrDf/efLdMec5bAcOHD2fMmDF8+umnODk5sXTpUoYOHYpWqyUnJ4eZM2eyZs0akpKSKCoq4tKlS5w+fbpC5xBCVE5GXiGbjpxnw6FUNh4+T+alq5dZtBro1LAed7X0564W/kQEeFiWQS8yKbL0uaixVE1ChgwZwvnz55k+fTrJycl06NCBtWvXWiarXj9/IT8/n6lTp3LixAnc3d259957+frrr/H29rbUOXv2LMOGDePChQv4+fnRs2dPtm/fjp+fn/3eiEZTvssiTe4Cz2DISqLYxFRzQ+bXm9xll9t1o6KiUBSFNWvW0KVLF/7880/ef/99wJy8RUdH8+6779K0aVNcXFx46KGHKjX5VghRNkVROJySbbnMsvPURa7d983LRc/tzf24u6U/tzXzo56bY4ntyNLnoiZTfWLq+PHjGT9+fImvbdy40er57bffzoEDB27Y3vLly20Vmu1pddD/Lfh2BJT2d0v/N+22XoizszMPPvggS5cu5dixY0RERNCpUycA/vrrL0aNGsWgQYMA82WskydP2iUOIeqqfIORrcfTLice50nMuGT1ekSAB3e28Ofulv50DPXGoZzrdciW8qKmUj0JqXNa3Q+PfAVrX4Jr1gnBM9icgLS6366nHz58OPfddx///PMPjz32mKW8WbNmrFy5kqioKDQaDdOmTbPJeiBC1HXXTirdejyNfMPV/1dODlq6N6nPXS0DuDPCjwb1KnaJ9VqypbyoiSQJUUOr+6HFAFVWTL3rrrvw8fHh8OHDPProo5byuXPn8sQTT9C9e3d8fX156aWXbLIeiBB1TZHRxO4zGZbE41Cy9Vb3wV7OltGObo19cXGUxfpE3SVJiFq0OgjvVfWn1Wo5d674JNqwsDA2bNhgVTZu3DgAy4jIiRMnbHJ7rhC1zbWTSjcdOW+1CdyNJpUKUddJEiKEEJcZTQqxCensTNNQPyG91C3lbTWpVIi6TpIQIYTg+p1odXx19G+rnWjtNalUiLpMkhAhRJ1X2k60SZn5PLNkF21CPDmWmmO3SaVC1FWShAgh6jSjSWHWzwdKXLnnivhE8yRtmVQqhG1JElJJ125vLypO+k9UF3EJ6VaLfJXmrcFteaRzqEwqFcKG5KJlBV3ZmKciWxWL4q6sxKrTyV+SQj0XcwtZGnuqXHWd9TpJQISwMRkJqSCdToe3tzepqakAuLq61vpfTCaTicLCQvLz821yi67JZOL8+fO4urri4CA/gqLqHU3JZvHWk6zcddZqnseN+Hs42zkqIeoe+QSohMDAQABLIlLbKYrCpUuXcHFxsVnCpdVqadiwYa1P4ET1YTIpbDpynkV/JfDn0TRLectAD85l5pN1yVDajk4Eyk60QtiFJCGVoNFoCAoKwt/fH4PBUPYBNZzBYGDz5s3cdtttlstRN8vR0VEWPhNVIregiB92neWLv05yIi0XMC8g1qdVAE/0CKdruA/r/kmWnWiFUIEkITdBp9PViTkNOp2OoqIinJ2dbZaECGFvZy/m8dW2U3wTd5rs/CIAPJwcGNIllJHdwwj1uXpLrexEK4Q6JAkRQtQaiqLw96mLLNqSwLp/ki2rmIbVd2V0j3AG39IAd6eSf+1d2Yl227FU1v8ZS99ekaWumCqEsA1JQoQQNV5BkZE1+5JY9FeCZU0PgJ5NfRndI4w7I/zRliOZ0Gk1RIb7cOGgQmS4jyQgQtiZJCFCiBorLaeApdtP8/X2U6TlFADmlUwf7BTCqO7hRAR6qByhEOJGJAkRQtQ4/5zLZPFfJ1m95xyFRvMttgGeTozoFsawrg3xkQ3jhKgRJAkRQtQIRpPC7wdTWLQlgdiEdEt5+1BvnugRxr1tg9DLpnFC1CiShAghqrWsfAPf7jjDl9tOcibdvHOtTqvhnjaBPNEznE4N66kcoRCisiQJEUJUSwlpuXy59STf/X2G3EIjAF4ueh6NbMjjtzYi2NtF5QiFEDdLkhAhRLWhKApbj19g0ZYENhxO5co+h0393XmiRziDOobIzrVC1CKShAghVJdvMLJqdyKL/zrJ4ZRsS/mdEX480TOcnk19ZYl/IWohSUKEEKpJycrn622nWBp7iot55i0QXB11PHRLA0Z2D6OJn7vKEQoh7EmSECGETRlNCnEJ6aRm5+PvYd747fpFv/acyWDxXwms2ZdE0eVlTUO8XRjVPYxHuoTi5SLbAwhRF0gSIoSwmbXxScX2Xwm6vP/K3S0DWBufzOK/Eth1OsPyetcwH0b3CKNPqwAc5BZbIeoUSUKEEDaxNj6JsUt2We1CC5Ccmc8zS3bh7aon4/IlF71OQ1T7YJ7oEU6bEK+qD1YIWzEZ4dRWyEkB9wBo1B20Mnm6vCQJEULcNKNJYdbPB4olIIClLCPPQH03PY/dGsbwWxvi7+FclSEKYXsHVsPalyDr3NUyz2Do/xa0ul+9uGoQGfsUQty0uIR0q0swpZk7pAPP92kuCYio+Q6shm9HWCcgAFlJ5vIDq9WJqyJMRjSnthCSvg3NqS3mUZ0qJiMhQoiblppddgICWC7HCFGjmYzmEZBSx/40sHYytBhQfS/NXB7Fccg6R2eAU/NVGcWRJEQIcdNc9OX7RSsjIKJWOPxb8REQKwpkJcJ3T4BfM3B0A70bOLqC3hUc3a957Hb59cuPdY5g7zVxroziXJ9EXRnFeeSrKktEVE9CPvnkE9555x2Sk5Np3749H330EV27di2xrsFgYM6cOXz55ZckJiYSERHBW2+9Rf/+/SvdphDi5sQcTGHKyv03rKMBAr3Mt+sKUSMoinmy6flDcP6w9fe8C+Vr4+AqOFjB82p01yUmrpcTGLdrHt8ombnB6zp9tRvFUTUJWbFiBZMmTWLBggVERkYyb948+vXrx+HDh/H39y9Wf+rUqSxZsoTPP/+cFi1asG7dOgYNGsTWrVvp2LFjpdoUQlROdr6BV385wLd/nwUgyNOZpKx8NFj/ervyN92MqFbF1gsRQnWKYh7VKCnZyM+4ubbbDAYXHzDkQWEOFOZdfpx79fuVx8bCy/EYoSDL/GVrWr15pMWQe4NKl0dxTm2F8F62j+E6qiYhc+fOZcyYMYwePRqABQsWsGbNGhYtWsTkyZOL1f/666955ZVXuPfeewEYO3Ysv//+O++99x5LliypVJtCiIrbejyN/363j8SMS2g08FTPcP7TN4KNh1OLrRMSeHmdkP5tglSMuA6QW0VvzGSCrLNXE4zUQ1cTjsLsko/RaKFeOPi1AL8I83f/FlCvMXza1Xz5osQRBY15fsWDn5f/38BouCY5yTMnCoW51zwupaww95rXr092Lj9XLk84NRnMX+WRk1K+ejdJtSSksLCQnTt3MmXKFEuZVquld+/ebNu2rcRjCgoKcHa2vqbs4uLCli1bKt3mlXYLCgosz7OyzBmowWDAYJCJdFf6QPqialXHfs83GHk3+ihfbjsNQIN6Lrz1YGu6hvkAJu6O8OWOZr34+9RFUrML8PdwonOjeui0mmr1Pm6kOvZ7WTSHfkG3/mU02VfnKSgewRj7voHS4j4VIysnkxFjgvkuDeNxNwjvWfkESjFBxmk05w+hSTuCJu0wpB1Gk3YUTSkjAIpGBz6NUXwjzF9+5u/UbwIOJc9j0vR5A90PowENmmsSEeXy2J+xz+soRhMYTeWP3cHN/GXLDaIVxTzKYjAnJpqTW3D4eVyZhxW51Eep5P+BivzfUS0JSUtLw2g0EhAQYFUeEBDAoUOHSjymX79+zJ07l9tuu40mTZoQExPDypUrMRqNlW4TYM6cOcyaNatY+fr163F1da3oW6u1oqOj1Q6hTqou/X4yG5Ye05Gab/4l293fxANh2aQd2M6vB4rX1wEXgHUVvSZeTVSXfi9LUMYOuiR8VPyF7HPofhjFjvBnSfLuUvWBlVNQxg7anl2KiyHdcpfGJb0P+xsMv2HcGsWIa0EqHvnn8MhPtHx3z0/CQSks8RiTRkeOUxDZzsFkO4dc/gomxykQRXv54zAPOAWcOnX5QWm0BIWPt8R+xSV9PeIbDCfphBZO/FrB3qgCiht99T44G9Ip6eKoAlzS+xAdnwH/VC7+vLy8ctdVfWJqRXzwwQeMGTOGFi1aoNFoaNKkCaNHj2bRokU31e6UKVOYNGmS5XlWVhahoaH07dsXT0/Pmw27xjMYDERHR9OnTx/0etnTo6pUl34vLDLx8cbj/N8/CZgU8Pdw4o2Brbi9uZ9qMdlTden3cjEZcfjYfJn5+g8U89wcDV0urKRo6NRqeWlGc+gXdD98zPWXNJwNF+mS8DHGwYtRmvWDiwlo0g6jOX/Y/D3tCFw4hsZYUGK7is4J6jdD8Wt+dXTDNwLqheGi0+MC2GaG4L1gmkrRmW2Wy2D60G501OroaJP27UPTBPhh9OVpqMVHcRzvn8u9NzGCduVqQnmoloT4+vqi0+lISbG+7pSSkkJgYGCJx/j5+bFq1Sry8/O5cOECwcHBTJ48mcaNG1e6TQAnJyecnJyKlev1+ur/S6gKSX+oQ81+P5ScxaQVezmQZP6lcn/7YGY/0BpvV0dV4rE7kxHNqVhC0rfheM4Th8a3Va8Pb0M+5GeaJ0xeyoBTf8E1l2Cup7k8yVD/83jwCTPPcdDoQHvlu+6assuPi5VdW097XZnOfDtpsTLtdecooQ0FWDeZkuZUXPlgdPjxKfPlBKWURbQcXMCvufWcDb8WaOqFgVZX4l/6tqeHpndWyZlspu0g0OmKrfaq8QyG/m/icJO351bk95VqSYijoyO33HILMTExDBw4EACTyURMTAzjx4+/4bHOzs6EhIRgMBj44YcfeOSRR266TSHEVUaTwmebT/B+9BEKjSbquep5bWBbBrSrxZNLq2LxJkUxX5u/lGGdTBT7XsprReVbFK6Y+O9uPnY1mIrM3/Vu5iTDv+U1yUYEeDU0Jzui4lrdDy0GUHRiM3v+XEeHXv1USbpVvRwzadIkRo4cSefOnenatSvz5s0jNzfXcmfLiBEjCAkJYc6cOQDExsaSmJhIhw4dSExMZObMmZhMJl588cVytymEuLGTabn857u97Dx1EYDeLf1548G2tXuhsYos3qQoUJBtnRzkZ5aSTJTwWnnvTiiVBpy9wMXbPMKQfrzsQ1o+AB6B5hEFk9H8XTGZ7xgpVnbtd+PV5yWWGa9r47rHxdq9pr6xnHdq9H8bIp+2/wJedZFWh9KoJ4n/ZNG+0U1MBr4JqiYhQ4YM4fz580yfPp3k5GQ6dOjA2rVrLRNLT58+jfaaLDc/P5+pU6dy4sQJ3N3duffee/n666/x9vYud5tCiJIpisKS7ad449dDXDIYcXdyYHpUKx6+pQGa2vwBUObiTcD3T4BniHnthvzM0i8PlJfWAZy9ryYTzt7Fv5f2mqPH1b/+TUaY16bsW0UfXly9LisBJPwJX5Zj3kFAK0lAajHVJ6aOHz++1EslGzdutHp+++23c+BACdPwK9CmEKK4pMxLvPj9Pv48mgZAt8b1eefhdjSoV8vuDlMUyE66uj5E6kE4E1fGEtyY/2LPOGldpnO6LknwKn8y4ehmmw9Wrc58uejbEVDaMnH936x+CQiY1zHxDC47gWrUvaojE1VI9SRECKEeRVH4cXciM1b/Q3Z+EU4OWibf04KR3cLQ1uTVTRUFMs9cswLmlVUwD1d+JcrbJ0PrgVeTCb0tF3O4Ca3uN18uKnFL+Ter75byNTmBEjYjSYgQdVRaTgGv/Lifdf+Y7yZrH+rN3Efa08TPXeXIKsBkgoxTxZfbTjtiXimyJBqdeRGqKxMcATa/U/a5wnqaJ0ZWR5cnGda4FVNragIlbEaSECHqoLXxybzy434u5Bai12mYcHcznrm9CQ46G9xpYI/lw01GuHjSelQj9SCkHYWiSyUfo9WDbzPruyn8WoBPE3BwtG57z9Kaf1lAq6uSvT5srprcpSHUIUmIEHVI5iUDs37+h5W7EgFoEejBe4+0p3Wwl21OcPk21+J/1ZbzNlejAdITrkk2LiccaUehlIWp0DmBb/MSko1w866hZZHLAuqrBndpCHVIEiJEHfHn0fO8+P0+kjLz0WrgX7c3YWLvZjg52OgXfkVucy0qgAvHi+9ceuFY6bdtFluY6vKaEZcXpropcllACFVIEiJELZdXWMScXw/x9XbzPhhh9V1575H23NLIx3YnKc9trj/9G/atMM/XuHC89NtcHd2Lj2pUxcJUcllAiConSYgQtdjOU+n859u9nLxg3lBqRLdGTL6nBa6ONv6vf2pr2be5FmTDoV+uPnfyupxkXF1u25xsNFBvXQi5LCBElZIkRIhaqKDIyPvRR/ls83FMCgR5OfPOQ+3p2czXNifIToZzeyBpLyTtMSch5dFuGLQfYk44PAJlESoh6jhJQoSoZf45l8l/vt3LoeRsAB7sFMKMqNZ4uVRiEzzFvAEaSXutk46clLKOLFnH4TXzDg4hhF1IEiJELVFkNLFg03E+iDmKwahQ382RNx5sS7/Wpe8gbUVRIOO0Ocm4NunISyteV6M1j2YEtYegDhDQBlY+ZR4hqcm3uQohqpQkIULUAsfP5/Cfb/ey50wGAP1aB/D6oLb4ujuVfICiQPqJqyMbSXvNX5cuFq+rdTDfiRJ8OeEI6gABrcHxuiXd73lbbnMVQlSIJCFC1GAmk8KX207y1tpD5BtMeDg7MOv+1gzqGHJ10zmTybzT6rk91yQc+6Ags3iDWr15w7CgDuZRjuAO4N8a9OXYQVducxVCVJAkIUJURyYjmlNbCEnfhuaUJ5Rwq+jZi3n897t9bDtxAYBezXx5+8HWBBnOmm+FvXJJJXlfyUuY65zMIxrBHa5eVvFvZb2aaEXV1OXDhRCqkCREiOrm8qqjDlnn6Axwar7VqqOKovDdzrO8/vN+ggpPMczxFCPDMohQTqD5dD8Y8oq36eACgW2vjm4EtTfP6SjPiqIVVVOXDxdCVDlJQoSoTi6vOqqgcO3Nq0pWEppvHyev3UhiE9JpnnmAWM1pnJ0ury56+prKejcIand1dCO4A9RvBjr57y6EqF7kt5IQ1cXlVUevT0AANJcnerru+5I7AS4vHKo4eqC5dnQjqIN5h1i5/CGEqAEkCRGiuri86mhZy3dt0vei6e1DCGnZHU29cPsuZS6EEHYkSYgQ1UFRAaa9KyhPOtHt3hE4dnzE7iEJIYS9SRIihJoK82DnF7D1Q7TZSeU65GieG63tG5UQQlQJSUKEUEN+Fuz4HLZ9almR9JKTP4X5OXiQh7aEazImBZKpzzHXtpKECCFqBbmYLERVykuHDa/DvDYQM9ucgNQLg6gP2Dt4Ey8angbMCce1rjyfZXgcf0+3qo1ZCCHsREZChKgK2Smw7SPYsQgMueYy3wjo9R9oMxh0DnQxKUx078XYHJih/4pg0i2HJ1Of2YbH2edxG13DfVR6E0IIYVuShAhhTxln4K8PYNdXYCwwlwW2hdv+Cy2irO5s0Wk1tAzyZN3hrkQXdKar9hD+ZJCKNztMLTChZX5UK3QlXasRQogaSJIQIezhwnHYMhf2LgdTkbmsQVdz8tGsD2iKJxK/H0jhj8PnAfBydWJ7XivLa0FezsyIakX/NkFVEr4QQlQFSUKEsKXUg/DnexD/Aygmc1n4bebkI6xXickHQHJmPv/9fi8AT/YM5+V7W7LtWCrr/4ylb69IujX1lxEQIUStI0mIELZwbjdsfhcO/XK1rFk/uO0FCO16w0ONJoWJK3ZzMc9A62BPXuwfgU6rITLchwsHFSLDfSQBEULUSpKECHEzTm2Dze/A8ZjLBRrzTrK9/mNeRr0c5m88xvYT6bg66vhoWEecHGTJdSFE3SBJiBAVpShw4g/Y/B6c2mIu0+ig7cPQaxL4RZS7qZ2n0nn/96MAzH6gDY393O0RsRBCVEuShAhRXooCh3+DP9+FxJ3mMq0eOg6HHhPBJ7xCzWVeMvDcN3swmhQGdghmcKcQ28cshBDVmCQhQpTFZIQDq+DPuZASby5zcIFbRkH3Z8Gr4smDoihMWbmPxIxLNKrvyqsD26ApZdKqEELUVqqvmPrJJ58QFhaGs7MzkZGRxMXF3bD+vHnziIiIwMXFhdDQUJ5//nny8/Mtr8+cORONRmP11aJFC3u/DVEbGQ2weyl80hW+f8KcgDh6QM/nYeJ+uOfNSiUgAMt3nOHX/ck4aDV8OLQjHs56GwcvhBDVn6ojIStWrGDSpEksWLCAyMhI5s2bR79+/Th8+DD+/v7F6i9btozJkyezaNEiunfvzpEjRxg1ahQajYa5c+da6rVu3Zrff//d8tzBQQZ8RAUY8mHPEtjyAWSeNpc5e8Ot/4bIp8Gl3k01fzQlm1k//wPAf/tF0D7U++biFUKIGkrVT+e5c+cyZswYRo8eDcCCBQtYs2YNixYtYvLkycXqb926lR49evDoo48CEBYWxrBhw4iNjbWq5+DgQGBgoP3fgKhdCnPh78Ww9SPISTaXufmZL7l0fgKcPG76FPkGI89+s5t8g4lezXwZ06vxTbcphBA1lWpJSGFhITt37mTKlCmWMq1WS+/evdm2bVuJx3Tv3p0lS5YQFxdH165dOXHiBL/++iuPP/64Vb2jR48SHByMs7Mz3bp1Y86cOTRs2LDUWAoKCigoKLA8z8rKAsBgMGAwGG7mbdYKV/qg1vZFfhbanQvRxi1Ak3cBAMUjGFO35zB1GA56F3M9G7z/V38+yKHkbOq7OfLWoNYYjUUYjSXXrfX9Xk1Jv6tD+l0d9uj3irSlURRFKbua7Z07d46QkBC2bt1Kt27dLOUvvvgimzZtKja6ccWHH37ICy+8gKIoFBUV8cwzzzB//nzL67/99hs5OTlERESQlJTErFmzSExMJD4+Hg+Pkv+SnTlzJrNmzSpWvmzZMlxdXW/ynQrVKCbq5xzG2ZBBvt6bC+4RoLk6DcqxKJvGqetonPY7emMeADmO/hwNjOJMvR4oWtvm6PvSNSw8bF4D5JmWRlp6q/JfTwgh7CovL49HH32UzMxMPD09b1i3RiUhGzduZOjQobz22mtERkZy7NgxJkyYwJgxY5g2bVqJ58nIyKBRo0bMnTuXJ598ssQ6JY2EhIaGkpaWVmYH1gUGg4Ho6Gj69OmDXl8zJlBqDv2Cbv3LaLLPWcoUj2CMfd9ACemMNvZTtLu+QGMwJx+KbwTGHs+jtBoINk4+AJIy84n6ZCuZl4p4skcjJvcvey2RmtjvtYH0uzqk39Vhj37PysrC19e3XEmIapdjfH190el0pKSkWJWnpKSUOp9j2rRpPP744zz11FMAtG3bltzcXJ5++mleeeUVtNriN/t4e3vTvHlzjh07VmosTk5OODk5FSvX6/Xyn+EaNaY/DqyGH0YD1vm1JjsJhx9GmZOMK5vKBbWH2/6LJmIADiX8/NiC0aTwwvfxZF4qol0DL166pxV6h/Kfq8b0ey0j/a4O6Xd12LLfK9KOarfoOjo6cssttxATE2MpM5lMxMTEWI2MXCsvL69YoqHTmYe3SxvQycnJ4fjx4wQFye6jdYLJCGtf4voExOxymakIGkTC8O/h6U3QMgrslIAAfLThKHEn03Fz1PHh0I44ViABEUKI2kzVu2MmTZrEyJEj6dy5M127dmXevHnk5uZa7pYZMWIEISEhzJkzB4CoqCjmzp1Lx44dLZdjpk2bRlRUlCUZeeGFF4iKiqJRo0acO3eOGTNmoNPpGDZsmGrvU1ShU1sh61zZ9e6eat7d1s7iEtL5MMa8LPvrg9oS5utm93MKIURNoWoSMmTIEM6fP8/06dNJTk6mQ4cOrF27loCAAABOnz5tNfIxdepUNBoNU6dOJTExET8/P6Kionj99dctdc6ePcuwYcO4cOECfn5+9OzZk+3bt+Pn51fl70+oICel7DoAOan2jQPIyCtk4vLdmBR4sFMIAzvKsuxCCHEt1VfxGj9+POPHjy/xtY0bN1o9d3BwYMaMGcyYMaPU9pYvX27L8ERN4x5g23qVpCgKL/2wj3OZ+YT7ujH7gTZ2PZ8QQtREFb44HRYWxuzZszl9+rQ94hHi5jTqDp7BN6igAc8Qcz07WhJ7mnX/pKDXmZdld3dSPd8XQohqp8JJyMSJE1m5ciWNGzemT58+LF++3Or2ViFUpdVB8/6lvHh5g7j+b5rr2cmh5Cxe/eUAAC/1b0HbBl52O5cQQtRklUpC9uzZQ1xcHC1btuTZZ58lKCiI8ePHs2vXLnvEKET5XTwJ+741P3a67v50z2B45Ctodb/dTn+p0Mizy3ZTWGTijgg/nugRbrdzCSFETVfpewU7derEhx9+aLkD5X//+x9dunShQ4cOLFq0qNRbZoWwG5MJVo2Dwhxo2B3+exxG/gKDF5q/T9xv1wQE4NU1BziamoOfhxPvPtwerVZj1/MJIURNVukL1QaDgR9//JHFixcTHR3NrbfeypNPPsnZs2d5+eWX+f3331m2bJktYxXixuL+D05tAb0bDPwEHBwhvFeVnf63/Uksiz2NRgPvP9IBX/fiC+AJIYS4qsJJyK5du1i8eDHffPMNWq2WESNG8P7779OiRQtLnUGDBtGlSxebBirEDZ0/Ar/PND/u+yr4VO3utGcv5vHSD/sAeOb2JvRs5lul5xdCiJqowklIly5d6NOnD/Pnz2fgwIElLs8aHh7O0KFDbRKgEGUyFsGqZ6AoH5rcBZ2fqNLTFxlNTFy+h6z8IjqEejOpT/MqPb8QQtRUFU5CTpw4QaNGjW5Yx83NjcWLF1c6KCEq5K95kLgTnLzg/o9BU7XzMD6MOcrfpy7i4eTAR8M6otfJsuxCCFEeFf5tmZqaWuIOt7Gxsfz99982CUqIckveDxvfND++923wqtpVSbcdv8BHf5g3R3z9wbaE+rhW6fmFEKImq3ASMm7cOM6cOVOsPDExkXHjxtkkKCHKpagQfnwGTAZocR+0G1Klp0/PLWTiit0oCjzSuQH3t7/RImlCCCGuV+Ek5MCBA3Tq1KlYeceOHTlw4IBNghKiXDa9CSnx4Fof7nu/Si/DKIrCi9/vJSWrgMZ+bsy8v3WVnVsIIWqLCichTk5OpKQU3yQsKSkJBwdZmlpUkbN/w5b3zY8HzAV3/yo9/VfbTvH7wVQcdVo+GtYRV0f52RdCiIqqcBLSt29fpkyZQmZmpqUsIyODl19+mT59+tg0OCFKVJgHP/4LFBO0fRhaD6zS0x84l8Xrvx4EYMq9LWgdLMuyCyFEZVT4z7d3332X2267jUaNGtGxY0cA9uzZQ0BAAF9//bXNAxSimA2vwoVj4BEE975TpafOKyzi2W92UVhk4u4W/ozqHlal5xdCiNqkwklISEgI+/btY+nSpezduxcXFxdGjx7NsGHDSlwzRAibSvgTtn9qfnz/R+BSr0pPP2v1AY6fzyXA04l3Hm6PpopvBxZCiNqkUhey3dzcePrpp20dixA3VpANP/3b/LjTSGhWtZf/ft57jhV/nzEvyz6kAz5ujlV6fiGEqG0qPZvuwIEDnD59msLCQqvy+++37wZhog5b9wpknAbvhtDv9So99Zn0PF5euR+AcXc0pXsTWZZdCCFuVqVWTB00aBD79+9Ho9FYdsu9MixtNBptG6EQAEejYdeX5scPfApOHlV2aoPRxHPLd5NdUESnht5M7N2sys4thBC1WYXvjpkwYQLh4eGkpqbi6urKP//8w+bNm+ncuTMbN260Q4iizstLh5/Gmx/f+u8q3RkX4P3oI+w+nYGHswMfDO2IgyzLLoQQNlHhkZBt27axYcMGfH190Wq1aLVaevbsyZw5c3juuefYvXu3PeIUddlvL0FOMtRvBndPr9JT/3UsjfmbjgPw5oPtZFl2IYSwoQr/SWc0GvHwMA+F+/r6cu7cOQAaNWrE4cOHbRudEAd+gv3fgkYLgxaA3qXKTn0hp4DnV+xBUWBY11AGtAuqsnMLIURdUOGRkDZt2rB3717Cw8OJjIzk7bffxtHRkc8++4zGjRvbI0ZRV+Wkwi/Pmx/3fB4adK6yUyuKwgvf7SU1u4Cm/u5Mv0+WZRdCCFurcBIydepUcnNzAZg9ezb33XcfvXr1on79+qxYscLmAYo6SlHMCUjeBQhoA7e/VKWnX/zXSf44fB5HBy0fP9oRF0ddlZ5fCCHqggonIf369bM8btq0KYcOHSI9PZ169erJwk3CdvatgEO/gFZvvgzj4FRlp45PzOTN3w4BMG1AS1oEelbZuYUQoi6p0JwQg8GAg4MD8fHxVuU+Pj6SgAjbyUyEX180P75jMgS2rbJT5xYU8dw3uyk0mujbKoDHbm1UZecWQoi6pkJJiF6vp2HDhrIWiLAfRYHV46EgE0JugR4Tq/T0M1b/w4m0XIK8nHn7oXaSXAshhB1V+O6YV155hZdffpn09HR7xCPqur8XwfEN4OAMAxeArtKL+lbYT3sS+X7nWbQamDekA96usiy7EELYU4V/w3/88cccO3aM4OBgGjVqhJubm9Xru3btsllwoo5JPwHrp5kf3z0D/JpX2alPXcjllR/NlxmfvasZkY3rV9m5hRCirqpwEjJw4EA7hCHqPJMRVo0DQy406gmRz1TZqQuLTDz3zW5yCoroGubDs3c1rbJzCyFEXVbhJGTGjBn2iEPUddvnw+mt4OgOAz8BbdUtjf5e9GH2ns3Ey0XP+0M7yLLsQghRRVT/bfvJJ58QFhaGs7MzkZGRxMXF3bD+vHnziIiIwMXFhdDQUJ5//nny8/Nvqk2hstRDEDPb/Ljf61AvrMpOvfnIef5v0wkA3hrcjhDvqluRVQgh6roKJyFarRadTlfqV0WsWLGCSZMmMWPGDHbt2kX79u3p168fqampJdZftmwZkydPZsaMGRw8eJCFCxeyYsUKXn755Uq3KVRmNMCqZ8BYAE17Q6eRVXbq89kFTPp2LwCP3dqQ/m0Cq+zcQgghKnE55scff7R6bjAY2L17N19++SWzZs2qUFtz585lzJgxjB49GoAFCxawZs0aFi1axOTJk4vV37p1Kz169ODRRx8FICwsjGHDhhEbG1vpNoXKtrwP53aDsxfc/xFU0S2xJpN5Wfa0nAIiAjyYOqBVlZxXCCHEVRVOQh544IFiZQ899BCtW7dmxYoVPPnkk+Vqp7CwkJ07dzJlyhRLmVarpXfv3mzbtq3EY7p3786SJUuIi4uja9eunDhxgl9//ZXHH3+80m0CFBQUUFBQYHmelZUFmBMsg8FQrvdTm13pA5v3RfI+HDa9hQYo6vcmiosfVFF/L/zrJJuOnMfJQcv7D7dFhwmDwVQl5y4vu/W7uCHpd3VIv6vDHv1ekbZstgjDrbfeytNPP13u+mlpaRiNRgICAqzKAwICOHToUInHPProo6SlpdGzZ08URaGoqIhnnnnGcjmmMm0CzJkzp8RRnPXr1+PqKlu3XxEdHW2ztrQmA7cfnoGnqYhzXp3ZccoVTv9qs/Zv5HQOzIvXARoeaGjg6M7NHK2SM1eOLftdlJ/0uzqk39Vhy37Py8srd12bJCGXLl3iww8/JCQkxBbNlWrjxo288cYbfPrpp0RGRnLs2DEmTJjAq6++yrRp0yrd7pQpU5g0aZLleVZWFqGhofTt2xdPT9k3xGAwEB0dTZ8+fdDr9TZpU/vHq+jyz6K4+uI3egn3uvnapN2y5BQUMfDT7RiVPPq18ue1oe2r7aqo9uh3UTbpd3VIv6vDHv1+5WpCeVQ4Cbl+ozpFUcjOzsbV1ZUlS5aUux1fX190Oh0pKSlW5SkpKQQGljxBcNq0aTz++OM89dRTALRt25bc3FyefvppXnnllUq1CeDk5ISTU/EN0vR6vfxnuIbN+uN0LGz7CABN1AfovYNuvs1yenXlP5xKzyPE24W3H+qAo2P1//eVn0N1SL+rQ/pdHbbs94q0U+Ek5P3337dKQrRaLX5+fkRGRlKvXr1yt+Po6Mgtt9xCTEyMZQE0k8lETEwM48ePL/GYvLw8tNetH3HljhxFUSrVpqhihbnmu2EUE7QbCi3vq7JTr9x1lpW7E9Fq4IOhHfBylV90QgihpgonIaNGjbLZySdNmsTIkSPp3LkzXbt2Zd68eeTm5lrubBkxYgQhISHMmTMHgKioKObOnUvHjh0tl2OmTZtGVFSUJRkpq02hst9nmZdn9wiGe96066mMJoW4hHRSs/MxmRSm/rgfgIm9m9M5zMeu5xZCCFG2Cichixcvxt3dnYcfftiq/LvvviMvL4+RI8u/zsOQIUM4f/4806dPJzk5mQ4dOrB27VrLxNLTp09bjXxMnToVjUbD1KlTSUxMxM/Pj6ioKF5//fVytylUdGITxP2f+fEDH4FL+UfOKmptfBKzfj5AUqb1QnbN/N0Zd6csyy6EENVBhZOQOXPm8H//93/Fyv39/Xn66acrlIQAjB8/vtRLJRs3brR67uDgwIwZM8pcOv5GbQqV5GfBT+PMjzs/YV6YzE7WxicxdskulBJeO5qaQ/SBZPq3qbp5KEIIIUpW4RVTT58+TXh4eLHyRo0acfr0aZsEJWqhdVMg8wx4N4I+r9rtNEaTwqyfD5SYgABogFk/H8BoKq2GEEKIqlLhJMTf3599+/YVK9+7dy/168v256IEh9fC7iWABgbOByd3u50qLiG92CWYaylAUmY+cQnpdotBCCFE+VQ4CRk2bBjPPfccf/zxB0ajEaPRyIYNG5gwYQJDhw61R4yiJstLh5+fMz/uNg7Cetj1dKnZpScglaknhBDCfio8J+TVV1/l5MmT3H333Tg4mA83mUyMGDGCN954w+YBihru1xcgJwV8I+CuqXY/nb+Hs03rCSGEsJ8KJyGOjo6sWLGC1157jT179uDi4kLbtm1p1KiRPeITNVn8Soj/ATQ6GDQf9C52P2WgpzNaDZQ25UMDBHo50zVcbtEVQgi1VXrZ9mbNmtGsWTNbxiJqk+wUWPMf8+Ne/4GQW+x+yrMX83hsYewNExCAGVGt0Gmr51LtQghRl1R4TsjgwYN56623ipW//fbbxdYOEXWUopjngVxKh8C2cNt/7X7K5Mx8hv8vlsSMS4T7uvHWg20J8rK+5BLo5cz8xzrJ7blCCFFNVHgkZPPmzcycObNY+T333MN7771ni5hETbdnGRxZC1o9DPo/cHC06+lSs/N59H/bOXUhj1AfF5aNiSTIy4WHOodaVkz19zBfgpERECGEqD4qnITk5OTg6Fj8Q0Wv11do5zxRS2WcgbWTzY/vfBkCWtv1dOm5hTz2v1hOnM8l2MuZZU/dSpCXee6JTquhWxO5bVwIIaqrCl+Oadu2LStWrChWvnz5clq1amWToEQNZTLB6vFQkAUNukD35+x6usw8A4/9L5YjKTkEeDqxbMythPq42vWcQgghbKfCIyHTpk3jwQcf5Pjx49x1110AxMTEsGzZMr7//nubByhqkL8XwomN4OACAxeArtLznsuUlW9gxKJYDiRl4evuyNKnbiXM181u5xNCCGF7Ff6UiIqKYtWqVbzxxht8//33uLi40L59ezZs2ICPj9z2WGddOA7R082P+8wCX/ttEpdbUMToxTvYezaTeq56lj51K0397bcKqxBCCPuo1J+qAwYMYMCAAQBkZWXxzTff8MILL7Bz506MRqNNAxQ1gMkIq8aCIQ/CekGXMXY71aVCI09+uYOdpy7i6ezA109GEhHoYbfzCSGEsJ8Kzwm5YvPmzYwcOZLg4GDee+897rrrLrZv327L2ERNse1jOBMLjh7wwCegrfSP1Q3lG4w8/fXfbD+RjruTA189GUmbEC+7nEsIIYT9VWgkJDk5mS+++IKFCxeSlZXFI488QkFBAatWrZJJqXVV6kHY8Jr5cf83oJ59Vs4tLDLx76W7+PNoGq6OOr4Y3YUOod52OZcQQoiqUe4/WaOiooiIiGDfvn3MmzePc+fO8dFHH9kzNlHdGQ3w47/AWAjN+kHHx+1yGoPRxLPf7GLDoVSc9VoWjuxC5zCZfySEEDVduUdCfvvtN5577jnGjh0ry7ULs83vQtJecPaG+z8Eje0XAisymnh+xR7W/ZOCo4OWz0d0lrU/hBCilij3SMiWLVvIzs7mlltuITIyko8//pi0tDR7xiaqs3O7YfM75scD3gOPQJufwmRSePH7ffyyLwm9TsOCxzrRq5mfzc8jhBBCHeVOQm699VY+//xzkpKS+Ne//sXy5csJDg7GZDIRHR1Ndna2PeMU1YkhH358BhQjtBoIbQbb/BQmk8LLP+5n5e5EdFoNHw3rxF0tAmx+HiGEEOqp8G0Mbm5uPPHEE2zZsoX9+/fzn//8hzfffBN/f3/uv/9+e8Qoqps/Xofzh8DNDwbMtfllGEVRmPnzPyzfcQatBuYN6UD/NrYfaRFCCKGum7qXMiIigrfffpuzZ8/yzTff2ComUZ2d2gZbL09IjvoQ3Gw7P0NRFF5fc5Cvtp1Co4F3H25PVPtgm55DCCFE9WCTdbV1Oh0DBw5k4MCBtmhOVCcmI5pTWwhJ34bmmB7WTQYU6DAcWtxr01MpisI76w7zvy0JAMwZ1JYHOzWw6TmEEEJUH/bb3EPUfAdWw9qXcMg6R2eAU/PN5S71of8cm5/uw5hjfLrxOACzH2jN0K4NbX4OIYQQ1Yd9lrYUNd+B1fDtCMg6V/y1SxfgxCabnm7+xuO8//sRAKYOaMmIbmE2bV8IIUT1I0mIKM5khLUvAUopFTSwdrK5ng0s3JLAW2sPAfDffhE81auxTdoVQghRvUkSIoo7tbXkERALBbISzfVu0tfbT/HqLwcAeO7uZoy703677wohhKheZE6IuKogB05ugbjPylc/J+WmTvftjjNMWxUPwDO3N+H53rISrxBC1CWShNRlJhMk74XjG+D4H3B6O5gM5T/evfKLh63anchLK/cBMLpHGC/1j0Bjh2XfhRBCVF+ShNQ1WefMCcfxDXDiD8i7YP26d0NofCcc/BkuXaTkeSEa8AyGRt0rFcKafUlM+nYPigKP3dqQ6fe1kgRECCHqIElCarvCPDi91Zx4HIuB8wetX3d0h/DboMld5i+fxuYVUJv2Nt8dgwbrRORystD/TdDqKhzO+n+SmbB8NyYFHuncgNn3t5EERAgh6qhqMTH1k08+ISwsDGdnZyIjI4mLiyu17h133IFGoyn2NWDAAEudUaNGFXu9f//+VfFW1KcokBwPf30AXz0Ab4XBksGw7ePLCYgGgjvBbf+F0b/BSydh2DfQdQzUb3J1CfZW98MjX4FnkHX7nsHm8lYVX6L/j8OpjFu2iyKTwsAOwcx5sB1arSQgQghRV6k+ErJixQomTZrEggULiIyMZN68efTr14/Dhw/j7+9frP7KlSspLCy0PL9w4QLt27fn4YcftqrXv39/Fi9ebHnu5ORkvzehtpxU60ss108Y9Qy5OtLR+A5w9Slfu63uhxYDKDqxmT1/rqNDr344NL6tUiMgfx1L419f78RgVBjQNoh3H26PThIQIYSo01RPQubOncuYMWMYPXo0AAsWLGDNmjUsWrSIyZMnF6vv42P9Abp8+XJcXV2LJSFOTk4EBpZv07OCggIKCgosz7OysgAwGAwYDBWYqFlVivLRnIlDk/AH2uN/oEmNt3pZ0buiNOyO0vhOTI3vgvpNrTeZq+B7MgRHkuiTRavgSBSjCYymCh0fdzKdJ7/aRWGRid4t/HhncGsUkxGDjdYZqa2u/OxVy5/BWkz6XR3S7+qwR79XpC2NoiilrUhld4WFhbi6uvL9999b7TszcuRIMjIy+Omnn8pso23btnTr1o3PPrt6W+moUaNYtWoVjo6O1KtXj7vuuovXXnuN+vVL3mxt5syZzJo1q1j5smXLcHV1rfgbszVFwSP/HH7Z+/HPiqd+ziEclEKrKhkuYaR6tuG8RxvS3Zph0upVCtZaQjbMP6CjwKShpbeJpyJMOFSLi4BCCCHsIS8vj0cffZTMzEw8PT1vWFfVJOTcuXOEhISwdetWunXrZil/8cUX2bRpE7GxsTc8Pi4ujsjISGJjY+nataul/MroSHh4OMePH+fll1/G3d2dbdu2odMVv5RQ0khIaGgoaWlpZXZguZiMaM5sM18mcQ9ACe1W9iWNvAtoEjahPbERTcIfaLKTrF5W3APMIx3hd6CE3w5ufjcfZykMBgPR0dH06dMHvb78yc3+xExGLN5JTkER3Rv78H+PdcRZX/FLOXVVZftd3Bzpd3VIv6vDHv2elZWFr69vuZIQ1S/H3IyFCxfStm1bqwQEYOjQoZbHbdu2pV27djRp0oSNGzdy9913F2vHycmpxDkjer3+5v9RLm8CZ7UCqWcw9H/LenJnUSGcjbu8ZscGOLcHq7tSHJzNt8Q2uQua3I3GvyUajaZKZxZXpD8OnMti9Je7yCkoomuYD/8b1QVXxxr946Yam/wcigqTfleH9Ls6bNnvFWlH1U8FX19fdDodKSnWEylTUlLKnM+Rm5vL8uXLmT17dpnnady4Mb6+vhw7dqzEJMRurmwCd/1aG1lJ5vJ73jY/P74BTv4JhTnW9fxbQ9PLE0obdgO9S5WEfbOOpGTz2MJYMi8Z6NjQm0WjJQERQghRnKqfDI6Ojtxyyy3ExMRY5oSYTCZiYmIYP378DY/97rvvKCgo4LHHHivzPGfPnuXChQsEBQWVWddmbrgJ3OWy3/5rXezqe/UuliZ3gkf5JtZWJyfO5/Do57Gk5xbSNsSLL0Z3xd1JEhAhhBDFqf7pMGnSJEaOHEnnzp3p2rUr8+bNIzc313K3zIgRIwgJCWHOnDlWxy1cuJCBAwcWm2yak5PDrFmzGDx4MIGBgRw/fpwXX3yRpk2b0q9fvyp7X2VvAndZYDto8yA0uRsC2oC25s7aPHUhl0c/jyUtp4AWgR58/WRXvFxkWFUIIUTJVE9ChgwZwvnz55k+fTrJycl06NCBtWvXEhBg3pfk9OnTaK/7YD58+DBbtmxh/fr1xdrT6XTs27ePL7/8koyMDIKDg+nbty+vvvpq1a4VUt7N3XpMgLYP2TeWKnD2Yh6Pfh5LclY+zfzdWfpUJN6ujmqHJYQQohpTPQkBGD9+fKmXXzZu3FisLCIigtJu6nFxcWHdunW2DK9yyru5201sAlddJGfm8+jnsSRmXKKxrxtLx0RS370WLw4nhBDCJmru2H9116i7+S4YSlsVVGNeybSSm8BVF6nZ+Tz6+XZOp+cR6uPC0jGR+Hs4qx2WEEKIGkCSEHvR6sy34QLFE5Gb2wSuuriQU8Bj/4vlRFouId4uLHvqVoK8asYdPEIIIdQnSYg92WETuOoiI6+QxxfGcSQlhwBPJ5Y+FUmoTzVYXVYIIUSNUS3mhNRqlzeB49RWy4qpNOpeo0dAsvINjFgUx4GkLHzdnVj61K2E+bqpHZYQQogaRpKQqqDVQXgvtaOoFKNJITYhnZ1pGuonpNM21IfRi+PYdzaTeq56lj4VSVN/d7XDFEIIUQNJEiJKtTY+iVk/HyApMx/Q8dXRv3HUaSg0Kng6O/D1k5FEBHqoHaYQQogaSpIQUaK18UmMXbKr2HqvhUZzyb/vaEqbEK+qD0wIIUStIRNTRTFGk8Ksnw+UuOD8FV9uO4nRpNoGzEIIIWoBSUJEMXEJ6ZcvwZQuKTOfuIT0KopICCFEbSRJiCgmNfvGCUhF6wkhhBAlkSREFFPeFU9lZVQhhBA3Q5IQUUzXcB+CvEpPMDRAkJczXcN9qi4oIYQQtY4kIaIYnVbDv25vXOJrVxagnxHVCp22tH1xhBBCiLJJEiKKURSFmIOpADg6WP+IBHo5M/+xTvRvE1TSoUIIIUS5yTohophf9yfz59E0HB20/PZcL5Iycln/Zyx9e0XSram/jIAIIYSwCUlChJWcgiJe/eUAAM/c3oQm/u40rOfEhYMKkeE+koAIIYSwGbkcI6x8GHOU5Kx8Qn1c+PcdTdQORwghRC0mSYiwOJKSzaItCQDMur81zvqau9OvEEKI6k+SEAGYJ6NOXRVPkUmhT6sA7moRoHZIQgghajlJQgQAq/YkEpeQjrNey4yoVmqHI4QQog6QJESQecnA62sOAfDsXc1oUM9V5YiEEELUBZKECN6PPkJaTgGNfd14qle42uEIIYSoIyQJqePiEzP5attJAGY/0AYnB5mMKoQQompIElKHmUwK036Kx6TAgHZB9Gzmq3ZIQggh6hBJQuqw73aeYffpDNwcdUwbIJNRhRBCVC1JQuqoi7mFvPmbeTLqxN7NCbzBrrlCCCGEPUgSUke9ve4wF/MMNA9wZ1SPMLXDEUIIUQdJElIH7TmTwfIdpwF49YE26HXyYyCEEKLqyadPHWM0KUxdtR9FgQc7hhDZuL7aIQkhhKijqkUS8sknnxAWFoazszORkZHExcWVWveOO+5Ao9EU+xowYICljqIoTJ8+naCgIFxcXOjduzdHjx6tirdS7S2LPUV8YhYezg5Mubel2uEIIYSow1RPQlasWMGkSZOYMWMGu3bton379vTr14/U1NQS669cuZKkpCTLV3x8PDqdjocffthS5+233+bDDz9kwYIFxMbG4ubmRr9+/cjPz6+qt1UtpeUU8M66wwC80DcCPw8nlSMSQghRl6mehMydO5cxY8YwevRoWrVqxYIFC3B1dWXRokUl1vfx8SEwMNDyFR0djaurqyUJURSFefPmMXXqVB544AHatWvHV199xblz51i1alUVvrPqZ86vh8jKL6J1sCeP3dpI7XCEEELUcQ5qnrywsJCdO3cyZcoUS5lWq6V3795s27atXG0sXLiQoUOH4ubmBkBCQgLJycn07t3bUsfLy4vIyEi2bdvG0KFDi7VRUFBAQUGB5XlWVhYABoMBg8FQqfdW3fx96iI/7DoLwIz7WmAyFmEylu/YK31QW/qippB+V4f0uzqk39Vhj36vSFuqJiFpaWkYjUYCAqy3jQ8ICODQoUNlHh8XF0d8fDwLFy60lCUnJ1vauL7NK69db86cOcyaNatY+fr163F1rfmbuRkVeGefDtDQzd9E0v6tJO2veDvR0dE2j02UTfpdHdLv6pB+V4ct+z0vL6/cdVVNQm7WwoULadu2LV27dr2pdqZMmcKkSZMsz7OysggNDaVv3754enrebJiqW7z1FEl5h/F20TPviR74uDlW6HiDwUB0dDR9+vRBr9fbKUpxPel3dUi/q0P6XR326PcrVxPKQ9UkxNfXF51OR0pKilV5SkoKgYGBNzw2NzeX5cuXM3v2bKvyK8elpKQQFBRk1WaHDh1KbMvJyQknp+KTNPV6fY3/z5CSlc+HG44D8NI9LQjwdqt0W7WhP2oi6Xd1SL+rQ/pdHbbs94q0o+rEVEdHR2655RZiYmIsZSaTiZiYGLp163bDY7/77jsKCgp47LHHrMrDw8MJDAy0ajMrK4vY2Ngy26yNXltzkJyCIjqEejOkc6ja4QghhBAWql+OmTRpEiNHjqRz58507dqVefPmkZuby+jRowEYMWIEISEhzJkzx+q4hQsXMnDgQOrXt15sS6PRMHHiRF577TWaNWtGeHg406ZNIzg4mIEDB1bV26oW/jqWxs97z6HVwGsD26DVatQOSQghhLBQPQkZMmQI58+fZ/r06SQnJ9OhQwfWrl1rmVh6+vRptFrrAZvDhw+zZcsW1q9fX2KbL774Irm5uTz99NNkZGTQs2dP1q5di7Nz3dmkrbDIxPSf4gF47NZGtAnxUjkiIYQQwprqSQjA+PHjGT9+fImvbdy4sVhZREQEiqKU2p5Go2H27NnF5ovUJf/bcoLj53PxdXfkP30j1A5HCCGEKEb1xcqE7SVmXOKjmGMATLmnJV4uMslLCCFE9SNJSC00++d/uGQw0jXMhwc7hagdjhBCCFEiSUJqmT8Op7LunxR0Wg2zB7ZGo5HJqEIIIaonSUJqkXyDkZmr/wFgdPcwWgTW/IXWhBBC1F6ShNQiCzYd59SFPAI8nZjYp7na4QghhBA3JElILXHqQi6fbjSvjDp1QCvcnarFjU9CCCFEqSQJqQUURWHm6n8oLDLRs6kv97ULKvsgIYQQQmWShNQC6w+k8Mfh8+h1GmY9IJNRhRBC1AyShNRweYVFzP75AABjejWmiZ+7yhEJIYQQ5SNJSA338YZjJGZcIsTbhfF3NVU7HCGEEKLcJAmpwY6l5vD5nycAmB7VCldHmYwqhBCi5pAkpIZSFIUZq+MxGBXujPCjb6sAtUMSQgghKkSSkBrql31J/HXsAo4OWmbeL5NRhRBC1DyShNRAOQVFvLbGPBn133c0oVF9N5UjEkIIISpOkpAaaF70EVKyCmhU35Vnbm+idjhCCCFEpUgSUsMcTs5m8daTAMy8vzXOep26AQkhhBCVJElIDaIoCtN+isdoUujXOoA7I/zVDkkIIYSoNElCapAfdycSl5COi17H9KjWaocjhBBC3BRJQmqIzEsG3vj1IADP3t2UEG8XlSMSQgghbo4kITXE3PWHScsppImfG0/1bKx2OEIIIcRNkySkBohPzOTr7acAePWBNjg6yD+bEEKImk8+zao5k0lh6qp4TApEtQ+me1NftUMSQgghbEKSkGru27/PsOdMBu5ODkwd0FLtcIQQQgibkSSkGruYW8hbaw8BMLF3MwI8nVWOSAghhLAdSUKqsbfXHeJinoEWgR6M6h6mdjhCCCGETUkSUk3tPn2R5TvOAPDqwDY46OSfSgghRO0in2zVkNFkXhlVUWBwpwZ0CfNROyQhhBDC5iQJqYaWxp4iPjELT2cHptzbQu1whBBCCLuQJKSaOZ9dwDvrDgPw334R+Lo7qRyREEIIYR+ShFQzc347SHZ+EW1DvHg0spHa4QghhBB2o3oS8sknnxAWFoazszORkZHExcXdsH5GRgbjxo0jKCgIJycnmjdvzq+//mp5febMmWg0GquvFi1qxiWNuIR0Vu5KRKMxT0bVaTVqhySEEELYjYOaJ1+xYgWTJk1iwYIFREZGMm/ePPr168fhw4fx9y++TX1hYSF9+vTB39+f77//npCQEE6dOoW3t7dVvdatW/P7779bnjs4qPo2y8VgNDFtVTwAQ7s0pEOot7oBCSGEEHam6qfz3LlzGTNmDKNHjwZgwYIFrFmzhkWLFjF58uRi9RctWkR6ejpbt25Fr9cDEBYWVqyeg4MDgYGBdo3d1r7cepLDKdnUc9XzYr8ItcMRQggh7E61JKSwsJCdO3cyZcoUS5lWq6V3795s27atxGNWr15Nt27dGDduHD/99BN+fn48+uijvPTSS+h0Oku9o0ePEhwcjLOzM926dWPOnDk0bNiw1FgKCgooKCiwPM/KygLAYDBgMBhu9q2WKTkrn/ejjwDw377NcHfUVMl5y+tKLNUpprpA+l0d0u/qkH5Xhz36vSJtqZaEpKWlYTQaCQgIsCoPCAjg0KFDJR5z4sQJNmzYwPDhw/n11185duwY//73vzEYDMyYMQOAyMhIvvjiCyIiIkhKSmLWrFn06tWL+Ph4PDw8Smx3zpw5zJo1q1j5+vXrcXV1vcl3WrYvjmjJLdQS5q7gkryPX3/dZ/dzVkZ0dLTaIdRJ0u/qkH5Xh/S7OmzZ73l5eeWuq1EURbHZmSvg3LlzhISEsHXrVrp162Ypf/HFF9m0aROxsbHFjmnevDn5+fkkJCRYRj7mzp3LO++8Q1JSUonnycjIoFGjRsydO5cnn3yyxDoljYSEhoaSlpaGp6fnzbzNMm09foGRX+xEq4Efx95KqyD7nq8yDAYD0dHR9OnTx3IZTNif9Ls6pN/VIf2uDnv0e1ZWFr6+vmRmZpb5GaraSIivry86nY6UlBSr8pSUlFLncwQFBaHX660uvbRs2ZLk5GQKCwtxdHQsdoy3tzfNmzfn2LFjpcbi5OSEk1Px9Tj0er1d/zMUFBmZtcY86jOiWxjtG9a327lswd79IUom/a4O6Xd1SL+rw5b9XpF2VLtF19HRkVtuuYWYmBhLmclkIiYmxmpk5Fo9evTg2LFjmEwmS9mRI0cICgoqMQEByMnJ4fjx4wQFBdn2DdjA//5M4MT5XHzdnZjUt7na4QghhBBVStV1QiZNmsTnn3/Ol19+ycGDBxk7diy5ubmWu2VGjBhhNXF17NixpKenM2HCBI4cOcKaNWt44403GDdunKXOCy+8wKZNmzh58iRbt25l0KBB6HQ6hg0bVuXv70bOXszjow1HAXhlQAs8nSXzF0IIUbeoeovukCFDOH/+PNOnTyc5OZkOHTqwdu1ay2TV06dPo9VezZNCQ0NZt24dzz//PO3atSMkJIQJEybw0ksvWeqcPXuWYcOGceHCBfz8/OjZsyfbt2/Hz8+vyt/fjcz++QD5BhOR4T4M7BCidjhCCCFElVN9Fa/x48czfvz4El/buHFjsbJu3bqxffv2Uttbvny5rUKzmz8OpbL+QAoOWg2vDmyDRiMrowohhKh7VF+2va7JNxiZsfofAJ7oGU7zgJJvGxZCCCFqO9VHQuoCo0khLiGd1Ox8Nh85z+n0PAI9nZlwdzO1QxNCCCFUI0mIna2NT2LWzwdIysy3Ko9qH4Sbk3S/EEKIuksux9jR2vgkxi7ZVSwBAfPtuWvjS15gTQghhKgLJAmxE6NJYdbPB7jRcrSzfj6A0aTKgrVCCCGE6iQJsZO4hPQSR0CuUICkzHziEtKrLighhBCiGpEkxE5Ss0tPQCpTTwghhKhtJAmxE38PZ5vWE0IIIWobSULspGu4D0FezpS2DJkGCPJypmu4T1WGJYQQQlQbkoTYiU6rYUZUK4BiiciV5zOiWqHTymqpQggh6iZJQuyof5sg5j/WiUAv60sugV7OzH+sE/3bVL+dfYUQQoiqIqtl2Vn/NkH0aRVoWTHV38N8CUZGQIQQQtR1koRUAZ1WQ7cm9dUOQwghhKhW5HKMEEIIIVQhSYgQQgghVCFJiBBCCCFUIUmIEEIIIVQhSYgQQgghVCFJiBBCCCFUIbfolkBRFACysrJUjqR6MBgM5OXlkZWVhV6vVzucOkP6XR3S7+qQfleHPfr9ymfnlc/SG5EkpATZ2dkAhIaGqhyJEEIIUTNlZ2fj5eV1wzoapTypSh1jMpk4d+4cHh4eaDSysmlWVhahoaGcOXMGT09PtcOpM6Tf1SH9rg7pd3XYo98VRSE7O5vg4GC02hvP+pCRkBJotVoaNGigdhjVjqenp/xyUIH0uzqk39Uh/a4OW/d7WSMgV8jEVCGEEEKoQpIQIYQQQqhCkhBRJicnJ2bMmIGTk5PaodQp0u/qkH5Xh/S7OtTud5mYKoQQQghVyEiIEEIIIVQhSYgQQgghVCFJiBBCCCFUIUmIEEIIIVQhSYgo1Zw5c+jSpQseHh74+/szcOBADh8+rHZYdcqbb76JRqNh4sSJaodSJyQmJvLYY49Rv359XFxcaNu2LX///bfaYdVqRqORadOmER4ejouLC02aNOHVV18t174jovw2b95MVFQUwcHBaDQaVq1aZfW6oihMnz6doKAgXFxc6N27N0ePHrV7XJKEiFJt2rSJcePGsX37dqKjozEYDPTt25fc3Fy1Q6sTduzYwf/93//Rrl07tUOpEy5evEiPHj3Q6/X89ttvHDhwgPfee4969eqpHVqt9tZbbzF//nw+/vhjDh48yFtvvcXbb7/NRx99pHZotUpubi7t27fnk08+KfH1t99+mw8//JAFCxYQGxuLm5sb/fr1Iz8/365xyS26otzOnz+Pv78/mzZt4rbbblM7nFotJyeHTp068emnn/Laa6/RoUMH5s2bp3ZYtdrkyZP566+/+PPPP9UOpU657777CAgIYOHChZaywYMH4+LiwpIlS1SMrPbSaDT8+OOPDBw4EDCPggQHB/Of//yHF154AYDMzEwCAgL44osvGDp0qN1ikZEQUW6ZmZkA+Pj4qBxJ7Tdu3DgGDBhA79691Q6lzli9ejWdO3fm4Ycfxt/fn44dO/L555+rHVat1717d2JiYjhy5AgAe/fuZcuWLdxzzz0qR1Z3JCQkkJycbPX7xsvLi8jISLZt22bXc8sGdqJcTCYTEydOpEePHrRp00btcGq15cuXs2vXLnbs2KF2KHXKiRMnmD9/PpMmTeLll19mx44dPPfcczg6OjJy5Ei1w6u1Jk+eTFZWFi1atECn02E0Gnn99dcZPny42qHVGcnJyQAEBARYlQcEBFhesxdJQkS5jBs3jvj4eLZs2aJ2KLXamTNnmDBhAtHR0Tg7O6sdTp1iMpno3Lkzb7zxBgAdO3YkPj6eBQsWSBJiR99++y1Lly5l2bJltG7dmj179jBx4kSCg4Ol3+sAuRwjyjR+/Hh++eUX/vjjDxo0aKB2OLXazp07SU1NpVOnTjg4OODg4MCmTZv48MMPcXBwwGg0qh1irRUUFESrVq2sylq2bMnp06dViqhu+O9//8vkyZMZOnQobdu25fHHH+f5559nzpw5aodWZwQGBgKQkpJiVZ6SkmJ5zV4kCRGlUhSF8ePH8+OPP7JhwwbCw8PVDqnWu/vuu9m/fz979uyxfHXu3Jnhw4ezZ88edDqd2iHWWj169Ch2C/qRI0do1KiRShHVDXl5eWi11h9FOp0Ok8mkUkR1T3h4OIGBgcTExFjKsrKyiI2NpVu3bnY9t1yOEaUaN24cy5Yt46effsLDw8NybdDLywsXFxeVo6udPDw8is25cXNzo379+jIXx86ef/55unfvzhtvvMEjjzxCXFwcn332GZ999pnaodVqUVFRvP766zRs2JDWrVuze/du5s6dyxNPPKF2aLVKTk4Ox44dszxPSEhgz549+Pj40LBhQyZOnMhrr71Gs2bNCA8PZ9q0aQQHB1vuoLEbRYhSACV+LV68WO3Q6pTbb79dmTBhgtph1Ak///yz0qZNG8XJyUlp0aKF8tlnn6kdUq2XlZWlTJgwQWnYsKHi7OysNG7cWHnllVeUgoICtUOrVf74448Sf5+PHDlSURRFMZlMyrRp05SAgADFyclJufvuu5XDhw/bPS5ZJ0QIIYQQqpA5IUIIIYRQhSQhQgghhFCFJCFCCCGEUIUkIUIIIYRQhSQhQgghhFCFJCFCCCGEUIUkIUIIIYRQhSQhQgghhFCFJCFCiDpDo9GwatUqtcMQQlwmSYgQokqMGjUKjUZT7Kt///5qhyaEUIlsYCeEqDL9+/dn8eLFVmVOTk4qRSOEUJuMhAghqoyTkxOBgYFWX/Xq1QPMl0rmz5/PPffcg4uLC40bN+b777+3On7//v3cdddduLi4UL9+fZ5++mlycnKs6ixatIjWrVvj5OREUFAQ48ePt3o9LS2NQYMG4erqSrNmzVi9erV937QQolSShAghqo1p06YxePBg9u7dy/Dhwxk6dCgHDx4EIDc3l379+lGvXj127NjBd999x++//26VZMyfP59x48bx9NNPs3//flavXk3Tpk2tzjFr1iweeeQR9u3bx7333svw4cNJT0+v0vcphLjM7vv0CiGEoigjR45UdDqd4ubmZvX1+uuvK4qiKIDyzDPPWB0TGRmpjB07VlEURfnss8+UevXqKTk5OZbX16xZo2i1WiU5OVlRFEUJDg5WXnnllVJjAJSpU6danufk5CiA8ttvv9nsfQohyk/mhAghqsydd97J/Pnzrcp8fHwsj7t162b1Wrdu3dizZw8ABw8epH379ri5uVle79GjByaTicOHD6PRaDh37hx33333DWNo166d5bGbmxuenp6kpqZW9i0JIW6CJCFCiCrj5uZW7PKIrbi4uJSrnl6vt3qu0WgwmUz2CEkIUQaZEyKEqDa2b99e7HnLli0BaNmyJXv37iU3N9fy+l9//YVWqyUiIgIPDw/CwsKIiYmp0piFEJUnIyFCiCpTUFBAcnKyVZmDgwO+vr4AfPfdd3Tu3JmePXuydOlS4uLiWLhwIQDDhw9nxowZjBw5kpkzZ3L+/HmeffZZHn/8cQICAgCYOXMmzzzzDP7+/txzzz1kZ2fz119/8eyzz1btGxVClIskIUKIKrN27VqCgoKsyiIiIjh06BBgvnNl+fLl/Pvf/yYoKIhvvvmGVq1aAeDq6sq6deuYMGECXbp0wdXVlcGDBzN37lxLWyNHjiQ/P5/333+fF154AV9fXx566KGqe4NCiArRKIqiqB2EEEJoNBp+/PFHBg4cqHYoQogqInNChBBCCKEKSUKEEEIIoQqZEyKEqBbkyrAQdY+MhAghhBBCFZKECCGEEEIVkoQIIYQQQhWShAghhBBCFZKECCGEEEIVkoQIIYQQQhWShAghhBBCFZKECCGEEEIV/w/rYStp3vjJhwAAAABJRU5ErkJggg==\n"
           },
           "metadata": {}
         },
@@ -1423,7 +1632,7 @@
             "text/plain": [
               "<Figure size 600x400 with 1 Axes>"
             ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiEAAAGJCAYAAABcsOOZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYXdJREFUeJzt3Xd4VFX+x/H3ZNJDEghpBEJHIIKgIIiiglRRFHWVIoq4q6srrpp1EZRqw4pYUHR/oKvAgroWXBDBCChKURCkK72l0iaFJJOZ+/tjyEBIAkmYyU35vJ4nT+7ce+653zkkmS/nnHuuxTAMAxEREZFK5mN2ACIiIlI7KQkRERERUygJEREREVMoCRERERFTKAkRERERUygJEREREVMoCRERERFTKAkRERERUygJEREREVMoCRERERFTKAkREY96++23sVgsdO3atdixvXv3YrFYeOWVV0o895VXXsFisbB37173vh49emCxWNxfQUFBXHLJJUybNg2n01liPUeOHOGf//wnrVu3JjAwkIiICPr168f//ve/UuO22WxMnjyZDh06UKdOHYKCgmjXrh1PPPEEhw8fLl8jiEiZ+JodgIjULHPmzKFp06asXbuWnTt30rJlywuus1GjRkyZMgWAjIwM5s6dy2OPPUZ6ejrPPfdckbI7duygV69epKenM3LkSDp37szx48eZM2cOAwcO5PHHH+fll18ucs7u3bvp3bs3+/fv5/bbb+f+++/H39+f3377jZkzZ/L555/z+++/X/D7EJGzGCIiHrJ7924DMD777DMjKirKmDRpUpHje/bsMQDj5ZdfLvH8l19+2QCMPXv2uPdde+21xsUXX1yk3MmTJ40mTZoYoaGhRkFBgXt/fn6+0a5dOyM4ONhYvXp1kXMKCgqMwYMHG4Axb94893673W506NDBCA4ONn744YdiMZ04ccJ48skny9wGIlJ2Go4REY+ZM2cO9erV44YbbuBPf/oTc+bM8cp1AgMDufzyy8nMzCQtLc29/7///S+bN29mzJgxxYaDrFYr7777LnXr1mXSpElFztm4cSNPPfUU3bt3L3atsLCwYr0tIuIZSkJExGPmzJnDrbfeir+/P0OHDuWPP/7g559/9sq1CueX1K1b173vq6++AuDuu+8u8Zzw8HBuvvlmtm/fzs6dOwFYsGABAHfddZdX4hSR0ikJERGPWLduHdu3b2fIkCEAdO/enUaNGnmkN8ThcJCRkUFGRgY7duxg9OjR/PLLLwwYMICgoCB3ua1btxIeHk6TJk1KratDhw4AbNu2zf09PDyc+Pj4C45TRMpHE1NFxCPmzJlDTEwMPXv2BMBisTB48GBmz57Nq6++itVqrXDd27dvJyoqqsi+m266iZkzZxbZl5mZSWho6DnrKjxus9nc3893joh4h3pCROSCORwO5s2bR8+ePdmzZw87d+5k586ddO3aldTUVJKSkspVn8ViKfK6adOmLF26lG+++Ya3336bhg0bkp6eTmBgYJFyoaGhZGZmnrPuwuOFiUdYWNh5zxER71ASIiIX7LvvviM5OZl58+bRqlUr99cdd9wB4B6SKUwaTp48WWI9OTk5RcoVCgkJoXfv3vTt25cHH3yQRYsWsXbtWp588ski5dq2bcuJEyfYv39/qbH+9ttvACQkJADQpk0bTpw4wYEDB8r7tkXkAikJEZELNmfOHKKjo/nkk0+KfQ0dOpTPP/+ckydPEhUVRXBwMDt27Cixnh07dhAcHExkZOQ5r3fJJZcwfPhw3n333SIJx4033gjAhx9+WOJ5NpuNL7/8kjZt2rjXLxk4cCAAs2fPLvf7FpELZPY9wiJSveXk5BihoaHGvffeW+LxH3/8scjaHIMGDTLCwsKMffv2FSm3b98+IzQ01Bg0aFCR/SWtE2IYhrFlyxbDYrEYjzzyiHtfXl6ekZCQYISEhBg///xzkfIOh8MYNmyYARj/+c9/3Pvz8/ON9u3bGyEhIcZPP/1U7Do2m03rhIh4icUwDMPsREhEqq/58+czZMgQvvjiC26++eZix51OJ7GxsVxxxRUsWLCAbdu2ccUVV+Dn58f9999P06ZN2bt3L++99x52u53Vq1fTtm1b9/k9evQgIyODzZs3F6v7xhtvZPny5ezbt4/69esDrrtdevXqxdGjR4usmDp37lzWr1/PP/7xj2LLxu/cuZPevXtz6NAh7rjjDq666ir8/PzYsmULc+fOpV69eqX23ojIBTA7CxKR6m3gwIFGYGCgkZ2dXWqZe+65x/Dz8zMyMjIMwzCMbdu2GYMHDzaio6MNX19fIzo62hgyZIixbdu2YueW1hNiGIaxfPlyAzAmTpxYZH9aWpqRmJhotGzZ0ggICDDq1q1r9O7d21iwYEGpMR47dsyYMGGC0b59eyM4ONgIDAw02rVrZ4wdO9ZITk4uQ0uISHmpJ0RERERMoYmpIiIiYgolISIiImIKJSEiIiJiCiUhIiIiYgolISIiImIKJSEiIiJiCj1FtwROp5PDhw8TGhpa7EFaIiIiUjrDMMjMzCQuLg4fn3P3dSgJKcHhw4eJj483OwwREZFq68CBAzRq1OicZZSElKDwEd8HDhwgLCzM5GjMZ7fbWbJkCX379sXPz8/scGoNtbs51O7mULubwxvtbrPZiI+Pd3+WnouSkBIUDsGEhYUpCcH1QxocHExYWJj+OFQitbs51O7mULubw5vtXpbpDJqYKiIiIqZQEiIiIiKmUBIiIiIiptCckAoyDIOCggIcDofZoXid3W7H19eX3Nxcj71fPz8/rFarR+oSEZHqydQk5Pvvv+fll19m3bp1JCcn8/nnnzNo0KBznrN8+XISExPZsmUL8fHxjBs3jnvuuadImenTp/Pyyy+TkpJChw4dePPNN+nSpYvH4s7Pzyc5OZmcnByP1VmVGYZBbGwsBw4c8Ni6KRaLhUaNGlGnTh2P1CciItWPqUlIdnY2HTp04N577+XWW289b/k9e/Zwww038MADDzBnzhySkpL4y1/+QoMGDejXrx8A8+fPJzExkRkzZtC1a1emTZtGv3792LFjB9HR0Rccs9PpZM+ePVitVuLi4vD396/xC5o5nU6ysrKoU6fOeReeKQvDMEhPT+fgwYO0atVKPSIiIrWUqUnI9ddfz/XXX1/m8jNmzKBZs2a8+uqrALRt25aVK1fy2muvuZOQqVOnct999zFy5Ej3OQsXLmTWrFmMGTPmgmPOz8/H6XQSHx9PcHDwBddXHTidTvLz8wkMDPRIEgIQFRXF3r17sdvtSkJEREzgcBqs2XOUdRkW6u85SreW0Vh9Kvc/1dVqTsiqVavo3bt3kX39+vXj0UcfBVwJwrp16xg7dqz7uI+PD71792bVqlWl1puXl0deXp77tc1mA1xzIex2e5GydrsdwzAA14dzbVD4fg3D8Nh7NgwDwzCUhJxD4c/e2T+D4l1qd3Oo3SvXN1tSeXbRdlJseYCVD//4hdiwAMYNaEO/i2MuqO7y/BtWqyQkJSWFmJiijRMTE4PNZuPkyZMcO3YMh8NRYpnt27eXWu+UKVOYPHlysf1Lliwp1tvh6+tLbGwsWVlZ5OfnX8C7qX4yMzM9Vld+fj4nT57k+++/p6CgwGP11kRLly41O4RaSe1ujurW7k4Ddtks2OwQ5gctwgwquTOh3DYesTDr98Je7dPBpthyGTVvA/de5KRDfaPC9ZdnvmS1SkK8ZezYsSQmJrpfFy4527dv32Irpubm5nLgwAHq1KlDYGBgZYdqisKHEXnygX65ubkEBQVxzTXX1Jp2LC+73c7SpUvp06ePVpCsRGr3yudwGqzelc53q9ZxXbdOXNEiqtKHBSrimy2pTHH3Jrh4qjfBUwzDIK/AyUm7g1y7k6zcAp5+/xegpP9EW7AAX6cGM/rOayr8b1A4mlAW1SoJiY2NJTU1tci+1NRUwsLCCAoKwmq1YrVaSywTGxtbar0BAQEEBAQU2+/n51fsj5DD4cBiseDj43NB8yMcToO1e46SlplLdGggXZpFVNlfusIhmML3DdC0aVMeffRR91BYefn4+GCxWEpsYylKbWQOtXvlWLw5mclfbSX5RC6uYYENNAgPZOLABPq3a2B2eKVavDmZh+dt5Oz+glRbHg/P28g7wy87b/x2x6nkIN/BSfupr1PbuXYHJ/Od7v1nl8ktqbz7mPP0doEDoxydGgaQfCKPXw9m0q1F/XK3C1Cu35tqlYR069aNRYsWFdm3dOlSunXrBoC/vz+dOnUiKSnJfauv0+kkKSmJUaNGVXa4pSr6S+dSGb90PXr0oGPHjkybNu2C6/r5558JCQm58KBEpNZavDmZB2evL/ZBnnIilwdnry/TB3l5GIaBw2lgdxjYnU7sBU7XtsN56uv0doHTwF7gJN/hpODU/sLtvAIHL3y9vVjcgHvfo/M3cMXa/eQWODlpdxZJIgq3C5wVH/KoCH+rD1YfOGk//9y+tMzc85bxBFOTkKysLHbu3Ol+vWfPHjZs2EBERASNGzdm7NixHDp0iA8//BCABx54gLfeeovRo0dz77338t133/Hxxx+zcOFCdx2JiYmMGDGCzp0706VLF6ZNm0Z2drb7bhmzVfYvXXkYhoHD4cDX9/w/FlFRUZUQkYjUVLl2BxO+3HLOD/J/fLyRH3dmUOB09RoUnEoU8s/YLimBsDsMChxO8k/tc5d1OsvVK3Bh78/J8t8zylTWYoFgPytB/lYC/awEnb1d7JgPQX6nXvufLhPoX7T8mWUCfX3wtfqwatcRhv5r9Xljig6tnGFyU5OQX375hZ49e7pfF87LGDFiBB988AHJycns37/ffbxZs2YsXLiQxx57jNdff51GjRrxf//3f+7bcwEGDx5Meno6EyZMICUlhY4dO7J48eJik1U9yTAMTtrPv5Kow2kwcUHpv3QWYNKCrVzVMrJMQzNBftYyz9G45557WLFiBStWrOD1118H4P3332fkyJEsWrSIcePGsWnTJpYsWUJ8fDyJiYmsXr2a7Oxs2rZty1NPPcVNN93kru/s4RiLxcK//vUvFi5cyDfffEPDhg159dVXi5wjIt5TVYZ47Q4n6Zl5pGXmkWrLJc2We3o7M49UWx5ptlyOZJ9/Yn92voOPVu8/b7kL4etjwddqwc/qg7/Vp8Rt19fp7SNZeWw+fP55D0O7xHNli8gSkogzEwfXtSprvakuzSJoEB5IyoncEj+LLEBsuOvnpzKYmoT06NHDfftnST744IMSz/n111/PWe+oUaMqdfjlpN1BwoRvLrgeA9fs5PaTlpSp/Nan+xHsX7Z/wtdff53ff/+ddu3a8fTTTwOwZcsWAMaMGcMrr7xC8+bNqVevHgcOHGDAgAE899xzBAQE8O9//5uhQ4eybds2mjZtWuo1Jk+ezEsvvcTLL7/Mm2++yZ133sm+ffuIiKicH2aR2qoyhnjtDicZWa4kojChSLPlFkku0jNdyYUnexv6JcRwccPwYomAr9VS5qShtG1fHws+FUjUytqbcFOHhhWeV+EtVh8LEwcm8ODs9VigSCJS2BITByZUWgJbreaESMWFh4fj7+9PcHCwe5Ju4W3LTz/9NH369HGXjYiIoEOHDu7XTz/9NP/973/56quvePjhh0u9xj333MPQoUMBeP7553njjTdYu3Yt/fv398ZbEhEufIj3zOQizZZL6qnkIs2WR2pmboWSC18fC9GhAUSFBRITGkBMWCDRp75HhQUQExrIgaPZ/HX2+vPWdc9VzarcB3lV600or/7tGvDO8MuKJa6xJkwIVhLiAUF+VrY+3e+85dbuOco97/983nIfjLy8TD+8QX6eWeSrc+fORV5nZWUxadIkFi5cSHJyMgUFBZw8ebLI0FhJLrnkEvd2SEgIYWFhpKWleSRGESnO4TSY/NXWc86rGPfFZjAgPTufdJsrqUjNdCUZaRVILqJCA4g+lVxEn0oozkwuosMCiAj2P28PQ+vY0Gr7QV7VehMqon+7BvRJiGXVzjSW/LCGvld31Yqp1ZXFYinTsMjVraLK9Et3davKvUf+7LtcHn/8cZYuXcorr7xCy5YtCQgI4Lbbbjvv4mxn35ZlsVhqzaqyIpUtJ7+A/21MLvI/2ZJkZOXzwJxz9zicmVy4eixOJxSuhKPsyUVZVfcP8qrUm1BRVh8LXZtFcGSbQVeT5hApCalEZv/S+fv743CcfwLtjz/+yD333MMtt9wCuBaeOV8viIh4VoHDSfKJXA4cy+HA0Rz2H83hwNGT7D+aw8FjOWRklX3F5sYRwbSODS2WXBQOkXgyuSiP6v5BXtibUBUmBFdXSkIqmZm/dE2bNmXNmjXs3buXOnXqlNpL0apVKz777DMGDhyIxWJh3Lhx55xALFJTVOYDvQzD4HiO3ZVcHCtMMk4nGoePnzzvOhIh/lay88//H4sXb7ukys2rKFRVhgUqyupjqbJtWx0oCTGBWdnz448/zogRI0hISODkyZO8//77JZabOnUq9957L1deeSWRkZGMHj2aY8eOeTU2EbMVX7nzlwu+wyTX7uDgsZOu5OJYDvuPnEo2Tu3Lyjv3c5P8rT40qhdEfEQw8RFBNI4IJr5e8KnXwdQJ8KX7i99Vy3kVZ6oKwwJiDiUhJjEje77ooouKPU34nnvuKVauadOmfPfdd+7XTqeT4cOHF3mOzt69e4ucU1JPyfHjxy8oXpHKUtE7TJxOg9TMXHfvxf6jORwsHDo5lkPqGc8UKU10aACNI4JpHBFMo1Pf4+sF0bh+MDGhgecdJqnO8ypElISISK12vjtMLLjuMHE6DQ4eP+mem3HgaA4Hj50k33Huydd1AnxpVC/InWjEu78H0aheMIEXeJdbdZ9XIbWbkhARqdXW7jl6zjtMDFx3mPxtbsmLJFp9LDSsG+ROLOJPDZkUJhz1gv28vhqmJkhKdaUkRERqrbwCB9//nl6msk0igukQX7fY3IwG4YH4Wiv+RG1P0QRJqY6UhIhIrXIsO59lO9L4dlsqK3akl+nuEoAXqvAdJiLVlZIQEanxdqVn8e3WVJK2pfHLvqOceedrZB1/svMdnCwlGakud5iIVEdKQkSkxilwOPll3zGStqXy7bY09mRkFznetkEYvdtG07ttDO0bhrNkawoPnnqOie4wEak8SkJEpEaw5dr5/vd0kral8d32NE6ctLuP+VktXNG8Pr3bxtCrbTSN6gUXOVd3mIiYQ0mIiFRbB47muHs71uw5gt1xuh+jbrAf17WOpndCDFe3iiQ00O8cNVX/lTtFqiMlISJSbTidBhsPHufbba75HdtTMoscbx4VQp+2MfRqG8NljeuW+64VrdwpUrmUhJjF6YB9P0FWKtSJgSZXgs+FLVrkbc2bN+fRRx/l0UcfNTsUqUVO5jtYuTPDNbF0exoZWadXIfWxQOemEacSj2iaR9UxMVIRKS8lIWbYugAWPwG2w6f3hcVB/xch4Sbz4hKpIlJtuSRtSyNpWyord2aQV3B6VdI6Ab5c2zqK3m2j6XFRNPVC/E2MVEQuhJKQyrZ1AXx8N5y9SLQt2bX/jg+ViEitYxgG25IzTw2zpLLx4IkixxvWDaJPQgy928bQpVkE/r7mLw4mIhdOSYgnGAbYc85fzumAr0dTLAFxVQJYXD0kzXuUbWjGLxjKuBz0e++9x6RJkzh48CA+Pqf/gN98883Ur1+fp556isTERFavXk12djZt27ZlypQp9O7du0z1ixRyOI0yLR+eV+Bg9e6jromlW1M5fNbS6R3j67puo02IoXVMqNeXPheRyqckxBPsOfB8nAcqMlxDNC/El634k4fBP6RMRW+//XYefvhhli1bRq9evQA4evQoixcvZtGiRWRlZTFgwACee+45AgIC+PDDDxk4cCA7duygUaNGFX1DUsss3pxc7DbXBmfc5no0O59l212rlX7/e9HVSgP9fOjeMoo+CdH0bBNNdGigGW9BRCqRkpBaol69elx//fXMnTvXnYR8+umnREZG0rNnT3x8fOjQoYO7/DPPPMPnn3/OggUL+Nvf/mZW2FKNLN6czIOz1xfr50s+kcsDs9fTIiqEPRnZRVYrjQ4NoNepRcOuahl5wU+UFZHqRUmIJ/gFu3olzmffTzDnT+cvd+enrrtlynLdcrjzzju57777ePvttwkICGDOnDkMGTIEHx8fsrKymDRpEgsXLiQ5OZmCggJOnjzJ/v37y3UNqZ0cToPJX20tcaCx0K5016qlbRuE0adtNL1OrVbqo9tgRWotJSGeYLGUbVikxXWuu2BsyZQ8L8TiOt7iOq/crjtw4EAMw2DhwoVcfvnl/PDDD7z22msAPP744yxdupRXXnmFli1bEhQUxJ/+9Cfy8/M9HofUPGv3HC0yBFOaN4Z25KYODSshIhGpDpSEVCYfq+s23I/vxvVUihKeUtH/Ba+tFxIYGMitt97KnDlz2LlzJ61bt+ayyy4D4Mcff+See+7hlltuASArK4u9e/d6JQ6peQ4dK8PEbFxzuEVECuk+t8qWcJPrNtyws55FERZXKbfn3nnnnSxcuJBZs2Zx5513uve3atWKzz77jA0bNrBx40aGDRuG0+k8R00irltrv9xwiClfbytTeU02FZEzqSfEDAk3QZsbTFkx9brrriMiIoIdO3YwbNgw9/6pU6dy7733cuWVVxIZGckTTzyBzWbzejxSfW08cJyn/7eVdfuOAa7VS52l9HRYcD0MrkuziMoLUESqPCUhZvGxQrOrK/+yPj4cPlx8Em3Tpk357rvviux76KGHANw9Irt37y6yxojUTqm2XF5cvJ3P1h8CIMjPyt96tKBJ/WAembcBKHGgkYkDE/QsFhEpQkmIiJRJrt3B//2wm7eX7yLn1Poet17WkNH92hAb7hpm8ff1KbZOSOwZ64SIiJxJSYiInJNhGCzclMyURds5dPwkAJc1rsuEgRfTMb5ukbL92zWgT0JsmVZMFRFREiIipdp86ARPf7WVtXuPAq7VT8dc34abOsSVuoy61cdCtxb1KzNMEfNUwyeiuzkdWPatpOHRVVj2hUHzayo9diUhIlJMWmYur3yzg0/WHcQwXEuqP3BtC/56TQuC/KvJH9iKqAJ/lGul6tru1fmJ6Kdi97UdpjPAvndMiV1JSAUZWvDggqj9qqZcu4NZP+5h+nc73c91ubljHE/0b0Nc3SCTo/OyKvJHucKq6//Iq2u7V+cnoleh2JWElJOfnx8AOTk5BAXV8D/KXlS4EqvVWg3+SNYChmHwzZYUnlu0jQNHXfM+OsTXZcKNCXRqUs/k6CpBFfqjXCHV9X/k1bXdnQ5Xe5/ziehjXEsxVLVEsIrFriSknKxWK3Xr1iUtLQ2A4ODgGv+IcafTSX5+Prm5uR65RdfpdJKenk5wcDC+vvoRNNuWwyd45n9bWb3bNe8jJiyAJ/q3YVDHhrXjuS5V7I9yuVXXD/ICO3w9mtLbHVj4D1evDgY47OAscP17OQu3C8BRcHrbaT91vMC75XNPFE34SorfdghebApW/5KLlPtzo5zlS6u/IB9yj53jxFOx7/upUpaR0CdABcTGxgK4E5GazjAMTp48SVBQkMcSLh8fHxo3blzjE7iqLCMrj1eX7GDezwcwDAjw9eGv1zTnr9e2ICTgAv40VIdhAacTTh6DnAzY+V3ZPlA+ux8imoGPr+v9+Pi6vizW4vvcr0vYZympXEnfz6y/pHosZU+gml0LhgMK8sCR7/o6c9uR7/pwcuSVsl3COQV5rg/uYufYSy935raz4Pz/TtlpMKtvxf6Nq4K8arzgY1ZqpVxGSUgFWCwWGjRoQHR0NHa73exwvM5ut/P9999zzTXXuIejLpS/v78WPjNJXoGDf/+0lzeTdpKZ5/oguPGSBoy5vg2N6pXvyczFmDUs4CiAk0chO8OVWGRnQM4R1/fs9FP7jpw+dvIoGOV8LMHmT70Te0VZfFxf5/wwL/wfeeNKC8vjgutDYN3TCZj1zGTM73SCZvU7I4nzK3/Z8pRP3QrfjDl/7DdPh4adiu8v95y4cpY/V/2H1sNXD5+/jjox5btmBSkJuQBWq7VWzGmwWq0UFBQQGBjosSREKp9hGCzdmspzi7ax74jrgXPtG4YzYWAClzf1wHLqnhwWKMg/I5k4K4E4O8nIyXD1alREYDj4hUDmuXpCTmk7CEJjzuiad5zeNhzF9zkLXD0uRV47zip/9jmOs16f4z85hrP8iZTFCr4Brg9Va4BrqMDX/9S236lj/qf2n1GuyDmF5cpxju+p42eec+hXmD/s/DHf/m9TVpc+p6bdYdUb538ieoehVa8XMLotrJhy/tibXFkp4ZiehEyfPp2XX36ZlJQUOnTowJtvvkmXLl1KLGu325kyZQr//ve/OXToEK1bt+bFF1+kf//+7jKTJk1i8uTJRc5r3bo127dv9+r7EKnKtqfYeOZ/W/lx5xEAokIDGN2vNbdd1sgz8z7KMiyw6J+uP24nj5eSUKSf3q5QN7YFgupBSCSERLn+Bx0SCcGRp76X8Nrq54p9Wrvz/1G+fZY5HyhO51lJyxmJy75V8Ok9569j+H+hec+q9YFYJ8bVrlXkw7BcTH4i+gWpYrGbmoTMnz+fxMREZsyYQdeuXZk2bRr9+vVjx44dREdHFys/btw4Zs+ezb/+9S/atGnDN998wy233MJPP/3EpZde6i538cUX8+2337pfa/Kj1FZHsvKYuvR3/rN2P07Dtaz6X7o34289W1LnQuZ9nCnXBlu+OP+8iqwU+L9eZa/XYj0jcThfQhEJwREV+8NZxf4oF+PjA/i4EqazJdxUtg/yqpaAQNVv9/MpfCJ6icOPL1TNycCFqlDsFsPEBRu6du3K5ZdfzltvvQW47pqIj4/n4YcfZsyY4uNtcXFxPPXUU+4HqwHcdtttBAUFMXv2bMDVE/LFF1+wYcOGCsdls9kIDw/nxIkThIWFVbiemsJut7No0SIGDBig4ZhKdCHtnl/g5MNVe3k96Q8yc11zBga0j2Xs9W2JjyjnvI+8LDi+/4yvfae+9sOxfZB7vOx1BdaF8HgIqV80gSj2OvLUPIBKnDdU4nyWhlX/A8U9DAYlfpBX1btjClXXdi9UHSZil8bpoGD392z44Rs6Xt0PXw8tEleez1DTugjy8/NZt24dY8eOde/z8fGhd+/erFq1qsRz8vLyCAwMLLIvKCiIlStXFtn3xx9/EBcXR2BgIN26dWPKlCk0blz6xKy8vDzy8vLcrwsfYW+322vFxNPzKWwDtUUlcjpw7HGtIOnYFQLNupfpj4NhGCz7PYMXvt7BnlPzPtrGhvLUgNZ0beaa91Hs39F+Ek4cwHJ8P5YTrkTDcuLAqe/7seQcOf91/UOx5Geet1zBnz7AaNL9vOUAcDhcX5Wl1fXQoi+OPSvZvOpb2nXrjbWw3avyz36r67Hc9j7WJU9iOWNuixEWh6PPcxitrq/y8VfLdj9ToytObzucrq9qwh7XlUMRNhLiumJ4KPbyfFaY1hNy+PBhGjZsyE8//US3bt3c+0ePHs2KFStYs2ZNsXOGDRvGxo0b+eKLL2jRogVJSUncfPPNOBwOdxLx9ddfk5WVRevWrUlOTmby5MkcOnSIzZs3ExoaWmIsJc0jAZg7dy7BwRd4t4BIOTU4/jPtD84hyH7Uve+kXwSbGt1Jct3LSz0vJQc+3+vD9hOu3oM6fgY3xjvpFplHiP0IwfkZBOenu77nnd4OLDhx3pjyrcHk+EeR4x/p+gqIcr8+6R9JgU8AfbckEmg/WuJqBsap97D04qmuOzrE8wwn9bN2EGg/Tq5fXY7Uaa22FlPk5OQwbNiwMvWEVKskJD09nfvuu4+vvvoKi8VCixYt6N27N7NmzeLkyZMlXuf48eM0adKEqVOn8uc//7nEMiX1hMTHx5ORkaHhGFxZ7dKlS+nTp4+GY7zMsv1/WP87EjCKfJgXvnLc9j5GmxuLnHMsM4vZS1bz66bfiCOdJj7pXBOVQ+vAY/jaDmDJSjnvdQ3/OlC3CUZ4PEbdJlA3HiO8MUbdxq7hk8DwcsQOljOGBc4Ve1Wkn3dzqN3N4Y12t9lsREZGVu3hmMjISKxWK6mpRRdESU1NdS8GdraoqCi++OILcnNzOXLkCHFxcYwZM4bmzZuXep26dety0UUXsXPnzlLLBAQEEBAQUGy/n5+ffhnOoPbwMqcDlj5JSRMMCz/UfRc9Bmmb4cRBnMf3cTJ1N5F5aSRiwJn/NEfPqsAvBOo2hnpNXN/rNoa6p7ctQfXAYinvmoxFtb8FrNZi4/uWU5PdfKvD+P4Z9PNuDrW7OTzZ7uWpx7QkxN/fn06dOpGUlMSgQYMA18TUpKQkRo0adc5zAwMDadiwIXa7nf/+97/ccccdpZbNyspi165d3HXXXZ4MX8Tz9v10njtMcK2H8cMrAPgAIad25+KPM7wxwVHNSkg2mrruHKmM1WkTbnItb15dJ+qJSKUy9d7VxMRERowYQefOnenSpQvTpk0jOzubkSNdXbp33303DRs2ZMqUKQCsWbOGQ4cO0bFjRw4dOsSkSZNwOp2MHj3aXefjjz/OwIEDadKkCYcPH2bixIlYrVaGDh1qynsUKbMyLpO8JaAj/8tqw0EjkhOBcdzcoxuDruqI1VpFxv99rFVvcSkRqZJMTUIGDx5Meno6EyZMICUlhY4dO7J48WJiYlzLxe7fv7/I0t65ubmMGzeO3bt3U6dOHQYMGMBHH31E3bp13WUOHjzI0KFDOXLkCFFRUXTv3p3Vq1cTFRVV2W9PpHyy0stU7JnMG1lnuZh7rmrKs9e1IjxIXdciUj2ZvorXqFGjSh1+Wb58eZHX1157LVu3bj1nffPmzfNUaCKVIzMFloyHTR8Drsc+lDRy4jQghfqEXnQNS25sR7PIkOKFRESqEdOTEJFay2GHte/BsimQn4mBhdWWDnQ1NmAYcOZq6s5Tc1WnWkcy4+4uWD2x1LqIiMmqyCCySC2zdyXMuBq+eRLyM6FhZzYN+IKhJ0fzoP1RUij6QLkU6vOg/VE+zbmMtXvOvvVFRKR6Uk+ISGWyJcOScacfCx9cH3pPgo7D2fNbMrCBb5xdWJrXmS4+24nmOGnUZa2zDc5T/2dIy8w1LXwREU9SEiJSGRx2WDMDlr8A+VmABTrfC9eNc90+C0SHnn4kgRMfVjsTSqzqzHIiItWZkhARb9vzAyx6HNK3u1437Aw3vAJxlxYp1qVZBFF1/EnPyi+xGgsQGx5Il2YRJR4XEalulISIeEuJQy+ToeOdpT4dtk6gb4lJSOE01IkDEzQpVURqDCUhIp5W0tDL5X+Gnk+5h15KMmvlHvZk5BDo60NokB/pmaefZxQbHsjEgQn0b9egEt6AiEjlUBIi4kl7vodF/zw99NLochjwCsR1POdpu9KzeGXJDgAm3XQxt3eOZ9XONJb8sIa+V3elW8to9YCISI2jJETEE2yHTw29/Nf1Org+9HkaOgwrdeilkMNp8M9PNpJX4OSai6IYfHk8FouFrs0iOLLNoGuzCCUgIlIjKQkRuRAOO6x+B1a86Bp6sfhA5z/DdU9BUL0yVTFz5W7W7z9OaIAvL9zaHktlPGhORKQKUBIiUlHFhl66uO56adChzFXsTMvilSW/AzDuxrbE1Q3yRqQiIlWSkhCR8io29BIJfSaXaejlTA6nwT8/3Uj+qWGYOzrHeylgEZGqSUmISFl5YOjlTP/3w25+1TCMiNRiSkJEymL3CtfQS4brDpaKDL2caWdaFq8u1TCMiNRuSkJEzsV2GL55CrZ85nodHHnqrpeh5Rp6OdOZwzDXahhGRGoxJSEiJSnIhzXvwPIXwZ7tGnq5/C/Q88kKDb2cqcgwzG0ahhGR2ktJiMjZdi8/NfTiGi4hvqtrwbEGl1xw1TvTMt3DMONvTKBBuIZhRKT2UhIiUujEIVjyFGz53PXaA0MvZ3I4DR7/5DfyC5z0aB3F7Z0bXXCdIiLVmZIQkYJ8WP02rHjprKGXpyCorscu868fdrPhwHFCA32ZorthRESUhEgt58WhlzPtTMtkqoZhRESKUBIiNZfTAft+gqxUqBMDTa4EH6vrWElDL32fgUuGeGTo5UwFDif/OHMYppOGYUREQEmI1FRbF8DiJ1y32BYKi4O+z8Hx/WcNvdx36q6Xul4J5V8/7GGjhmFERIpREiI1z9YF8PHdgFF0v+0wfDry9Ov4K2DAyx4fejnTH6mZvKZhGBGREikJkZrF6XD1gJydgJzJ4gM3vQUdh4EXeyUKHE4e//Q38h1OemoYRkSkGM8OfouYbd9PRYdgSmI4oW5jryYgcPYwzCUahhEROYuSEKlZslI9W66CzhyGmXBjArHhgV69nohIdaQkRGqWOjGeLVcBBQ4nj3+ykXyHk+vaRPMnDcOIiJRISYjULE2udN0FUyoLhDV0lfOS937YzcaDJwgN9OX5W3Q3jIhIaZSESM3iY4V+L5Ry8FQy0P+F0+uFeNjvqZlMW/oHABMHXqxhGBGRc1ASIjVPQe6pjbN6IMLi4I4PIeEm71z2rGGY2y5r6JXriIjUFLpFV2oW+0lIetq1fd041zLsJa2Y6gXvfr+b3zQMIyJSZkpCpGZZMwNsByGsEXR7CPwqZ3GwHSmZvP6thmFERMpDwzFSc2RnwA9TXdu9xldaAlLgcPLPTzUMIyJSXkpCpOZY8RLk2SD2Emh/R6VdtnAYJkzPhhERKRclIVIzHNkFv8x0bfd9xuNPwi3N2cMwMWEahhERKSslIVIzfDsRnAXQqi8071EplzxzGKZXm2hu1TCMiEi5KAmR6m//atj2levBdH2errTLnjkM87yGYUREyk1JiFRvhgFLxrm2L70LottWymV3pGQy7VvXs2Em3aRhGBGRijA9CZk+fTpNmzYlMDCQrl27snbt2lLL2u12nn76aVq0aEFgYCAdOnRg8eLFF1SnVHNbv4CDP4NfCPR8slIuaT+1KJndYdC7bTS3XKphGBGRijA1CZk/fz6JiYlMnDiR9evX06FDB/r160daWlqJ5ceNG8e7777Lm2++ydatW3nggQe45ZZb+PXXXytcp1RjBXnw7STX9pUPQ2hspVz23RW72HTo1DCMFiUTEakwU5OQqVOnct999zFy5EgSEhKYMWMGwcHBzJo1q8TyH330EU8++SQDBgygefPmPPjggwwYMIBXX321wnVKNfbzTDi217Ua6pUPV8olt6fYeD3JdTfMpJsuJlrDMCIiFWbaiqn5+fmsW7eOsWPHuvf5+PjQu3dvVq1aVeI5eXl5BAYW/aMfFBTEypUrK1xnYb15eXnu1zabDXAN/9jt9vK/uRqmsA2qVFucPI7v9y9hAQqueQLDJwC8HJ/d4eQfH2/A7jC4rnUUN7aL9mqbVMl2rwXU7uZQu5vDG+1enrpMS0IyMjJwOBzExMQU2R8TE8P27dtLPKdfv35MnTqVa665hhYtWpCUlMRnn32Gw+GocJ0AU6ZMYfLkycX2L1myhODg4PK+tRpr6dKlZofglnDoP7Q6eQxbYEOWH66HkbzI69dcctDClsNWgq0GPeok8/XXyV6/JlStdq9N1O7mULubw5PtnpOTU+ay1erZMa+//jr33Xcfbdq0wWKx0KJFC0aOHHnBQy1jx44lMTHR/dpmsxEfH0/fvn0JCwu70LCrPbvdztKlS+nTpw9+fn5mhwPH9+M7IwmA4Jtf4fqWfbx+yR0pmSxZuxoweHpQe27uGOf1a1a5dq8l1O7mULubwxvtXjiaUBamJSGRkZFYrVZSU1OL7E9NTSU2tuQJhlFRUXzxxRfk5uZy5MgR4uLiGDNmDM2bN69wnQABAQEEBAQU2+/n56dfhjNUmfZY8Tw48qHZtfi2uR68PDHU7nAy5ostp+6GieG2zo0rdTJqlWn3Wkbtbg61uzk82e7lqce0ian+/v506tSJpKQk9z6n00lSUhLdunU757mBgYE0bNiQgoIC/vvf/3LzzTdfcJ1STRxaB5s/BSyu5dkrIRmYsXwXmw/ZCA/y4/lb2uluGBERDzF1OCYxMZERI0bQuXNnunTpwrRp08jOzmbkyJEA3H333TRs2JApU6YAsGbNGg4dOkTHjh05dOgQkyZNwul0Mnr06DLXKdWYYcCS8a7tSwZDgw5ev+S2ZBtvfOe6G2ay7oYREfEoU5OQwYMHk56ezoQJE0hJSaFjx44sXrzYPbF0//79+JzxILLc3FzGjRvH7t27qVOnDgMGDOCjjz6ibt26Za5TqrEdX8O+H8E3EK4b5/XLnbkoWZ+EmEqZByIiUpuYPjF11KhRjBo1qsRjy5cvL/L62muvZevWrRdUp1RTDjssneDavuJBqBvv9Uu+s3wXWw67hmGe0zCMiIjHmb5su0iZrP83HPkDgutD98e8frltyTbePHMYJlTDMCIinqYkRKq+XBssf8G1fe0YCAz36uU0DCMiUjmUhEjV9+PrkJ0OES2gs/cnGBcOw9QN1jCMiIg3KQmRqu3EIVg13bXdZzJYvbt+gIZhREQqj5IQqdqWPQcFJyH+Cmhzo1cvdeYwTN+EGG7qoGEYERFvUhIiVVfKJtgw17Xd7zmvL0z29rLTwzDPahhGRMTrlIRI1bV0AmDAxbdAo85evdTWwxqGERGpbEpCpGra+S3s+g58/KDXRK9eqnAYpsBp0O9iDcOIiFQWJSFS9TgdsOTUwmRd7oeIZl693PRlO9mabKNesB/PDmqvYRgRkUqiJESqng1zIW2Laz2Qax736qW2HD7BW9/tBGDyze2ICi3+NGUREfEOJSFSteRnu+6IAbjmnxAc4b1LFTh5/JPf3MMwAy9p4LVriYhIcUpCpGpZNR0yk6FuY9dQjBe9vXwn2zQMIyJiGiUhUnVkpblWRwXXZFRf7w2NaBhGRMR8SkKk6lg+BfKzIO4yaHeb1y5z5jBM/4tjNQwjImISJSFSNaTvgHX/dm33fdarC5NNX3Z6GOaZQVqUTETELOVKQmw2G06ns9h+h8OBzWbzWFBSCy2dCIYDWt8ATa/y2mW2HD7B9GWuYZinNQwjImKqMichn3/+OZ07dyY3N7fYsdzcXC6//HK++uorjwYntcSeH+D3r8FidT2kzkvyC5z842PXomTXt4vlRg3DiIiYqsxJyDvvvMPo0aMJDg4udiwkJIQnnniCt956y6PBSS3gdMKSca7tziMhspXXLvXWsp1sT8kkIsRfwzAiIlVAmZOQzZs306NHj1KPX3PNNWzatMkTMUltsvlTSN4A/qFw7RiPVu1wGqzadYQvNxxi7pp9TD/1bJinb76YyDoahhERMZtvWQseO3aMgoKCUo/b7XaOHTvmkaCklrDnQtLTru3uj0KdKI9VvXhzMpO/2kryiaLDh5fG1+WG9hqGERGpCsrcE9K0aVN++eWXUo//8ssvNGnSxCNBSS2xZgacOAChcXDF3zxW7eLNyTw4e32xBATg1wPH+WZLiseuJSIiFVfmJOTWW2/lqaeeIjU1tdixlJQUxo0bx223eW9tB6lhco7CD1Nd29eNA//ic40qwuE0mPzVVoxSjluAyV9txeEsrYSIiFSWMg/HjBkzhi+//JJWrVoxfPhwWrduDcD27duZM2cO8fHxjBnj2TF9qcFWvAR5JyCmPXQY4rFq1+45WmIPSCEDSD6Ry9o9R+nWor7HrisiIuVX5iQkNDSUH3/8kbFjxzJ//nz3/I+6desyfPhwnnvuOUJDQ70WqNQgR3bBz/9ybfd9GnysHqs6LbP0BKQi5URExHvKnIQAhIeH8/bbbzN9+nQyMjIwDIOoqCjd6ijlkzQZnAXQsje0uM6jVUeHBnq0nIiIeE+5kpBCmzZt4vfffwegdevWtG/f3qNBSQ22fw1s/RIsPtDnaY9X36VZBPWC/TiWYy/xuAWIDQ+kS7MIj19bRETKp1xJyNq1a/nzn//M1q1bMQzXxD6LxcLFF1/MzJkzufzyy70SpNQQhnF6YbKOwyDmYo9f4sDRHHLtjhKPFfbXTRyYgNVHvXciImYr890xW7dupVevXgQFBTF79mzWr1/P+vXr+eijjwgICKBXr15s3brVm7FKdbf1Szi4FvyCoedTHq8+O6+A+z/6hZN2J80ig4kNK7ogWWx4IO8Mv4z+7bROiIhIVVDmnpBJkybRp08f/vvf/xaZA9KxY0eGDh3KrbfeyqRJk/j444+9EqhUcwX58O0k13a3URAW59HqDcPg8U828ntqFlGhAcy7vxuRdQJYu+coaZm5RIe6hmDUAyIiUnWUOQlZtmwZX3/9dYmTUC0WC08++SQDBgzwaHBSg/wyC47tgZBouOrvHq/+7eW7+HpzCn5WCzOGdyImzDXxVLfhiohUXWUejsnMzCQmJqbU47GxsWRmZnokKKlhTh6HFS+4tnuOhQDP3sq9bHsaryzZAcDTN7ejU5N6Hq1fRES8o8xJSJMmTVi7dm2px9esWaNl26VkK6fCyWMQ2RouvdujVe/JyObv837FMGBY18YM7dLYo/WLiIj3lDkJGTJkCImJiWzevLnYsU2bNvH4448zePBgjwYnNcDx/bB6hmu7z9NgrdBd4SXKyivgvg9/ITO3gM5N6jFpoOfvthEREe8p8yfC2LFj+fbbb+nYsSN9+vShbdu2GIbBtm3b+Pbbb+nSpQtPPvmkN2OV6ijpGXDkQdOr4aJ+HqvW6TRInL+BnWlZxIQF8Pbwy/D3LXNOLSIiVUCZk5DAwECWLVvGa6+9xn/+8x9WrFgBwEUXXcSzzz7LY489RkBAwHlqkVrl0HrYdOpuqb7PgAdX1n1r2U6WbE3F3+rDjOGdtAKqiEg1VK6+cX9/f5544gmeeOIJb8UjNYVhwNIJru32d0DcpR6r+tutqbz2rWvF3mcHtePSxpqIKiJSHXms/zo5OZlRo0Z5qjqp7n7/Bvb+ANYA6DXeY9XuSs/isfkbMAy464om3HF5vMfqFhGRylWunpAtW7awbNky/P39ueOOO6hbty4ZGRk8++yzvPvuuzRv3txbcUp14iiApacSjysegLqeuWPFlmt3TUTNK6BL0wjG35jgkXpFRMQcZe4JWbBgAZdeeil///vfeeCBB+jcuTPLli2jbdu2bN++nc8//5wtW7aUO4Dp06fTtGlTAgMD6dq16zlvAwaYNm0arVu3JigoiPj4eB577DFyc08/ln3SpElYLJYiX23atCl3XHIBfv0QMn6HoAjonuiRKgsnou5Oz6ZBeCDT79REVBGR6q7Mf8WfffZZHnroIWw2G1OnTmX37t38/e9/Z9GiRSxevJj+/fuX++Lz588nMTGRiRMnsn79ejp06EC/fv1IS0srsfzcuXMZM2YMEydOZNu2bcycOZP58+cXuyvn4osvJjk52f21cuXKcscmFZSXCcued21f+wQE1fVIta8n/cG329Lw93VNRI0K1SRoEZHqrsxJyI4dO3jooYeoU6cODz/8MD4+Prz22msX9OTcqVOnct999zFy5EgSEhKYMWMGwcHBzJo1q8TyP/30E1dddRXDhg2jadOm9O3bl6FDhxbrPfH19SU2Ntb9FRkZWeEYpZx+fAOy0yGiOXS+1yNVLtmSwutJfwDw/C3t6RBf1yP1ioiIuco8JyQzM5OwsDAArFYrQUFBFzQHJD8/n3Xr1jF27Fj3Ph8fH3r37s2qVatKPOfKK69k9uzZrF27li5durB7924WLVrEXXfdVaTcH3/8QVxcHIGBgXTr1o0pU6bQuHHp8xLy8vLIy8tzv7bZbADY7XbsdnuF32NNUdgG520LWzK+P72JBSjoOR7DsMAFtt/ONNdEVIC7rmjMzZfE1Jp/kzK3u3iU2t0candzeKPdy1NXuSamfvPNN4SHhwPgdDpJSkoqtoLqTTfdVKa6MjIycDgcxZ5HExMTw/bt20s8Z9iwYWRkZNC9e3cMw6CgoIAHHnigyHBM165d+eCDD2jdujXJyclMnjyZq6++ms2bNxMaWvIzS6ZMmcLkyZOL7V+yZAnBwcFlej+1wdKlS895vOO+/6NJwUmOhLRi5S4f2L3ogq6XUwBTN1nJzrfQMszgUmM3ixbtvqA6q6Pztbt4h9rdHGp3c3iy3XNycspc1mIYhlGWgj4+5x+5sVgsOByOMl348OHDNGzYkJ9++olu3bq5948ePZoVK1awZs2aYucsX76cIUOG8Oyzz9K1a1d27tzJI488wn333cf48SXfBnr8+HGaNGnC1KlT+fOf/1ximZJ6QuLj48nIyHD3/tRmdrudpUuX0qdPH/z8/EoulLoF3//rgQWDghFfYzSq+DAduCai/nXOryz/PYMG4YF8/kBX6tepXfNAytTu4nFqd3Oo3c3hjXa32WxERkZy4sSJ836GlrknxOl0XnBgZ4qMjMRqtZKamlpkf2pqKrGxsSWeM378eO666y7+8pe/ANC+fXuys7O5//77eeqpp0pMlOrWrctFF13Ezp07S40lICCgxNVe/fz89MtwhnO2x7KnAQMSbsa32ZUXfK1Xl+xg+e8ZBPj68N5dnYmtV+eC66yu9HNoDrW7OdTu5vBku5enHtPucfT396dTp04kJSW59xUO8ZzZM3KmnJycYomG1WoFoLQOnaysLHbt2kWDBg08FLkUszMJdiWBjx/0mnjB1S3enMyb37mSxhdua0/7RuEXXKeIiFQ9Ze4JeeONN0rcHx4ezkUXXVRq4nAuiYmJjBgxgs6dO9OlSxemTZtGdnY2I0eOBODuu++mYcOGTJkyBYCBAwcydepULr30UvdwzPjx4xk4cKA7GXn88ccZOHAgTZo04fDhw0ycOBGr1crQoUPLHZ+UgdNxenn2y/8C9VtcUHW/p2aS+PFGAO69qhm3XNroQiMUEZEqqsxJyGuvvVbi/uPHj3PixAmuvPJKFixYQERERJkvPnjwYNLT05kwYQIpKSl07NiRxYsXuyer7t+/v0jPx7hx47BYLIwbN45Dhw4RFRXFwIEDee6559xlDh48yNChQzly5AhRUVF0796d1atXExUVVea4pBw2zoPUzRAQDteOvqCqTuTYuf/DX8jJd3Bli/o8OUCLzImI1GRlTkL27NlT6rHdu3czfPhwxo0bx9tvv12uAEaNGlXqM2eWL19e5LWvry8TJ05k4sTSu/znzZtXruvLBcjPge+ecW1f8w8ILnsCejaH0+CR+b+y90gODesG8dawy/C1akVUEZGazCN/5Zs3b84LL7zAkiVLPFGdVBerp0NmMoQ3hi5/vaCqXl2yg+U70gn08+HduzoREeLvoSBFRKSq8th/NRs3bkxKSoqnqpOqLisNVk5zbfeaAH6BFa5q4W/JvL18FwAv3nYJ7RpqIqqISG3gsSRk06ZNNGnSxFPVSVW3/AXIz4IGHaHdbRWuZnuKjcc/cU1Eve/qZtzcsaGHAhQRkaquzHNCCpcyP9uJEydYt24d//jHPxgxYoTHApMqLP13WPeBa7vvs1CGhexKcjwnn/s/XMdJu4PuLSN5or8mooqI1CZlTkLq1q2LxWIp8ZjFYuEvf/kLY8aM8VhgUoV9OxEMB1x0PTS7ukJVOJwGD//nV/YfzSE+Iog3h16qiagiIrVMmZOQZcuWlbg/LCyMVq1aUadOHTZv3ky7du08FpxUQXtXwo5FYLFCn+LP2ymrl77Zzg9/ZLgmog7vTD1NRBURqXXKnIRce+21Je7PzMxk7ty5zJw5k19++aXMz46RashwwpJxru1OIyCqdYWq+WrjYd5d4XoQ3ct/6kBCnJ7PIyJSG1W4//v7779nxIgRNGjQgFdeeYWePXuyevVqT8YmVYHTgWXfShoeXYXPihfg8K/gXwd6jK1QdVsP2/jnp66JqH+9tjkDO8R5MloREalGytwTApCSksIHH3zAzJkzsdls3HHHHeTl5fHFF1+QkJDgrRjFLFsXwOIn8LUdpjPAvlP7L+oHdaLLXd2x7Hzu/+gXcu1Orm4Vyeh+mogqIlKblbknZODAgbRu3ZrffvuNadOmcfjwYd58801vxiZm2roAPr4bbIeLH9v8met4ORQ4nDz8n185eOwkjSOCeXPopVh9Sp7oLCIitUOZe0K+/vpr/v73v/Pggw/SqlUrb8YkZnM6YPETQMlPJgZg8RhocwP4WMtU5YuLt7NyZwbB/lbeu7sTdYM1EVVEpLYrc0/IypUryczMpFOnTnTt2pW33nqLjIwMb8YmZtn3U8k9IG4G2A65ypXBlxsO8a8fXM8eeuX2DrSJ1URUEREpR0/IFVdcwRVXXMG0adOYP38+s2bNIjExEafTydKlS4mPjyc0NNSbsYo35ByF9B2Qvv3098O/lu3crNTzFtl86ASjP/0NgL/1aMGA9g0uJFoREalByjUxFSAkJIR7772Xe++9lx07djBz5kxeeOEFxowZQ58+fViwoHxzBaQSGAZkp5+RaJyRdGSnVbzeOjHnPHw0O5+/frSOvAInPVpH8Y++FbulV0REaqZyJyFnat26NS+99BJTpkzhq6++YtasWZ6KSyrCMFxPtT2zV6Pw+8ljpZ8XHu9a8yOqjet7/Vbw6UjITKHkeSEWCIuDJleWWmWBw8lDc9Zz6PhJmtYP5vUhmogqIiJFXVASUshqtTJo0CAGDRrkiepqHqfDNX8iK9XVe9DkyjJP6Cy5PiecOFA00cg41cORV/IzfsAC9ZqeSjQuOp1wRF4EASUMo13/kuvuGCwUTUROJRL9Xzjne3h+0XZW7T5CiL+V9+7uTHiQX8Xeq4iI1FgeSULkHE6ttVFkomdYHPR/ERJuOve5Tgcc21u8VyPjd7DnlHyOxQoRzc/o2ShMNlqBX1DZ4064Ce74sJTYXzhn7J+tP8isH10TUV+9owMXxWiukIiIFKckxJsK19o4e0jDluzaf8eHrg9zhx2O7i4+jJLxBzjySq7bx8+VWJw5jBLVxpWA+AZ4Jv6Em6DNDRTs/p4NP3xDx6v74dv8mnP2gGw6eIKxn20C4OHrWtK/nSaiiohIyZSEeMs519o4te+z++G7Z+HoLnAWlFyPb6BryMSdaJxKNuo1A2sl/PP5WDGadOfQFhsdmnQ/ZwKSkZXHXz/6hbwCJ73aRPNY74u8H5+IiFRbSkK85bxrbQAFJ11zOcD1PJao1hDZumjvRt3GFzZ/pJLYT01EPXwil+aRIbw2pCM+mogqIiLnoCTEW8qwhgYAVz0KXe6DsIZgqb4f2s8t3MaaPUepE+DLe3d3IixQE1FFROTclIR4y3nW0HBr2RvCG3k3Fi/75JcDfPDTXgCm3tGBltGaiCoiIudX5mXbpZyaXOm6k4TSejcsrt6Pc6y1UR1sPHCcp77YDMAjvVrR9+JYkyMSEZHqQkmIt/hYXbfhAsUTkbKttVHVpWfm8deP1pFf4KR32xge6aUHG4qISNkpCfGmwrU2ws66TTUs7vTtudVUfoGTv81ZR4otlxZRIbw2uIMmooqISLloToi3nVprw6MrplYBz/xvKz/vPUZogC/v3d2ZUE1EFRGRclISUhl8rNDsarOj8JiPfz7AR6v3YbHAtCEdaRFVx+yQRESkGtJwjJTLr/uPMe7URNTHel9Er7ZlvAtIRETkLOoJkXNyOA3W7DnKugwL1i2pPL1wG/kOJ30TYhjVs6XZ4YmISDWmJERKtXhzMpO/2kryiVzAyod/bASgQVggUwdrRVQREbkwGo6REi3enMyDs9efSkCKSrblsvKPdBOiEhGRmkRJiBTjcBpM/mpriY/eA9cqJ5O/2orDWVoJERGR81MSIsWs3XO0xB6QQgaQfCKXtXuOVl5QIiJS4ygJkWLSMktPQCpSTkREpCRKQqSY6NBAj5YTEREpiZIQKaZLswgahJeeYFiABuGBdGkWUXlBiYhIjaMkRIqx+lgY3b9NiccKb8qdODABq27RFRGRC6AkREqUcmpi6tmJRmx4IO8Mv4z+7RqUdJqIiEiZmZ6ETJ8+naZNmxIYGEjXrl1Zu3btOctPmzaN1q1bExQURHx8PI899hi5uUUnSJa3TikqJ7+A//thNwAv3Nqe2fd25u5WDmbf25mVT1ynBERERDzC1CRk/vz5JCYmMnHiRNavX0+HDh3o168faWlpJZafO3cuY8aMYeLEiWzbto2ZM2cyf/58nnzyyQrXKcXNXbOfI9n5NI4I5pZLG9K1WQSdIg26NovQEIyIiHiMqUnI1KlTue+++xg5ciQJCQnMmDGD4OBgZs2aVWL5n376iauuuophw4bRtGlT+vbty9ChQ4v0dJS3Tikq1+7gve9dvSB/69ECX6vpnWUiIlJDmfbsmPz8fNatW8fYsWPd+3x8fOjduzerVq0q8Zwrr7yS2bNns3btWrp06cLu3btZtGgRd911V4XrBMjLyyMvL8/92mazAWC327Hb7Rf0Pqub/6zZT1pmHg3CAxnYPqZIG9S2tjCb2t0candzqN3N4Y12L09dpiUhGRkZOBwOYmKKPgo+JiaG7du3l3jOsGHDyMjIoHv37hiGQUFBAQ888IB7OKYidQJMmTKFyZMnF9u/ZMkSgoODy/vWqq0CJ7z+qxWwcFVENt8uWVzk+NKlS80JrJZTu5tD7W4Otbs5PNnuOTk5ZS5brZ6iu3z5cp5//nnefvttunbtys6dO3nkkUd45plnGD9+fIXrHTt2LImJie7XNpuN+Ph4+vbtS1hYmCdCrxY+/uUgx/O3Eh0awKS7uhPgZwVcWe3SpUvp06cPfn5+JkdZe6jdzaF2N4fa3RzeaPfC0YSyMC0JiYyMxGq1kpqaWmR/amoqsbGxJZ4zfvx47rrrLv7yl78A0L59e7Kzs7n//vt56qmnKlQnQEBAAAEBAcX2+/n51ZpfhgKHk3d/2AvA/dc0p05w8cXKalN7VCVqd3Oo3c2hdjeHJ9u9PPWYNuvQ39+fTp06kZSU5N7ndDpJSkqiW7duJZ6Tk5ODj0/RkK1W1//WDcOoUJ3i8uWGw+w/mkP9EH/u7NrE7HBERKQWMHU4JjExkREjRtC5c2e6dOnCtGnTyM7OZuTIkQDcfffdNGzYkClTpgAwcOBApk6dyqWXXuoejhk/fjwDBw50JyPnq1OKczgNpi/bCcBfrm5OkL/V5IhERKQ2MDUJGTx4MOnp6UyYMIGUlBQ6duzI4sWL3RNL9+/fX6TnY9y4cVgsFsaNG8ehQ4eIiopi4MCBPPfcc2WuU4pbuCmZ3RnZ1A32465u6gUREZHKYfrE1FGjRjFq1KgSjy1fvrzIa19fXyZOnMjEiRMrXKcU5XQavPXdHwDce1Uz6gSY/iMhIiK1hFaiquWWbE3h99QsQgN8GXFlU7PDERGRWkRJSC1mGAZvfueaC3LPVU0JD9KMdBERqTxKQmqx77anseWwjRB/K/de1czscEREpJZRElJLGYbBG6d6QYZ3a0K9EH+TIxIRkdpGSUgt9cMfGWw8cJxAPx/uu7q52eGIiEgtpCSkFnLNBXHdETOsSxMi6xRfLVZERMTblITUQqt3H+Xnvcfw9/Xhr9eqF0RERMyhJKQWKuwFGdw5npiw4s+IERERqQxKQmqZdfuO8tOuI/hZLTzQo4XZ4YiISC2mJKSWeSPJdUfMbZc1omHdIJOjERGR2kxJSC2y8cBxVvyejtXHwt96tDQ7HBERqeWUhNQihauj3twxjsb1g02ORkREajslIbXE1sM2vt2WisUCD/VUL4iIiJhPSUgt8dYy1x0xN14SR4uoOiZHIyIioiSkVvgjNZOvN6cAMEq9ICIiUkUoCakF3lq2E8OA/hfH0jo21OxwREREACUhNd6ejGy+2ngYgFHXqRdERESqDiUhNdz0ZTtxGtCrTTTtGoabHY6IiIibkpAa7MDRHD7/9RAAD/dqZXI0IiIiRSkJqcHeXr4Lh9Pg6laRdIyva3Y4IiIiRSgJqaEOHz/Jp+sOAPB39YKIiEgVpCSkhnp3xS7sDoMrmkdwedMIs8MREREpRklIDZRmy+U/P5/qBblOvSAiIlI1KQmpgd77fjf5BU46NalHtxb1zQ5HRESkREpCapgjWXnMWbMfgIeva4nFYjE5IhERkZIpCalh/m/lHk7aHVzSKJxrL4oyOxwREZFSKQmpQY7n5PPhT3sB1zNi1AsiIiJVmZKQGmTWj3vJznfQJjaUPgkxZocjIiJyTkpCaghbrp33f9wDwMPXtVIviIiIVHlKQmqID3/aS2ZuAS2j63B9u1izwxERETkvJSE1QHZeATNXunpBRvVsiY+PekFERKTqUxJSA8xevY9jOXaa1g/mxksamB2OiIhImSgJqeZO5jv41w+7Afhbz5b4WvVPKiIi1YM+saq5/6zdT0ZWPo3qBXHLpQ3NDkdERKTMlIRUY7l2B+9+vwuAB3u0wE+9ICIiUo3oU6sa+2TdQVJteTQID+RPnRqZHY6IiEi5KAmppvILnMxY7uoF+es1zQnwtZockYiISPkoCammPv/1IIeOnySyTgBDujQ2OxwREZFyqxJJyPTp02natCmBgYF07dqVtWvXllq2R48eWCyWYl833HCDu8w999xT7Hj//v0r461UigKHk+nLTveCBPqpF0RERKofX7MDmD9/PomJicyYMYOuXbsybdo0+vXrx44dO4iOji5W/rPPPiM/P9/9+siRI3To0IHbb7+9SLn+/fvz/vvvu18HBAR4701UsgUbD7P/aA4RIf7ceYV6QUREpHoyvSdk6tSp3HfffYwcOZKEhARmzJhBcHAws2bNKrF8REQEsbGx7q+lS5cSHBxcLAkJCAgoUq5evXqV8Xa8zuE0eGvZTgD+3L0Zwf6m55EiIiIVYuonWH5+PuvWrWPs2LHufT4+PvTu3ZtVq1aVqY6ZM2cyZMgQQkJCiuxfvnw50dHR1KtXj+uuu45nn32W+vXrl1hHXl4eeXl57tc2mw0Au92O3W4v79vyqoWbUtidnk14kC9DOzeslPgKr1HV2qKmU7ubQ+1uDrW7ObzR7uWpy2IYhuGxK5fT4cOHadiwIT/99BPdunVz7x89ejQrVqxgzZo15zx/7dq1dO3alTVr1tClSxf3/nnz5hEcHEyzZs3YtWsXTz75JHXq1GHVqlVYrcXnT0yaNInJkycX2z937lyCg4Mv4B16ltOAlzZaST5poX8jB9fHm/ZPJyIiUqKcnByGDRvGiRMnCAsLO2fZat2XP3PmTNq3b18kAQEYMmSIe7t9+/ZccskltGjRguXLl9OrV69i9YwdO5bExET3a5vNRnx8PH379j1vA1amJVtTSV69kZAAK8/e3ZPwIL9Kua7dbmfp0qX06dMHP7/Kuaao3c2idjeH2t0c3mj3wtGEsjA1CYmMjMRqtZKamlpkf2pqKrGx534cfXZ2NvPmzePpp58+73WaN29OZGQkO3fuLDEJCQgIKHHiqp+fX5X5ZTAMg7dXuJ6Ue8+VTYkMq/wemqrUHrWJ2t0candzqN3N4cl2L089pk5M9ff3p1OnTiQlJbn3OZ1OkpKSigzPlOSTTz4hLy+P4cOHn/c6Bw8e5MiRIzRoUH2fMLtsRxpbDtsI9rfy5+7NzQ5HRETkgpl+d0xiYiL/+te/+Pe//822bdt48MEHyc7OZuTIkQDcfffdRSauFpo5cyaDBg0qNtk0KyuLf/7zn6xevZq9e/eSlJTEzTffTMuWLenXr1+lvCdPMwyDN5Jcd8QMv6IJESH+JkckIiJy4UyfEzJ48GDS09OZMGECKSkpdOzYkcWLFxMTEwPA/v378fEpmivt2LGDlStXsmTJkmL1Wa1WfvvtN/79739z/Phx4uLi6Nu3L88880y1XStk5c4MNhw4ToCvD3+5upnZ4YiIiHiE6UkIwKhRoxg1alSJx5YvX15sX+vWrSntpp6goCC++eYbT4ZnujdP9YIM7dKY6NBAk6MRERHxDNOHY+TcVu8+wtq9R/G3+vDAtS3MDkdERMRjlIRUcW9+9wcAt3duRGy4ekFERKTmUBJSha3bd4wfdx7B18fCgz3UCyIiIjWLkpAqrLAX5NbLGtKoXtVZuVVERMQTlIRUUb8dPM7yHen4WOBvPVqaHY6IiIjHKQmpot78znVHzM0dG9I0MuQ8pUVERKofJSFV0LZkG0u3pmKxwEM91QsiIiI1k5KQKuitZa5ekAHtG9Ayuo7J0YiIiHiHkpAqZmdaJos2JQPw8HXqBRERkZpLSUgVM33ZLgwD+ibE0CY2zOxwREREvEZJSBWyNyObLzccAuDh61qZHI2IiIh3KQmpQt5evhOnAT1aR9G+UbjZ4YiIiHiVkpAq4sDRHD5br14QERGpPZSEVBEzVuyiwGlwVcv6dGpSz+xwREREvE5JSBWQciKXT345CKgXREREag8lIVXAjBW7yHc46dI0giua1zc7HBERkUqhJMRkaZm5/GftfgAe7qV1QUREpPZQEmKy//thD3kFTjrG16V7y0izwxEREak0SkJMdDQ7n9mr9wHw914tsVgsJkckIiJSeZSEmGjmyt3k5Dto1zCMnq2jzQ5HRESkUikJMcmJHDv//snVCzKqZyv1goiISK2jJMQk7/+0h6y8AlrHhNI3IcbscERERCqdkhATZObambVyDwCjrmuJj496QUREpPZREmKCD1ftw5ZbQPOoEAa0b2B2OCIiIqZQElLJcvILmFnYC9KzJVb1goiISC2lJKSSzVm9n6PZ+TSpH8xNHeLMDkdERMQ0vmYHUBs4nAZr9xzl0PEc3vxuJwB/69ECX6tyQBERqb2UhHjZ4s3JTP5qK8knct37fCwQ7K+mFxGR2k2fhF60eHMyD85ej3HWfqcBf//Pr/hZLfRvp4mpIiJSO2k8wEscToPJX20tloCcafJXW3E4z1VCRESk5lIS4iVr9xwtMgRzNgNIPpHL2j1HKy8oERGRKkRJiJekZZaegFSknIiISE2jJMRLokMDPVpORESkplES4iVdmkXQIDyQ0pYiswANwgPp0iyiMsMSERGpMpSEeInVx8LEgQkAxRKRwtcTByZoxVQREam1lIR4Uf92DXhn+GXEhhcdcokND+Sd4Zfp9lwREanVtE6Il/Vv14A+CbGs3XOUtMxcokNdQzDqARERkdpOSUglsPpY6NaivtlhiIiIVClVYjhm+vTpNG3alMDAQLp27cratWtLLdujRw8sFkuxrxtuuMFdxjAMJkyYQIMGDQgKCqJ379788ccflfFWREREpIxMT0Lmz59PYmIiEydOZP369XTo0IF+/fqRlpZWYvnPPvuM5ORk99fmzZuxWq3cfvvt7jIvvfQSb7zxBjNmzGDNmjWEhITQr18/cnO1JoeIiEhVYfpwzNSpU7nvvvsYOXIkADNmzGDhwoXMmjWLMWPGFCsfEVH0ltZ58+YRHBzsTkIMw2DatGmMGzeOm2++GYAPP/yQmJgYvvjiC4YMGVKszry8PPLy8tyvbTYbAHa7Hbvd7pk3Wo0VtoHaonKp3c2hdjeH2t0c3mj38tRlMQzDtIeX5OfnExwczKeffsqgQYPc+0eMGMHx48f58ssvz1tH+/bt6datG++99x4Au3fvpkWLFvz666907NjRXe7aa6+lY8eOvP7668XqmDRpEpMnTy62f+7cuQQHB5f/jYmIiNRSOTk5DBs2jBMnThAWFnbOsqb2hGRkZOBwOIiJiSmyPyYmhu3bt5/3/LVr17J582Zmzpzp3peSkuKu4+w6C4+dbezYsSQmJrpf22w24uPj6du373kbsDaw2+0sXbqUPn364OfnZ3Y4tYba3Rxqd3Oo3c3hjXYvHE0oC9OHYy7EzJkzad++PV26dLmgegICAggICCi238/PT78MZ1B7mEPtbg61uznU7ubwZLuXpx5Tk5DIyEisViupqalF9qemphIbG3vOc7Ozs5k3bx5PP/10kf2F56WmptKgwenFwFJTU4sMz5xL4QhVebK5msxut5OTk4PNZtMfh0qkdjeH2t0candzeKPdCz87yzLbw9QkxN/fn06dOpGUlOSeE+J0OklKSmLUqFHnPPeTTz4hLy+P4cOHF9nfrFkzYmNjSUpKcicdNpuNNWvW8OCDD5YprszMTADi4+PL94ZEREQEcH2WhoeHn7OM6cMxiYmJjBgxgs6dO9OlSxemTZtGdna2+26Zu+++m4YNGzJlypQi582cOZNBgwZRv37RRcAsFguPPvoozz77LK1ataJZs2aMHz+euLi4IpNfzyUuLo4DBw4QGhqKxaKVTQvnyBw4cEBzZCqR2t0candzqN3N4Y12NwyDzMxM4uLizlvW9CRk8ODBpKenM2HCBFJSUujYsSOLFy92Tyzdv38/Pj5FlzPZsWMHK1euZMmSJSXWOXr0aLKzs7n//vs5fvw43bt3Z/HixQQGBpZY/mw+Pj40atTowt5YDRQWFqY/DiZQu5tD7W4Otbs5PN3u5+sBKWTqLbpSPdhsNsLDw8t0u5V4jtrdHGp3c6jdzWF2u5u+YqqIiIjUTkpC5LwCAgKYOHFiibcxi/eo3c2hdjeH2t0cZre7hmNERETEFOoJEREREVMoCRERERFTKAkRERERUygJEREREVMoCZFSTZkyhcsvv5zQ0FCio6MZNGgQO3bsMDusWuWFF15wrwIs3nfo0CGGDx9O/fr1CQoKon379vzyyy9mh1WjORwOxo8fT7NmzQgKCqJFixY888wzZXruiJTd999/z8CBA4mLi8NisfDFF18UOW4YBhMmTKBBgwYEBQXRu3dv/vjjD6/HpSRESrVixQoeeughVq9ezdKlS7Hb7fTt25fs7GyzQ6sVfv75Z959910uueQSs0OpFY4dO8ZVV12Fn58fX3/9NVu3buXVV1+lXr16ZodWo7344ou88847vPXWW2zbto0XX3yRl156iTfffNPs0GqU7OxsOnTowPTp00s8/tJLL/HGG28wY8YM1qxZQ0hICP369SM3N9ercekWXSmz9PR0oqOjWbFiBddcc43Z4dRoWVlZXHbZZbz99ts8++yzdOzYkWnTppkdVo02ZswYfvzxR3744QezQ6lVbrzxRmJiYpg5c6Z732233UZQUBCzZ882MbKay2Kx8Pnnn7ufp2YYBnFxcfzjH//g8ccfB+DEiRPExMTwwQcfMGTIEK/Fop4QKbMTJ04AEBERYXIkNd9DDz3EDTfcQO/evc0OpdZYsGABnTt35vbbbyc6OppLL72Uf/3rX2aHVeNdeeWVJCUl8fvvvwOwceNGVq5cyfXXX29yZLXHnj17SElJKfL3Jjw8nK5du7Jq1SqvXtv0B9hJ9eB0Onn00Ue56qqraNeundnh1Gjz5s1j/fr1/Pzzz2aHUqvs3r2bd955h8TERJ588kl+/vln/v73v+Pv78+IESPMDq/GGjNmDDabjTZt2mC1WnE4HDz33HPceeedZodWa6SkpAC4HxxbKCYmxn3MW5SESJk89NBDbN68mZUrV5odSo124MABHnnkEZYuXVrmpz6LZzidTjp37szzzz8PwKWXXsrmzZuZMWOGkhAv+vjjj5kzZw5z587l4osvZsOGDTz66KPExcWp3WsBDcfIeY0aNYr//e9/LFu2jEaNGpkdTo22bt060tLSuOyyy/D19cXX15cVK1bwxhtv4Ovri8PhMDvEGqtBgwYkJCQU2de2bVv2799vUkS1wz//+U/GjBnDkCFDaN++PXfddRePPfYYU6ZMMTu0WiM2NhaA1NTUIvtTU1Pdx7xFSYiUyjAMRo0axeeff853331Hs2bNzA6pxuvVqxebNm1iw4YN7q/OnTtz5513smHDBqxWq9kh1lhXXXVVsVvQf//9d5o0aWJSRLVDTk4OPj5FP4qsVitOp9OkiGqfZs2aERsbS1JSknufzWZjzZo1dOvWzavX1nCMlOqhhx5i7ty5fPnll4SGhrrHBsPDwwkKCjI5upopNDS02JybkJAQ6tevr7k4XvbYY49x5ZVX8vzzz3PHHXewdu1a3nvvPd577z2zQ6vRBg4cyHPPPUfjxo25+OKL+fXXX5k6dSr33nuv2aHVKFlZWezcudP9es+ePWzYsIGIiAgaN27Mo48+yrPPPkurVq1o1qwZ48ePJy4uzn0HjdcYIqUASvx6//33zQ6tVrn22muNRx55xOwwaoWvvvrKaNeunREQEGC0adPGeO+998wOqcaz2WzGI488YjRu3NgIDAw0mjdvbjz11FNGXl6e2aHVKMuWLSvx7/mIESMMwzAMp9NpjB8/3oiJiTECAgKMXr16GTt27PB6XFonREREREyhOSEiIiJiCiUhIiIiYgolISIiImIKJSEiIiJiCiUhIiIiYgolISIiImIKJSEiIiJiCiUhIiIiYgolISJSa1gsFr744guzwxCRU5SEiEiluOeee7BYLMW++vfvb3ZoImISPcBORCpN//79ef/994vsCwgIMCkaETGbekJEpNIEBAQQGxtb5KtevXqAa6jknXfe4frrrycoKIjmzZvz6aefFjl/06ZNXHfddQQFBVG/fn3uv/9+srKyipSZNWsWF198MQEBATRo0IBRo0YVOZ6RkcEtt9xCcHAwrVq1YsGCBd590yJSKiUhIlJljB8/nttuu42NGzdy5513MmTIELZt2wZAdnY2/fr1o169evz888988sknfPvtt0WSjHfeeYeHHnqI+++/n02bNrFgwQJatmxZ5BqTJ0/mjjvu4LfffmPAgAHceeedHD16tFLfp4ic4vXn9IqIGIYxYsQIw2q1GiEhIUW+nnvuOcMwDAMwHnjggSLndO3a1XjwwQcNwzCM9957z6hXr56RlZXlPr5w4ULDx8fHSElJMQzDMOLi4oynnnqq1BgAY9y4ce7XWVlZBmB8/fXXHnufIlJ2mhMiIpWmZ8+evPPOO0X2RUREuLe7detW5Fi3bt3YsGEDANu2baNDhw6EhIS4j1911VU4nU527NiBxWLh8OHD9OrV65wxXHLJJe7tkJAQwsLCSEtLq+hbEpELoCRERCpNSEhIseERTwkKCipTOT8/vyKvLRYLTqfTGyGJyHloToiIVBmrV68u9rpt27YAtG3blo0bN5Kdne0+/uOPP+Lj40Pr1q0JDQ2ladOmJCUlVWrMIlJx6gkRkUqTl5dHSkpKkX2+vr5ERkYC8Mknn9C5c2e6d+/OnDlzWLt2LTNnzgTgzjvvZOLEiYwYMYJJkyaRnp7Oww8/zF133UVMTAwAkyZN4oEHHiA6Oprrr7+ezMxMfvzxRx5++OHKfaMiUiZKQkSk0ixevJgGDRoU2de6dWu2b98OuO5cmTdvHn/7299o0KAB//nPf0hISAAgODiYb775hkceeYTLL7+c4OBgbrvtNqZOnequa8SIEeTm5vLaa6/x+OOPExkZyZ/+9KfKe4MiUi4WwzAMs4MQEbFYLHz++ecMGjTI7FBEpJJoToiIiIiYQkmIiIiImEJzQkSkStDIsEjto54QERERMYWSEBERETGFkhARERExhZIQERERMYWSEBERETGFkhARERExhZIQERERMYWSEBERETHF/wNOH9O+faA0ngAAAABJRU5ErkJggg==\n"
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiEAAAGJCAYAAABcsOOZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZHZJREFUeJzt3Xd8FNX6x/HP7qZDElpICARCL1KlRBDbpVpQbBSlesWrP1ExehWUasOK2FEv2EBBrw2vSjGC9F6kF6lCEhJaGkk2u/P7Y0kkJiGF3UzK9/16xeyeOXPOs8cl++zMmTMWwzAMREREREqZ1ewAREREpHJSEiIiIiKmUBIiIiIiplASIiIiIqZQEiIiIiKmUBIiIiIiplASIiIiIqZQEiIiIiKmUBIiIiIiplASIiIiIqZQEiIibvXuu+9isViIiorKs+3QoUNYLBZeffXVfPd99dVXsVgsHDp0KKfs2muvxWKx5Pz4+/vTtm1bpk+fjtPpzLedkydP8u9//5vmzZvj5+dHjRo16NOnD//73/8KjDspKYkpU6bQrl07qlatir+/P61bt+bJJ5/k+PHjxRsEESkSL7MDEJGKZc6cOURGRrJu3Tr2799PkyZNLrnNevXqMXXqVAASExP5/PPPefTRR0lISOD555/PVXfPnj306NGDhIQERo4cSadOnThz5gxz5syhX79+PP7447zyyiu59jlw4AA9e/bkyJEj3Hnnndx33334+Pjw+++/M3PmTL799lv27t17ya9DRP7GEBFxkwMHDhiA8c033xghISHG5MmTc20/ePCgARivvPJKvvu/8sorBmAcPHgwp+yaa64xLrvsslz1zp07ZzRo0MAIDAw0srKycsozMzON1q1bGwEBAcaaNWty7ZOVlWUMHDjQAIy5c+fmlNvtdqNdu3ZGQECAsXz58jwxnT171njqqaeKPAYiUnQ6HSMibjNnzhyqV6/OjTfeyB133MGcOXM80o+fnx+dO3cmOTmZEydO5JR//fXXbN++nbFjx+Y5HWSz2Xj//fepVq0akydPzrXP1q1befrpp+nevXuevoKCgvIcbRER91ASIiJuM2fOHG677TZ8fHwYPHgw+/btY/369R7pK3t+SbVq1XLKfvjhBwCGDRuW7z7BwcHccsst7N69m/379wMwf/58AIYOHeqROEWkYEpCRMQtNm7cyO7duxk0aBAA3bt3p169em45GuJwOEhMTCQxMZE9e/bwxBNPsGHDBm644Qb8/f1z6u3cuZPg4GAaNGhQYFvt2rUDYNeuXTm/g4ODiYiIuOQ4RaR4NDFVRNxizpw5hIaGct111wFgsVgYOHAgs2fP5rXXXsNms5W47d27dxMSEpKr7Oabb2bmzJm5ypKTkwkMDLxoW9nbk5KScn4Xto+IeIaOhIjIJXM4HMydO5frrruOgwcPsn//fvbv309UVBTx8fHExMQUqz2LxZLreWRkJIsXL2bhwoW8++671K1bl4SEBPz8/HLVCwwMJDk5+aJtZ2/PTjyCgoIK3UdEPENJiIhcsl9//ZXY2Fjmzp1L06ZNc34GDBgAkHNKJjtpOHfuXL7tpKWl5aqXrUqVKvTs2ZPevXvzwAMP8NNPP7Fu3TqeeuqpXPVatmzJ2bNnOXLkSIGx/v777wC0atUKgBYtWnD27FmOHj1a3JctIpdISYiIXLI5c+ZQu3Ztvvrqqzw/gwcP5ttvv+XcuXOEhIQQEBDAnj178m1nz549BAQEUKtWrYv217ZtW4YMGcL777+fK+G46aabAPj000/z3S8pKYnvv/+eFi1a5Kxf0q9fPwBmz55d7NctIpfI7GuERaR8S0tLMwIDA4177rkn3+0rV67MtTZH//79jaCgIOPw4cO56h0+fNgIDAw0+vfvn6s8v3VCDMMwduzYYVgsFuORRx7JKcvIyDBatWplVKlSxVi/fn2u+g6Hw7jrrrsMwPjiiy9yyjMzM402bdoYVapUMVatWpWnn6SkJK0TIuIhFsMwDLMTIREpv+bNm8egQYP47rvvuOWWW/JsdzqdhIWFccUVVzB//nx27drFFVdcgbe3N/fddx+RkZEcOnSIDz74ALvdzpo1a2jZsmXO/tdeey2JiYls3749T9s33XQTS5cu5fDhw9SsWRNwXe3So0cPTp06lWvF1M8//5xNmzbx2GOP5Vk2fv/+/fTs2ZNjx44xYMAArrzySry9vdmxYweff/451atXL/DojYhcArOzIBEp3/r162f4+fkZqampBdYZMWKE4e3tbSQmJhqGYRi7du0yBg4caNSuXdvw8vIyateubQwaNMjYtWtXnn0LOhJiGIaxdOlSAzAmTZqUq/zEiRNGdHS00aRJE8PX19eoVq2a0bNnT2P+/PkFxnj69Glj4sSJRps2bYyAgADDz8/PaN26tTFu3DgjNja2CCMhIsWlIyEiIiJiCk1MFREREVMoCRERERFTKAkRERERUygJEREREVMoCRERERFTKAkRERERU+guuvlwOp0cP36cwMDAPDfSEhERkYIZhkFycjLh4eFYrRc/1qEkJB/Hjx8nIiLC7DBERETKraNHj1KvXr2L1lESko/sW3wfPXqUoKAgk6Mxn91uZ9GiRfTu3Rtvb2+zw6k0NO7m0LibQ+NuDk+Me1JSEhERETmfpRejJCQf2adggoKClITgepMGBAQQFBSkPw6lSONuDo27OTTu5vDkuBdlOoMmpoqIiIgplISIiIiIKZSEiIiIiCk0J6SEDMMgKysLh8NhdigeZ7fb8fLyIj093W2v19vbG5vN5pa2RESkfFISUgKZmZnExsaSlpZmdiilwjAMwsLCOHr0qNvWTbFYLNSrV4+qVau6pT0RESl/TE1Cli1bxiuvvMLGjRuJjY3l22+/pX///hfdZ+nSpURHR7Njxw4iIiIYP348I0aMyFXnnXfe4ZVXXiEuLo527drx1ltv0aVLF7fE7HQ6OXjwIDabjfDwcHx8fCr8gmZOp5OUlBSqVq1a6MIzRWEYBgkJCfz55580bdpUR0RERCopU5OQ1NRU2rVrxz333MNtt91WaP2DBw9y4403cv/99zNnzhxiYmK49957qVOnDn369AFg3rx5REdHM2PGDKKiopg+fTp9+vRhz5491K5d+5JjzszMxOl0EhERQUBAwCW3Vx44nU4yMzPx8/NzSxICEBISwqFDh7Db7UpCRERM4HAarD14io2JFmoePEXXJrWxWUv3S7WpScj111/P9ddfX+T6M2bMoGHDhrz22msAtGzZkhUrVvD666/nJCHTpk1j1KhRjBw5MmefH3/8kVmzZjF27Fi3xe6uD+PKqqIfPRKRysHhNFh38BQnktOpHehHl4Y1Sv2DvCQWbI9lyg87iT2bDtj4dN8G6gT7MalfK/q2rlNqcZSrOSGrV6+mZ8+eucr69OnDmDFjANdRio0bNzJu3Lic7VarlZ49e7J69eoC283IyCAjIyPneVJSEuCakGm323PVtdvtGIaB0+nE6XRe6ksqFwzDyPntrtfsdDoxDENHQi4i+7339/egeJbGvfQ5nAZr/khgY6KF4H0nuKJxSLn4IF+4I57nftpNXNJfnx9hQb6Mv6EFfS4LNTGyi1u4I56H5m7F+Ft53Nl0Hpi9ibcGtbuk+Ivzb6dcJSFxcXGEhuYemNDQUJKSkjh37hynT5/G4XDkW2f37t0Ftjt16lSmTJmSp3zRokV5Trl4eXkRFhZGSkoKmZmZl/Bqyp/k5GS3tZWZmcm5c+dYtmwZWVlZbmu3Ilq8eLHZIVRKGvfSsfWkhW8OWTmTacH1jXwL1XwMbot00q7m3z8my46tJy3M2pt9RPyvhCkuKZ3Rc7dwTzPz4zcMcBhgd/71k+6Ad3fZzicguRO98183Gf/NFuyHHJQ0DyzORRvlKgnxlHHjxhEdHZ3zPHvd+969e+dZtj09PZ2jR49StWpV/Pz8Stynw2mw/tApTiRnUDvQl86RZfcQXvYdES+8q3CjRo145JFHeOSRR0rUZnp6Ov7+/lx99dWXNI4Vmd1uZ/HixfTq1UvLWJcijXvpWbgjno9W5/1GfjbTwkd7bZf8jdxTHE6Dqa8tAzLy2WrBAvwcH8ATd1+d6++6YRjYHQYZWQ7S7U7SsxykZ57/ff55ht1Jut1Betb53+efZ2T9VZ5hd3Du7+V2Z0675y4odxY7D7JwJhNCWl1BVMMaJRqf7LMJRVGukpCwsDDi4+NzlcXHxxMUFIS/vz82mw2bzZZvnbCwsALb9fX1xdfXN0+5t7d3nj9CDocDi8WC1Wot8byQ3OfiXErjXNy1115L+/btmT59erH2yz4Fk/26AdavX0+VKlVKPAZWqxWLxZLvGEtuGiNzaNw9y+E0eP7nPXkSEHB9I7cAz/+8h+vb1i30C1r2h3uW0+n67XCS5TSwO5xknS/PzLr49tz7562bmeUky+mqf+RUWq5TMPnFH3s2g+umLcdqsZBud3DO7ihhUuAeFgv4edmwWiA1s/D1nk6mZZX4/V+c/cpVEtK1a1d++umnXGWLFy+ma9euAPj4+NCxY0diYmJyLvV1Op3ExMQwevTo0g43Xwu2x/LA7E0Fnot7b8jlpTop6EKGYeBwOPDyKvxtERISUgoRiUhFkm53kJCcQWJKBiv2Jeb6IvZ3rg/ydK59ZQneXlayHK6kITtZyH6e5TRwmPXJXoiLvb7spMDP24qft+2CH2s+5Rc8zrXtb/t6FbCPtxUfm+uL3+o/TjL4wzWFxl47sHSOUJuahKSkpLB///6c5wcPHmTLli3UqFGD+vXrM27cOI4dO8ann34KwP3338/bb7/NE088wT333MOvv/7Kl19+yY8//pjTRnR0NMOHD6dTp0506dKF6dOnk5qamnO1jCcYhsE5e+GZpcNpMGn+jotm/pPn7+TKJrWKdGrG39tW5KtMRowYwW+//cZvv/3GG2+8AcBHH33EyJEj+emnnxg/fjzbtm1j0aJFREREEB0dzZo1a0hNTaVly5Y8/fTT3HzzzTntRUZGMmbMmJxJwRaLhQ8//JAff/yRhQsXUrduXV577bVc+4iI55h1lYbd4eRkSiYJyRkkpKSTmJxJQkrG+eeu34nnHyenF3/+19HT50oUl81qwctqwdtmxctmwctqxdtmwctmwdt6QZmXFW/r+XKbFS+rBS/b+brn62XXz94en5zBD1uPFxrDxJta0rFBjYsmBaWtS8Ma1An2I+5ser6fRRYgLNj1/ikNpiYhGzZs4Lrrrst5nj0vY/jw4Xz88cfExsZy5MiRnO0NGzbkxx9/5NFHH+WNN96gXr16/Oc//8m5PBdg4MCBJCQkMHHiROLi4mjfvj0LFizIM1nVnc7ZHbSauPCS2zFwTWpqM3lRkervfKYPAT5F+1/4xhtvsHfvXlq3bs0zzzwDwI4dOwAYO3Ysr776Ko0aNaJ69eocPXqUG264geeffx5fX18++eQTBg8ezK5du4iMjCywjylTpvDyyy/zyiuv8NZbb3H33Xdz+PBhatQonTezSGXl7lO8DqfBqdTMnEQi8W+/s49mJCRncDqteFcR+dishAT64udt5Y+E1ELrP31DS9rWC86VGLiSCWtOkpH9PCdxsFqwejABczgNNhw6VegH+fBuDcvcXD+b1cKkfq14YPYmLJAr/uxIJ/VrVWpxm5qEXHvttTmXf+bn448/znefzZs3X7Td0aNHl5nTL2VFcHAwPj4+BAQE5MyPyb5i6JlnnqFXr145dWvUqEG7du1ynj/zzDN8/fXX/PDDDzz00EMF9jFixAgGDx4MwAsvvMCbb77JunXr6Nu3rydekohQ9FO8hmFwJs2eJ5nI+Z2cQeL5IxqnUjOKNXfBZrVQq6oPIYG+1KrqS0hV378eB+Z+HOTnhcViweE06P7Sr4V+kN/TXR/k7ta3dR3eG3J5nsQ1TOuElE/+3jZ2PtOn0HrrDp5ixEfrC6338cjORToU5u/tnvU1OnXqlOt5SkoKkydP5scffyQ2NpasrCzOnTuX66hUftq2bZvzuEqVKgQFBXHixAm3xCgieTmcBpPn7yzwFC/AQ19spkbADk6lZWJ3FD2zsFigZhWfvxKJiyQW1fy9i33kQR/k5urbug69WoWxev8JFi1fS++roirfiqkVhcViKdJpkauahhTpXNxVTUt3oZ4qVarkev7444+zePFiXn31VZo0aYKvry+33357oeui/H1GtMViqTQLuol4SmpGFrFnz3HsTDrHz5wj9sxfjw8kphB/kas0AOwOg/jkv+pUC/AmpGr+yYTrseuIRo0AH7xsnl0ZuqJ8kJfHFVPBlQhGNazByV0GUSbFrSSkFJmd+fv4+OBwFD6BduXKlYwYMYJbb70VcF3zXdhREJGKoLTvpeFwGpxIdiUU2YmF6+f847PnOFPMORf5eax3M+7oWI+aVXzx8Spbt5woK9/IS8pmtdC1cU2zwyi3lISUMjMz/8jISNauXcuhQ4eoWrVqgUcpmjZtyjfffEO/fv2wWCyMHz/+onN3RCoCT9xLIyndnpNYXJhkxJ5J59iZc8QlpRfp8tJAPy/qVvMnvJo/4dX8CK/mT91q/pxKzWTKDzsL3b9TgxrUCfYv0WsoDWXhG7mYQ0mICcw6hPf4448zfPhwWrVqxblz5/joo4/yrTdt2jTuueceunXrRq1atXjiiSc4ffq0R2MTMVNJ1u+xO5zEnf3riMXx84nFhYlGckbhl6R6WS2EBf+VWGQnGeHV/AkP9qdONT+C/PJf/MnhNPhg2YEyc7mlSHEpCTGJGYfwmjVrludGfiNGjMhTLzIykl9//TXnudPpZMiQIbmWsD906FCuffI7UnLmzJlLilekNDicBlN+uPjkzif++zsbDp8m9uxfRzNOJGdQlAOE1QO8c5KK/JKMkEDfEn8BMfsUr8ilUhIiIpXauoOnLrqyJUBSehb/WX4wT7mPl5W61fypE+x3QaKRO8nw9/HsXaLL++ROqdyUhIhIpXT0VBq/7U1g3vqiTbq+tnkIVzUNyZVk1KziY8qql39X3q/SkMpLSYiIVAppmVmsOXCSZXsTWbY3gQOJha/WeaF/Xd24TF8Foas0pDxSEiIiFZJhGOyKTWbZvgSW7U1gw6HTZDr+uiLMZrXQsX51ujetySerD3MqJVOTO0VKmZIQEakwTqVmsnxfgutox74EEpJzL+RVr7o/VzcL4eqmIXRrUjPnqpNmoYGa3CliAiUhIlJu2R1ONh85w7K9CSzbl8C2Y2dzXbHi722ja+OaXN20Flc3C6FhrSr5zuHQ5E4RcygJEZFy5eiptJxTLKv2n8yzFkeLsECuaRbC1c1C6BRZHV+vol2dUt5X7hQpj5SEiEiZVtiE0uoB3lzVNOT8aZZa1A7yK3FfWrlTpHQpCRGRMsUwDHbHJbNsbwK/FTCh9PL61bj6fOLRum6wkgWRckpJiFmcDji8ClLioWooNOgGVs8uanSpGjVqxJgxYxgzZozZoUgZ5nAaxV6v4sIJpcv3JXDibxNK61ZzTSi9plnuCaUiUr4pCTHDzvmw4ElIOv5XWVA49H0JWt1sXlwilyj3TeBc8rsJnN3hZMvRM/y2p+AJpVc0quE6xdIshEYFTCgVkfJNSUhp2zkfvhwGf1+RICnWVT7gUyUiUi4VdhO4Z/u3xmLhohNKs492FGdCqYiUX0pC3MEwwJ5WeD2nA35+gjwJiKsRwOI6QtLo2qKdmvEOgCJ+O/zggw+YPHkyf/75J1arNaf8lltuoWbNmjz99NNER0ezZs0aUlNTadmyJVOnTqVnz55Fal8qt6LcBG78d9tzlVcP8KZ705Ccy2dDL2FCqYiUT0pC3MGeBi+Eu6Ehw3WK5sWIolV/6jj4VClS1TvvvJOHHnqIJUuW0KNHDwBOnTrFggUL+Omnn0hJSeGGG27g+eefx9fXl08//ZR+/fqxZ88e6tWrV9IXJJVEUW4CB9AstCo3tQ3n6mYhtNGEUpFKT0lIJVG9enWuv/56Pv/885wk5L///S+1atXiuuuuw2q10q5du5z6zz77LN9++y3z58/n//7v/8wKW8qJE8mFJyAAD17XhFva1/VwNCJSXigJcQfvANdRicIcXgVz7ii83t3/dV0tU5R+i+Huu+9m1KhRvPvuu/j6+jJnzhwGDRqE1WolJSWFyZMn8+OPPxIbG0tWVhbnzp3jyJGi3WFUKq9Dial8teHPItWtHahTLiLyFyUh7mCxFO20SON/uK6CSYol/3khFtf2xv/wyOW6/fr1wzAMfvzxRzp37szy5ct5/fXXAXj88cdZvHgxr776Kk2aNMHf35877riDzMxMt8chFcOxM+d4K2YfX238E4czv/fzX3QTOBHJj5KQ0mS1uS7D/XIYFHSrrL4vemy9ED8/P2677TbmzJnD/v37ad68OZdffjkAK1euZMSIEdx6660ApKSkcOjQIY/EIeVbfFI67yzZz9x1R3MWEbu2eQhXNKrJSz/vBnQTOBEpGiUhpa3Vza7LcPNdJ+RFj1+ee/fdd3PTTTexY8cOhgwZklPetGlTvvnmG/r164fFYmHChAk4nc6LtCSVzcmUDGb89gefrj5MRpbrvdGtcU0e692Mjg1cRzgiawboJnAiUmRKQszQ6mZocaMpK6b+4x//oEaNGuzZs4e77rorp3zatGncc889dOvWjVq1avHkk0+SlJTk8Xik7DubZufD5QeYtfIgaZkOADo2qM5jvZrRrUmtXHWzbwJX3BVTRaRyUhJiFqsNGl5V+t1arRw/nncSbWRkJL/++muusgcffBAg54jIgQMHcq0xIhVbcrqdj1Ye4sPlB0hOdy0s1rpuEI/1bs61zUIKXMHUZrXQtXHN0gzVfZwOLIdXUPfUaiyHg6DR1WX+dgpisnJ4C44cZeD9riRERHI5l+ng09WHmPHbH5xOswPQPDSQ6N7N6N0qtOIun37+dgpeScfpBHD4vfJ1OwV9GJa+8nwLjjLyflcSIiIApNsdfLHuCO8s+YPEFNcN5BrVqsKYXs24qU0drBX5lEp5v52CPgxLX3l+z5Sh2HVsXaSSszucfL72CNe9upQpP+wkMSWDetX9efXOdix69GpubhdesRMQp8P1AX6xRecXjHXVK4uyP1CS/naaNfsDZed8c+IqivIae3l+z5Sx2HUkRKSScjgNvtt8jDdi9nHklOveR2FBfjzUowl3dozAx6uE31HK+mkBw4CMJEg7CWmn4eCyvB+CuXeApGPwzSio0Qis3q7XY/N2Pbadf57z2Mv1k7P9/PN8t1/wO6fuheWFjFuhHygW1wdKixuL9//A6QTDAc6s8z8O1487yxx2V2wX+zD8fjSc+uN8kdP1/84wzj92uuplP76w3HBesE8+2/Ps9/d982vX+GtbamLR3jMzuoNv0Pn2jCL+Jm95Tkwl2Pfvvx0ZkH628NgPryqVeYtKQkrIuPC+41JsGj/zOJ0GP26LZfove/kjIRWAWlV9+L9rm3BXVH38vC8hYSjt0wJOJ2SchbRT539Owrnzv7Ofp52Ec6f/Kjt3yvVBWFzbv3Z//IWyXCRJ8XJ9kBflw3B6W/Dydb1uw1l4gpBvYmCCjLPwy2Szoyi5EzvNjqDkUuJLpRslIcXk7e0NQFpaGv7+/iZHU35lr8Rqs5Whb8gVnGEYLN4Zz7TFe9kdlwxAtQBv/nV1Y4Z3a0CAzyX+ObjU88xOJ6SfySeZuCChuDCZyK6T/a23uLwDIKCm60P99IHC67e8BQJDXR/8Tjs4sj+0sx/bXc8d9r8+0B1/L/t73Qse55sYGeDIdP1ciqSiLatfJNlHciy284+tf3tuO/+TT52cMhukJcKJXYX3V7+r6wgUFtfq1Bbr+Z8LHvP38guf57f9gt/5brtwv3y2n9wPK98oPPZrxkJoq7/ayfe39YLHFFI3n98XxlmUNo5vhvmjC4+9amjhddzA9CTknXfe4ZVXXiEuLo527drx1ltv0aVLl3zr2u12pk6dyieffMKxY8do3rw5L730En379s2pM3nyZKZMmZJrv+bNm7N79263xGuz2ahWrRonTpwAICAgoOJeLXCe0+kkMzOT9PR0t1yi63Q6SUhIICAgAC8v09+CFZ5hGCzbl8hri/bw+5+uw7CBvl7ce1Uj7ukeSaCf96V3UpTzzPMfcv3xPnf6fILxtyMW6WdKnlD4VAX/GhBQw5VYZP/OKcsuv6DM2/+v2Ke3Lvx2Cnd+5NnTSoZRQBKTT8KSXefPjbBwbOFt95kKdS//KwHIkyQUtcyN0wgPLodPbiq83nVPm7KcwUU5HbDtq8LfM9c8UbZORQLUbglLXyg89qLcv8wNTP0EmDdvHtHR0cyYMYOoqCimT59Onz592LNnD7Vr185Tf/z48cyePZsPP/yQFi1asHDhQm699VZWrVpFhw4dcupddtll/PLLLznP3f1BFxYWBpCTiFR0hmFw7tw5/P393ZZwWa1W6tevX+ETOLOt/uMkry3aw4bDpwEI8LExolsk913diGoBPiVrNDMNkmNdpwGyfx/bUMhpAVxJRsyUi9cB8AksIJmoCQHV/5ZMnK/j5Vuy1wKm307hr67On3qxFSMprNsRVr9Z+AdK1L/K3odhg25Fu5dWKX0YFktZec+URBmL3WKYeHI+KiqKzp078/bbbwOub8gRERE89NBDjB2bN7sPDw/n6aefzllEC+D222/H39+f2bNnA64jId999x1btmwpcVxJSUkEBwdz9uxZgoKCCqzncDiw2+0l7qe8sNvtLFu2jKuvvjrndNSl8vHx0cJnF+N0kHVgGVuWL6T9VX3wKua6CRsPn2ba4j2s3H8SAB8vK8OuaMD91zamVtUCPrCdTtcRieTjrg+Gv/9OOu56fNFJbYWI6Or6Rl5QMuFfA7xKmBxdqnzns9QtldspXJKc02CQ7wdKubhUFMpd7FB+3zPg0diL+hkKJh4JyczMZOPGjYwbNy6nzGq10rNnT1avXp3vPhkZGfj55b4VuL+/PytWrMhVtm/fPsLDw/Hz86Nr165MnTqV+vXrFxhLRkYGGRkZOc+zlyu32+2FJhmVYU6D0+kkKysLm83mttfrcDhwOMrg5WtlgGX3/7Ategqv5L/WTTACw3H0fgGjxcUPX+84nsT0mP0s3ZsIgLfNwoCO9bj/yjqEWc5giV9L1v5YLMmxkJz9O+6v586iJdWGdwAEhmEE1oHAOhhOB7ad3xa6X9Y1T2I06H6RhgGzEvum10Pj3jgOrmD76l9o3bUntobdXclfWf6y0fR6LLd/hG3RU1iS//pAMYLCcfR6HqPp9WU3/vIcO+S8ZyxHV+dcDWZEdC377xnw6Pu9OF/OTTsScvz4cerWrcuqVavo2rVrTvkTTzzBb7/9xtq1a/Psc9ddd7F161a+++47GjduTExMDLfccgsOhyMnifj5559JSUmhefPmxMbGMmXKFI4dO8b27dsJDAzMN5b85pEAfP755wQEBLjpFYsUrs6Z9XQ++Bbw191n4a/viOsbPkRstc4XbDDwdqSQnHSaXXFnOZdyhjBOEWY5RXPfUzTwOk1Vx2l8s5KLHEO6VxDp3tVJ967OOe/qpPvU+Ovx+d9ZtoDzE92y43DSe0c0fvZT5HeCzQDOeddg8WXTzk+kE7cznNRM2YOf/Qzp3tU4WbV5+Rnr8hy75JGWlsZdd91VpCMh5SoJSUhIYNSoUfzwww9YLBYaN25Mz549mTVrFufOncu3nzNnztCgQQOmTZvGP//5z3zr5HckJCIigsTExEIHsDKw2+0sXryYXr16ue10jOTD6cDr7Q6QfLzAD3J8qmI06QUpcViS4zCSjmN1ZORTO5/9bb6uoxaBYa7fQeHnn9f563fVULCV7HSIZff/sH090vX4gkPrxvlX47j9o0KP5JQFer+bQ+NuDk+Me1JSErVq1Srbp2Nq1aqFzWYjPj73tcjx8fE5Ez//LiQkhO+++4709HROnjxJeHg4Y8eOpVGjRgX2U61aNZo1a8b+/fsLrOPr64uvb97z5N7e3vrHcAGNh4cdXOOac1EAC0BmCpYLTntkJyunjKqk+damelgDqtSq75rQF1gn12+Lf3WwWPJNcNyiza1gs+U5z2wJCoe+L+JV1s+R/43e7+bQuJvDneNenHZMS0J8fHzo2LEjMTEx9O/fH3DNPYiJiWH06Itfw+zn50fdunWx2+18/fXXDBgwoMC6KSkp/PHHHwwdOtSd4Yu4X3JckaptqdaLjxNbcMxRnTiq06ppcx7q05rWdYM9HGARtLrZtTpnWV4xVUTKDFMv0Y2Ojmb48OF06tSJLl26MH36dFJTUxk50nVId9iwYdStW5epU6cCsHbtWo4dO0b79u05duwYkydPxul08sQTT+S0+fjjj9OvXz8aNGjA8ePHmTRpEjabjcGDB5vyGkWK5OByWPZykaq+eCKKNc5WdG9Sizd6N+Py+tU9HFwxWW1lb10HESmTTE1CBg4cSEJCAhMnTiQuLo727duzYMECQkNdK7UdOXIk12Wc6enpjB8/ngMHDlC1alVuuOEGPvvsM6pVq5ZT588//2Tw4MGcPHmSkJAQunfvzpo1awgJCSntlydSuOObIeYZ+ONXAJyAxcg95zOb04A4auKsF8UXfS6ja+OapRuriIibmb5c5ejRows8/bJ06dJcz6+55hp27rz4Wvxz5851V2ginpO4H5Y8BzvOz++wehHXdDDTtvnxoveHGAZceONa5/l5nlPsQ3m0TyslICJSIZiehIhUKknH4beXYNNnrpuGYYG2A+Dacaw94sOXW7dw1l6FSd6fEs6pnN3iqMkU+1AWOrtwQ3LRroYRESnrlISIlIa0U7DidVj3AWSlu8qa9YV/TICw1gDUPu1a3XShswuLMzrRxbqb2pzhBNVY52yBE9epydqBfvl2ISJS3igJEfGkzFRY8y6sfMt1W3Jw3RW0xyRo0DVX1S4NaxAW7Efc2XScWFnjbJVruwUIC/ajS8MapRS8iIhnKQkR8YSsTNj0Cfz2MqSev9FhaGtX8tG0V74zT21WC9c2D2HuuqN5tmXXntSvFTarx1b6EBEpVUpCRNzJ6YTt/4Vfn4Mzh11l1SPhuvHQ+vaL3gp9/4kUvtt8DIBAPy+S07NytoUF+zGpXyv6tq7jyehFREqVkhARdzAM2LvQdbntiR2usqqhcM0T0GFYoXeGzcxyMmbeZtLtTq5qWotZwzuz9kACi5avpfdVUXRtUltHQESkwlESInKpDq+GXybD0TWu577B0P0RiLoffKoUqYlpi/ey/VgS1QO8efXOdnh7WYlqWIOTuwyiGtZQAiIiFZKSEJGSitsGMc/CvoWu515+rsTjykcgoOiTR1f/cZL3l/0BwNTb2hIapKtfRKRyUBIiUlynDsCSF2DbfwEDLDa4fJjr1EtQeLGaOptm57Evt2AYMLBTBH1b53/zRhGRikhJiEhRJce5rnbZ9Ak4z08abX07XPc01Gxc7OYMw+Dp77Zx/Gw6kTUDmNivVeE7iYhUIEpCRApz7gysfAPWvAdZ51xlTXpCj4lQp12Jm/128zH+93ssNquF1we2p4qv/jmKSOWiv3oiBclMc61wuuJ1SD/jKqvXBXpOgsjul9T00VNpTPzedRXNmB5N6VDW7oQrIlIKlISI/J3DDps/g6UvQUqcqyykpevIR/Pr87/FbTFkOZw8Om8LKRlZdGpQnf+7rokbghYRKX+UhIhkczph57euhcZOHXCVVavvmvPR5k6w2tzSzXtL/2DD4dNU9fXi9YHtdfmtiFRaSkJEDAP2x0DMFIj73VUWUMt1tUvHEeDl67authw9w/SYfQA8c8tlRNQIcFvbIiLljZIQqdyOroNfpsDhFa7nvkHQ7WG44gHwrerWrlIzshgzdzMOp8FNbetwa4e6bm1fRKS8URIiFZfTAYdXQUq8awn1Bt3+OqVyYpdrobE9P7qe23yhyyjoHg1VanoknGf/t5NDJ9MID/bj+f5tsFzi3BIRkfJOSYhUTDvnw4InIen4X2VB4XDV4/Dnetg6F9dCY1boMASueRKC63ksnAXb45i7/igWC7w2oD3BAd4e60tEpLxQEiIVz8758OUwwMhdnnQcfoz+63mrW1x3tw1p5tFw4pPSGfuNa67Jv65uTNfGnjnSIiJS3igJkYrF6XAdAfl7AnIhmy+M+BEiOns+HKfB419t5UyandZ1g4ju5dmER0SkPLGaHYCIWx1elfsUTH4cGZCVXirhfLTqEMv3JeLnbWX6wA74eOmfnIhINv1FlIolJd699S7B7rgkXlqwG4Cnb2xFk9ruvdpGRKS8UxIiFUvVUPfWK6F0u4NHvthCZpaTHi1qMySqvkf7ExEpj5SESMXSoJvrKpgCWSCorqueB728YA974pOpVdWHl+5oq8txRUTyoSREKharzXW5bb7OJwJ9X3TbEuz5WbY3gVkrDwLwyh3tqFXVfSuuiohUJEpCpOL5c4Prt80nd3lQOAz4FFrd7LGuT6Vm8thXWwEYekUDrmtR22N9iYiUd7pEVyqW+J2wZY7r8bAfwGnPf8VUDzAMg7Ff/05CcgZNalflqRtaeqwvEZGKQEmIVCy/TAbD6VqIrMEVpdr1vPVHWbQzHm+bhTcGtcffx3MJj4hIRaDTMVJxHFwG+xaC1Qt6TCrdrhNTmfLDTgAe792cy8KDS7V/EZHySEmIVAxOJyye6Hrc6R6o2bjUurY7nIyZu5lzdgddG9Vk1FWNSq1vEZHyTEmIVAw7voHjm8EnEK5+olS7fjNmH1v/PEuQnxevDWiH1arLcUVEikJJiJR/WRkQ84zrcfdHoGpIqXW9/tAp3lmyH4AXbmtDeDX/UutbRKS8UxIi5d/6mXDmMATWgSseLLVuk9LtPDpvC04Dbru8Lje1vdgiaSIi8ndKQqR8O3cGlr3senzdU+ATUGpdT/p+B3+ePkdEDX+m3HxZqfUrIlJRmJ6EvPPOO0RGRuLn50dUVBTr1q0rsK7dbueZZ56hcePG+Pn50a5dOxYsWHBJbUo5t2IanDsNIS2h3V2l1u38rcf5dvMxrBaYPrA9gX7epda3iEhFYWoSMm/ePKKjo5k0aRKbNm2iXbt29OnThxMnTuRbf/z48bz//vu89dZb7Ny5k/vvv59bb72VzZs3l7hNKcfOHIU1M1yPe00BW+kse3PszDme/nYbAKP/0ZSODWqUSr8iIhWNqUnItGnTGDVqFCNHjqRVq1bMmDGDgIAAZs2alW/9zz77jKeeeoobbriBRo0a8cADD3DDDTfw2muvlbhNKceWPA+ODIi8Cpr2LpUuHU6D6HlbSE7Pon1ENR7+R5NS6VdEpCIybcXUzMxMNm7cyLhx43LKrFYrPXv2ZPXq1fnuk5GRgZ+fX64yf39/VqxYUeI2s9vNyMjIeZ6UlAS4Tv/Y7fbiv7gKJnsMytRYxG3Da+tcLEDWdRMwsrJKpdv3lx1k7cFTBPjYePX21hhOB3anwyN9lclxrwQ07ubQuJvDE+NenLZMS0ISExNxOByEhobmKg8NDWX37t357tOnTx+mTZvG1VdfTePGjYmJieGbb77B4XCUuE2AqVOnMmXKlDzlixYtIiCg9CY6lnWLFy82O4QcXfe/TG0M/qx2BRu3xMGWnzze59EUeH27DbBwS0QmO9YuZYfHey1b416ZaNzNoXE3hzvHPS0trch1y9W9Y9544w1GjRpFixYtsFgsNG7cmJEjR17yqZZx48YRHR2d8zwpKYmIiAh69+5NUFDQpYZd7tntdhYvXkyvXr3w9jZ/AqblwBK8Nm/HsHoTetfb3FA90uN9nst00P+91TiMNHq3qs2UQe2wWDy7KFlZG/fKQuNuDo27OTwx7tlnE4rCtCSkVq1a2Gw24uPjc5XHx8cTFhaW7z4hISF89913pKenc/LkScLDwxk7diyNGjUqcZsAvr6++Pr65in39vbWP4YLlInxcDrhV9fCZJYuo/Cu3bRUup3y424OJKYRGuTLS7e3w8fHp1T6hTIy7pWQxt0cGndzuHPci9OOaRNTfXx86NixIzExMTllTqeTmJgYunbtetF9/fz8qFu3LllZWXz99dfccsstl9ymlBPbvoT4beAbDFf/u1S6/GVnPLPXHAHgtTvbU71K6SUgIiIVmamnY6Kjoxk+fDidOnWiS5cuTJ8+ndTUVEaOHAnAsGHDqFu3LlOnTgVg7dq1HDt2jPbt23Ps2DEmT56M0+nkiSeeKHKbUo7Z0yHmWdfjqx6FAM9fGpuQnMGTX/8OwL3dG9K9aS2P9ykiUlmYmoQMHDiQhIQEJk6cSFxcHO3bt2fBggU5E0uPHDmC1frXwZr09HTGjx/PgQMHqFq1KjfccAOfffYZ1apVK3KbUo6tex+S/oSgehB1v8e7MwyDJ/67lZOpmbQIC+TffZt7vE8RkcrE9Impo0ePZvTo0fluW7p0aa7n11xzDTt37rykNqWcSjsFy86vB/OP8eDt+RvFfbbmMEv2JODjZeXNwR3w9bJ5vE8RkcrE9GXbRYpk+WuQcRZC20DbAR7vbl98Ms//uAuAcde3oFlooMf7FBGpbJSESNl3+hCs+8D1uNcUsHr2iERGloNH5m4hI8vJ1c1CGNEt0qP9iYhUVkpCpOz79TlwZEKj66BJD493N23RXnbGJlGjig+v3tHW4+uBiIhUVkpCpGw7vhm2fQVYXEdBPGzV/kQ+WH4AgBdva0PtIL9C9hARkZJSEiJll2HAogmux20HQp12Hu3uTFom0V9uxTBgcJf69L6s4AXuRETk0ikJkbJr/y9waDnYfOEfT3u0K8MwePrb7cQlpdOoVhUm3NTSo/2JiIiSECmrnA5YPNH1OOpfUK2+R7v7etMxftwWi5fVwvRB7QnwMf3qdRGRCk9JiJRNW7+AEzvBrxpcFV1o9Utx5GQak77fDsCjvZrRtl41j/YnIiIuSkKk7MlMg1+fdz2++t/gX91jXWU5nIyZt5nUTAddImtw/zWNPdaXiIjkpiREyp6170HycdcpmC6jPNrVO0v+YNORMwT6ejFtYDtsVl2OKyJSWpSESNmSmgjLX3c9/sdE8PL1WFebjpzmzV/3AfDcra2pVz3AY32JiEheSkKkbFn2CmQmuy7HbX27x7pJycji0XlbcDgNbmkfzi3t63qsLxERyZ+SECk7Tv4B6//jetzrWbB67u35zA87OHwyjbrV/HnmltYe60dERAqmJETKjphnwJkFTXpBo2s81s3P22L5csOfWCwwbUA7gv29PdaXiIgUTEmIlA1/boCd3+Hp5dnjzqYz9pttADxwTWOiGtX0WF8iInJxSkLEfBcuz97+bgi9zCPdOJ0Gj321hbPn7LSpG8yYns080o+IiBSNkhAx356f4cgq8PKD657yWDezVh5k5f6T+HvbmD6oPT5eevuLiJhJa1OLuRxZ8Msk1+Mr/g+C3XeVisNpsO7gKU4kp3Mu08FLP+8GYPxNLWkcUtVt/YiISMkoCRFzbf4MEveCfw3oPsZtzS7YHsuUH3YSezY9V3nbusHc1cWz96EREZGi0fFoMU9GCiyd6np8zZPgF+yWZhdsj+WB2ZvyJCAAvx87y8IdcW7pR0RELo2SEDHP6ncgJR6qR0Kne9zSpMNpMOWHnRgFbLcAU37YicNZUA0RESktSkLEHCknYOUbrsc9JoGXj1uaXXfwVL5HQLIZQOzZdNYdPOWW/kREpOSUhIg5lr4I9lQIvxwuu9VtzZ5ILjgBKUk9ERHxnGIlIUlJSTidzjzlDoeDpKQktwUlFVziPtj4setx7+fA4r4719YO9HNrPRER8ZwiJyHffvstnTp1Ij097zfI9PR0OnfuzA8//ODW4KSC+mUyGA5ofgNEXunWprs0rHHRZdgtQJ1gP7o0rOHWfkVEpPiKnIS89957PPHEEwQE5L3deZUqVXjyySd5++233RqcVEBH1sDu/4HFCj0nu735nceTSM3Iyndb9vGWSf1aYbO67+iLiIiUTJGTkO3bt3PttdcWuP3qq69m27Zt7ohJKqoLl2e/fBiENHdr86dSM7l/9kaynAZt6wYRFpT7lEtYsB/vDbmcvq3ruLVfEREpmSIvVnb69GmysvL/hglgt9s5ffq0W4KSCmrXD/DnOvAOgGvHubVph9Pg4S82c+zMOSJrBvDZvVdQ1dcrZ8XU2oGuUzA6AiIiUnYUOQmJjIxkw4YNtGjRIt/tGzZsoEGDBm4LTCoYh901FwSg20MQGObW5l9dtIcV+xPx97bx/tBOOfNCujbWXXJFRMqqIp+Oue2223j66aeJj4/Psy0uLo7x48dz++23uzU4qUA2fgyn/oAqIa4kxI0WbI/lvaV/APDyHW1pHhbo1vZFRMQzinwkZOzYsXz//fc0bdqUIUOG0Ly563z+7t27mTNnDhEREYwdO9ZjgUo5lpHsWhcE4Nqx4Ou+JGH/iRQe+3IrAPd2b0i/duFua1tERDyryElIYGAgK1euZNy4ccybNy9n/ke1atUYMmQIzz//PIGB+gYq+Vj5JqQlQs0mcPlwtzWbnG7nX59tIDXTwRWNajD2+vxPFYqISNlUrLvoBgcH8+677/LOO++QmJiIYRiEhIRgceNiU1LBJMXC6vOXbvecDLaC1/AoDsMw+PdXv/NHQiphQX68fdfleNm0ALCISHlSrCQk27Zt29i7dy8AzZs3p02bNm4NSiqQpVPBngYRUdDiJrc1O+O3AyzYEYePzcp7Qy6nVlVft7UtIiKlo1hfHdetW0ebNm3o0KEDAwYMYMCAAbRv3562bduyfv36EgXwzjvvEBkZiZ+fH1FRUaxbt+6i9adPn07z5s3x9/cnIiKCRx99NNcqrpMnT8ZiseT6KeiKHvGwE7th82eux72eddvy7Mv3JfDKwt0ATL75MjrUr+6WdkVEpHQVOQnZuXMnPXr0wN/fn9mzZ7Np0yY2bdrEZ599hq+vLz169GDnzp3F6nzevHlER0czadIkNm3aRLt27ejTpw8nTpzIt/7nn3/O2LFjmTRpErt27WLmzJnMmzePp556Kle9yy67jNjY2JyfFStWFCsucZNfJoHhhJb9oH6UW5o8eiqNh7/YjNOAgZ0iGNwlwi3tiohI6Svy6ZjJkyfTq1cvvv7661xzQNq3b8/gwYO57bbbmDx5Ml9++WWRO582bRqjRo1i5MiRAMyYMYMff/yRWbNm5XulzapVq7jyyiu56667ANfaJYMHD2bt2rW5X5SXF2Fh7l2HQorp4HLYuwAsNugx2S1NptsdPDBnI6fT7LStF8yUWy7TfCQRkXKsyEnIkiVL+Pnnn/P9o2+xWHjqqae44YYbitxxZmYmGzduZNy4v1bOtFqt9OzZk9WrV+e7T7du3Zg9ezbr1q2jS5cuHDhwgJ9++omhQ4fmqrdv3z7Cw8Px8/Oja9euTJ06lfr16xcYS0ZGBhkZGTnPs+8IbLfbsdvtRX5NFVX2GBR5LAwntkXjsQKOy4fjDG4AlziOhmHw1Lc72H4sieoB3rw1sC02nNjtee/qXFEUe9zFLTTu5tC4m8MT416ctoqchCQnJxMaGlrg9rCwMJKTk4vccWJiIg6HI0+boaGh7N69O9997rrrLhITE+nevTuGYZCVlcX999+f63RMVFQUH3/8Mc2bNyc2NpYpU6Zw1VVXsX379gIvIZ46dSpTpkzJU75o0aJ8b9hXWS1evLhI9cJPr6Fz7BayrH78ktGBjJ9+uuS+V8RZ+OagDQsGgyPT2bJqCVsuudXyoajjLu6lcTeHxt0c7hz3tLS0ItctchLSoEED1q1bR0RE/ufg165d6/Fl25cuXcoLL7zAu+++S1RUFPv37+eRRx7h2WefZcIE143Rrr/++pz6bdu2JSoqigYNGvDll1/yz3/+M992x40bR3R0dM7zpKQkIiIi6N27N0FBQR59TeWB3W5n8eLF9OrVC2/vQi6xzcrA633X/wtL9zH0uGrwJfe/+cgZvlu3HjD4d59mjOre8JLbLA+KNe7iNhp3c2jczeGJcc8+m1AURU5CBg0aRHR0NM2bN6d169a5tm3bto3HH3+cYcOGFbnjWrVqYbPZ8iwDHx8fX+B8jgkTJjB06FDuvfdeANq0aUNqair33XcfTz/9NFZr3nm21apVo1mzZuzfv7/AWHx9ffH1zXuJp7e3t/4xXKBI47HxP3DmMFQNxdb9YWyXOH4nktN5aN5W7A6DG9qE8cC1TSvdPBC9D82hcTeHxt0c7hz34rRT5Ktjxo0bR7169Wjfvj3XX3890dHRPProo/Tt25cOHToQHh6e5yqVi/Hx8aFjx47ExMTklDmdTmJiYujatWu++6SlpeVJNGw2G+CaM5CflJQU/vjjD+rU0e3bPe7cGfjtZdfj654CnyqX1Jzd4WT055uJT8qgSe2qvHxHu0qXgIiIVGRFPhLi5+fHkiVLeP311/niiy/47bffAGjWrBnPPfccjz76aL5HEy4mOjqa4cOH06lTJ7p06cL06dNJTU3NuVpm2LBh1K1bl6lTpwLQr18/pk2bRocOHXJOx0yYMIF+/frlJCOPP/44/fr1o0GDBhw/fpxJkyZhs9kYPPjSTwtIIVZOh3OnoFZzaD/kkpub+tNu1h08RVVfL94f2pGqviVaW09ERMqoYv1V9/Hx4cknn+TJJ590S+cDBw4kISGBiRMnEhcXR/v27VmwYEHOZNUjR47kOvIxfvx4LBYL48eP59ixY4SEhNCvXz+ef/75nDp//vkngwcP5uTJk4SEhNC9e3fWrFlDSEiIW2KWApz9E9a853rcawrYLi1h+H7LMWatPAjAawPa0Tik6qVGKCIiZYzbvlrGxsby/PPP8/bbbxdrv9GjRzN69Oh8ty1dujTXcy8vLyZNmsSkSZMKbG/u3LnF6l/cZMkLkJUODa6EZn0vqaldsUk8+fXvAIy+rgl9LtOaLyIiFVGxkpAdO3awZMkSfHx8GDBgANWqVSMxMZHnnnuO999/n0aNGnkqTinL4rbDls9djy9xefazaXbun72RdLuTq5uF8GivZm4KUkREypoiT0ydP38+HTp04OGHH+b++++nU6dOLFmyhJYtW7J7926+/fZbduzY4clYpaz6ZRJgwGW3Qr2OJW7G6TQYM28zh0+mUa+6P28MbI/NqomoIiIVVZGTkOeee44HH3yQpKQkpk2bxoEDB3j44Yf56aefWLBgAX37XtoheCmn/lgC+38Bqzf0mHhJTb0Rs48lexLw9bIyY0hHqlfxcVOQIiJSFhU5CdmzZw8PPvggVatW5aGHHsJqtfL666/TuXNnT8YnZZnTCYvPJx6d/wk1Sn46LmZXPG/E7APghVvb0LpusDsiFBGRMqzISUhycnLO6qE2mw1/f3/NAanstv8X4n4H3yC4+okSN3MoMZUx87YAMKxrA27vWM9NAYqISFlWrImpCxcuJDjY9Q01e2Gx7du356pz8803uy86Kbvs6RDzrOtx90ehSs0SNZOWmcW/PttIcnoWHRtUZ/yNrdwYpIiIlGXFSkKGDx+e6/m//vWvXM8tFgsOh+PSo5Kyb/2HcPYIBNWFKx4oUROGYfDk19vYE59MSKAv7959OT5eRT44JyIi5VyRkxCns+LeMl2KKe0ULHvF9fi6p8Hbv0TNzFp5iB+2HsfLauHduy8nNMjPjUGKiEhZp6+dUnwrpkH6Wah9GbQbVKIm1hw4yQs/7QJg/I0t6RxZw50RiohIOVDkIyFvvvlmvuXBwcE0a9aswJvOSQVz+jCsfd/1uNczYLUVu4nYs+cY/fkmHE6DWzvUZXi3SPfGKCIi5UKRk5DXX3893/IzZ85w9uxZunXrxvz586lRQ99oK7Qlz4MjExpeA016FHv3jCwHD8zeRGJKJi3rBPHCrW10Z1wRkUqqyKdjDh48mO/P6dOn2b9/P06nk/Hjx3syVjFb3O/w+zzX417PlGh59md+2MmWo2cI8vPi/SEd8fcp/pEUERGpGNwyJ6RRo0a8+OKLLFq0yB3NSVnidGA5vIK6p1Zh+98YV1mbARDevthNfbn+KHPWHsFigTcGd6B+zQC3hioiIuWL2+6iW79+feLi4tzVnJQFO+fDgifxSjpOpwvL619R7KZ+//MM4793rSkT3bMZ1zWv7Z4YRUSk3HJbErJt2zYaNGjgrubEbDvnw5fDACPvth8fgyoh0KpoC9OdSs3kgdmbyMxy0rNlbR68rol7YxURkXKpyElIUlJSvuVnz55l48aNPPbYY3kWM5NyyumABU+SbwKSbcFYaHFjoVfHZDmcPPTFJo6dOUfDWlWYNrA9Vt0ZV0REKEYSUq1atQKvYrBYLNx7772MHTvWbYGJiQ6vgqTjF6lgQNIxV72GV120qVcX7WXl/pME+NiYMaQjQX7e7o1VRETKrSInIUuWLMm3PCgoiKZNm1K1alW2b99O69at3RacmOTI6qLVS4m/6Oaft8Uy47c/AHj5jrY0Dwu81MhERKQCKXIScs011+RbnpyczOeff87MmTPZsGGD7h1TXhkGHPwNlr8GB5cVbZ+qoQVu2n8imce/2grAqKsaclPbcHdEKSIiFUiJJ6YuW7aMmTNn8vXXXxMeHs5tt93G22+/7c7YpDQ4nbDnJ1fycXyTq8xiAy9fsKcVsJMFgsKhQbd8tyan27nvs42kZjq4olENnuzbwjOxi4hIuVasJCQuLo6PP/6YmTNnkpSUxIABA8jIyOC7776jVSvdgr1ccdhh+9ew4nVI2O0q8/KDy4dDt4fg+ObzV8dA7gmq5+cF9X0x30mpTqfBY19u5UBCKnWC/Xj7rsvxsukWRSIikleRk5B+/fqxbNkybrzxRqZPn07fvn2x2WzMmDHDk/GJu9nPwebZsOpNOHPEVeYbDF3uhagHoGqIq6xaBAz41HWVzIWTVIPCXQlIAZfnvvfbHyzaGY+Pzcp7QzpSq6qvh1+QiIiUV0VOQn7++WcefvhhHnjgAZo2berJmMQT0pNgwyxY/Q6knnCVVQmBK/4POv8T/ILz7tPqZmhxI1kHlrFl+ULaX9UHr0ZXF3hZ7rK9Cby6aA8AU265jPYR1Tz0YkREpCIochKyYsUKZs6cSceOHWnZsiVDhw5l0KCS3cZdSlFqIqx5D9Z/COlnXWXBEXDlI9BhCHj7X3x/qw2jQXeO7UiiXYPuBSYgR0+l8fDczRgGDOocweAu9d38QkREpKIp8sn6K664gg8//JDY2Fj+9a9/MXfuXMLDw3E6nSxevJjk5GRPxinFdfZP+PlJeL01LH/VlYDUagb9Z8DDm6HLqMITkCJKtzu4f/ZGzqTZaVcvmMk3X+aWdkVEpGIr9ozBKlWqcM8997BixQq2bdvGY489xosvvkjt2rW5+eaiLeMtHpS4H75/EN5oD2tnQNY5CO8AA2fD/62F9oPB5r4FwwzD4Olvt7PjeBI1qvjw3pCO+HnrzrgiIlK4S7psoXnz5rz88sv8+eeffPHFF+6KSUoidit8ORze7uSaeOq0Q+RVMPRbGLUEWvYDq/uvUpm99ghfb/oTqwXeHtyB8GruOboiIiIVn1tuYGez2ejfvz/9+/d3R3NSHIdXudb42P/LX2XNb4Du0RDR2aNdbzx8imd+2AHA2Otb0K1JLY/2JyIiFYvb7qIrpcgwYN8iWD4Njq5xlVms0Pp26P4ohHp+TsaJ5HQemL0Ju8PgxjZ1GHVVI4/3KSIiFYuSkPLE6YAd38KK6RC/zVVm84H2d8OVD0ON0kkE7A4no+ds5kRyBk1rV+WlO9oWeHNDERGRgigJKQ+yMmDrXFg5HU4dcJX5VIVO90DXByEwrFTDeeGnXaw7dIpAXy9mDO1IVV+9jUREpPj06VGWZaTApk9g1VuQHOsq86/uWtm0yygIqOHxEBxOg7UHT7Ex0ULNg6c4kWzno5WHAHhtQDsah1T1eAwiIlIxKQkpi9JOwboPYe17cO60qywwHLqNdt3bxbd0PvgXbI9lyg87iT2bDtj4dN+GnG2jr2tC78tK9wiMiIhULEpCypLkOFj9Nmz4CDJTXGU1GsGVY6DdINedbUvJgu2xPDB7U65b112oVZ2gUotFREQqJtNvb/rOO+8QGRmJn58fUVFRrFu37qL1p0+fTvPmzfH39yciIoJHH32U9PT0S2rT45wOOLgctv3X9dvpyL391EH4YQxMb+M69ZKZAqGt4Y5ZMHoDdBxeqgmIw2kw5YedBSYgFuDZH3ficBZUQ0REpHCmHgmZN28e0dHRzJgxg6ioKKZPn06fPn3Ys2cPtWvXzlP/888/Z+zYscyaNYtu3bqxd+9eRowYgcViYdq0aSVq0+N2zi/gTrQvQc3GsOJ12P41GE7Xtogr4KrHoGkvMOmKk3UHT50/BZM/A4g9m866g6fo2rhm6QUmIiIViqlHQqZNm8aoUaMYOXIkrVq1YsaMGQQEBDBr1qx8669atYorr7ySu+66i8jISHr37s3gwYNzHekobpsetXM+fDksdwICrudfDoX3usG2r1wJSJOeMPJn+OdCaNbbtAQEXGuAuLOeiIhIfkw7EpKZmcnGjRsZN25cTpnVaqVnz56sXr063326devG7NmzWbduHV26dOHAgQP89NNPDB06tMRtAmRkZJCRkZHzPCkpCQC73Y7dbi/ZC3Q68Pr5ScCgoHTCAIwWN+Po9gjUacf5TkvWnxvVDCja26JmgFfJx0cKlT22GuPSpXE3h8bdHJ4Y9+K0ZVoSkpiYiMPhIDQ0NFd5aGgou3fvznefu+66i8TERLp3745hGGRlZXH//ffz1FNPlbhNgKlTpzJlypQ85YsWLSIgIKC4Lw2Amsm76J58/KJ1LMDKrMs4ufkYbD5Won48wWlANR8bZzKBfFMog2o+kLBzDT/tKuXgKqHFixebHUKlpHE3h8bdHO4c97S0tCLXLVdXxyxdupQXXniBd999l6ioKPbv388jjzzCs88+y4QJE0rc7rhx44iOjs55npSUREREBL179yYoqGRXgVh2nIP9hde7onUkxmU3lKgPT/KOjGf03K15yi3n//vcbe3oc1lonu3iPna7ncWLF9OrVy+8vd1352O5OI27OTTu5vDEuGefTSgK05KQWrVqYbPZiI+Pz1UeHx9PWFj+609MmDCBoUOHcu+99wLQpk0bUlNTue+++3j66adL1CaAr68vvr55rz7x9vYu+f+U4LpFquYVXBfK4D+469vWJeR/u0hIycxVHhbsx6R+rejbuo5JkVU+l/Q+lBLTuJtD424Od457cdoxbWKqj48PHTt2JCYmJqfM6XQSExND165d890nLS0N699uR2+z2QAwDKNEbXpMg26uq2AKnBFigaC6rnpl0OKdcSSkZBLk58V/hnZgWFMHs+/pxIon/6EERERE3MLU0zHR0dEMHz6cTp060aVLF6ZPn05qaiojR44EYNiwYdStW5epU6cC0K9fP6ZNm0aHDh1yTsdMmDCBfv365SQjhbVZaqw212W4Xw7DlYhcuKbG+cSk74uuemXQh8sPAjC0awOuaRZC6n6DqIY1sFl1ozoREXEPU5OQgQMHkpCQwMSJE4mLi6N9+/YsWLAgZ2LpkSNHch35GD9+PBaLhfHjx3Ps2DFCQkLo168fzz//fJHbLFWtboYBnxawTsiLru1l0KYjp9l4+DQ+NivDu0aaHY6IiFRQpk9MHT16NKNHj85329KlS3M99/LyYtKkSUyaNKnEbZa6VjdDixvh8CpIiYeqoa5TMGX0CAjAf5a77tR7c/twagf56ZI5ERHxCNOTkErBaoOGV5kdRZEcOZnGgu1xAIy6qpHJ0YiISEVm+r1jpGyZtfIgTgOubhZC87BAs8MREZEKTEmI5DibZufLDUcBGHVVQ5OjERGRik5JiOSYs+4waZkOWoQF0r1JLbPDERGRCk5JiACQmeXk45WHANdcEIuJN9ATEZHKQUmIADB/63FOJGcQGuRLv3bhZocjIiKVgJIQwTCMnMtyh3eLxMdLbwsREfE8fdoIK/YnsjsumQAfG3d3aWB2OCIiUkkoCZGcJdoHdIogOEA3jhIRkdKhJKSS2x2XxLK9CVgtcM+VuixXRERKj5KQSu4/54+C9G0dRv2aASZHIyIilYmSkErsRFI63285BsC9WqJdRERKmZKQSuyT1YewOww6NqjO5fWrmx2OiIhUMkpCKqm0zCxmrzkC6EZ1IiJiDiUhldRXG/7k7Dk7DWoG0KtVqNnhiIhIJaQkpBJyOA1mrnBNSP1n94bYrFqiXURESp+SkEpo8c44jpxKI9jfmzs61jM7HBERqaSUhFRC2YuTDb2iAQE+XiZHIyIilZWSkEpm4+HTbDx8Gh+blWHdtES7iIiYR0lIJZN9o7pb2odTO9DP5GhERKQyUxJSiRw5mcbCHXGAFicTERHzKQmpRGatPIjTgKubhdA8LNDscEREpJJTElJJnEnLZN76owDcp6MgIiJSBigJqSTmrD3CObuDFmGBXNmkptnhiIiIKAmpDDKznHyy6hDgWqLdYtHiZCIiYj4lIZXA/K3HOZGcQWiQL/3ahZsdjoiICKAkpMIzDCPnstwR3Rri46X/5SIiUjboE6mCW74vkd1xyQT42LirS32zwxEREcmhJKSC+/D8UZABnSIIDvA2ORoREZG/KAmpwHbFJrF8XyJWi+tuuSIiImWJkpAK7D/nb1R3fes6RNQIMDkaERGR3JSEVFDxSenM33oMgHuv0lEQEREpe5SEVFCfrDqE3WHQqUF1OtSvbnY4IiIieZSJJOSdd94hMjISPz8/oqKiWLduXYF1r732WiwWS56fG2+8MafOiBEj8mzv27dvabyUMiE1I4s5a48AulGdiIiUXV5mBzBv3jyio6OZMWMGUVFRTJ8+nT59+rBnzx5q166dp/4333xDZmZmzvOTJ0/Srl077rzzzlz1+vbty0cffZTz3NfX13Mvooz5asNRzp6z06BmAL1ahZodjoiISL5MPxIybdo0Ro0axciRI2nVqhUzZswgICCAWbNm5Vu/Ro0ahIWF5fwsXryYgICAPEmIr69vrnrVq1eOUxIOp8GslYcAuLd7Q2xWLdEuIiJlk6lHQjIzM9m4cSPjxo3LKbNarfTs2ZPVq1cXqY2ZM2cyaNAgqlSpkqt86dKl1K5dm+rVq/OPf/yD5557jpo1879xW0ZGBhkZGTnPk5KSALDb7djt9uK+LFMt2BHPkVNpVPP35pa2YW6JP7uN8jYW5Z3G3Rwad3No3M3hiXEvTlsWwzAMt/VcTMePH6du3bqsWrWKrl275pQ/8cQT/Pbbb6xdu/ai+69bt46oqCjWrl1Lly5dcsrnzp1LQEAADRs25I8//uCpp56iatWqrF69GpvNlqedyZMnM2XKlDzln3/+OQEB5evS1te32TiUYqF3XSc31neaHY6IiFQyaWlp3HXXXZw9e5agoKCL1jV9TsilmDlzJm3atMmVgAAMGjQo53GbNm1o27YtjRs3ZunSpfTo0SNPO+PGjSM6OjrneVJSEhEREfTu3bvQASxLNh05w6HV6/C2WZh893WEBLpnHozdbmfx4sX06tULb2+tulpaNO7m0LibQ+NuDk+Me/bZhKIwNQmpVasWNpuN+Pj4XOXx8fGEhYVddN/U1FTmzp3LM888U2g/jRo1olatWuzfvz/fJMTX1zffiave3t7l6h/DR6tcV8Tc2qEu4TWqur398jYeFYXG3Rwad3No3M3hznEvTjumTkz18fGhY8eOxMTE5JQ5nU5iYmJynZ7Jz1dffUVGRgZDhgwptJ8///yTkydPUqdOnUuOuaw6fDKVhTvjAF2WKyIi5YPpV8dER0fz4Ycf8sknn7Br1y4eeOABUlNTGTlyJADDhg3LNXE128yZM+nfv3+eyaYpKSn8+9//Zs2aNRw6dIiYmBhuueUWmjRpQp8+fUrlNZlh1oqDGAZc0yyEZqGBZocjIiJSKNPnhAwcOJCEhAQmTpxIXFwc7du3Z8GCBYSGuta3OHLkCFZr7lxpz549rFixgkWLFuVpz2az8fvvv/PJJ59w5swZwsPD6d27N88++2yFXSvkTFomX274E4BROgoiIiLlhOlJCMDo0aMZPXp0vtuWLl2ap6x58+YUdFGPv78/CxcudGd4Zd6ctUc4Z3fQsk4QVzbJ/zJkERGRssb00zFyaTKyHHy86hAAo65qiMWixclERKR8UBJSzs3fcpyE5AxCg3y5qW242eGIiIgUmZKQcswwDP6z/CAAI7o1xMdL/ztFRKT80KdWObZsXyJ74pMJ8LFxV5f6ZocjIiJSLEpCyrH/LD8AwMDOEQQHaHEfEREpX5SElFO7YpNYvi8RqwXuubKh2eGIiIgUm5KQcip7Lsj1resQUaN83WRPREQElISUS/FJ6czfegyAe6/SURARESmflISUQx+vOoTdYdA5sjod6lc3OxwREZESURJSzqRmZDFnzWFAN6oTEZHyTUlIOfPVhqMkpWcRWTOAni1DzQ5HRESkxJSElCMOp8HMla4Jqf/s3hCbVUu0i4hI+aUkpBxZuCOOo6fOUT3Amzs6RpgdjoiIyCVRElKOfHh+cbIhVzTA38dmcjQiIiKXRklIObHx8Ck2HzmDj83K0K4NzA5HRETkkikJKSc+XOaaC9K/Qzi1A/1MjkZEROTSKQkpBw4lprJwZxygy3JFRKTiUBJSDsxaeRDDgGubh9AsNNDscERERNxCSUgZdyYtk682/AnAKB0FERGRCkRJSBk3Z+0RztkdtKwTRLfGNc0OR0RExG2UhJRhGVkOPl51CIBRVzXEYtHiZCIiUnEoCSnDvt9ynITkDMKC/LipbbjZ4YiIiLiVkpAyyjAMZi53XZY74spIfLz0v0pERCoWfbKVUcv2JbInPpkqPjYGd6lvdjgiIiJupySkjPpwmWuJ9gGdIwj29zY5GhEREfdTElIG7TyexIr9iVgtcM+VDc0OR0RExCOUhJRB/1nhOgpyfZs6RNQIMDkaERERz1ASUsbEJ6Xzw9bjgBYnExGRik1JSBnz8apD2B0GnSOr0z6imtnhiIiIeIySkDIkNSOLOWsOA7pRnYiIVHxKQsqQLzccJSk9i4a1qtCzZajZ4YiIiHiUkpAywuE0mLXStTjZPd0bYrNqiXYREanYlISUEQt3xHH01DmqB3hzx+X1zA5HRETE45SElAGGYfDB+cXJhlzRAH8fm8kRiYiIeF6ZSELeeecdIiMj8fPzIyoqinXr1hVY99prr8ViseT5ufHGG3PqGIbBxIkTqVOnDv7+/vTs2ZN9+/aVxkspkY2HT7Pl6Bl8bFaGdY00OxwREZFSYXoSMm/ePKKjo5k0aRKbNm2iXbt29OnThxMnTuRb/5tvviE2NjbnZ/v27dhsNu68886cOi+//DJvvvkmM2bMYO3atVSpUoU+ffqQnp5eWi+rWD5c7joKcmuHuoQE+pocjYiISOkwPQmZNm0ao0aNYuTIkbRq1YoZM2YQEBDArFmz8q1fo0YNwsLCcn4WL15MQEBAThJiGAbTp09n/Pjx3HLLLbRt25ZPP/2U48eP891335XiKyuaQ4mpLNoZD8C9V2mJdhERqTy8zOw8MzOTjRs3Mm7cuJwyq9VKz549Wb16dZHamDlzJoMGDaJKlSoAHDx4kLi4OHr27JlTJzg4mKioKFavXs2gQYPytJGRkUFGRkbO86SkJADsdjt2u71Er62oPlz2B4YB1zStRWQNP4/3VxLZMZXF2Coyjbs5NO7m0LibwxPjXpy2TE1CEhMTcTgchIbmXhMjNDSU3bt3F7r/unXr2L59OzNnzswpi4uLy2nj721mb/u7qVOnMmXKlDzlixYtIiDAc/duSbXDl5tsgIXW3vH89NNPHuvLHRYvXmx2CJWSxt0cGndzaNzN4c5xT0tLK3JdU5OQSzVz5kzatGlDly5dLqmdcePGER0dnfM8KSmJiIgIevfuTVBQ0KWGWaB3lx7A7txPy7BAHhl0BRZL2VwbxG63s3jxYnr16oW3t7fZ4VQaGndzaNzNoXE3hyfGPftsQlGYmoTUqlULm81GfHx8rvL4+HjCwsIuum9qaipz587lmWeeyVWevV98fDx16tTJ1Wb79u3zbcvX1xdf37wTQr29vT32jyEjy8Fna48CcN81jfDx8fFIP+7kyfGQgmnczaFxN4fG3RzuHPfitGPqxFQfHx86duxITExMTpnT6SQmJoauXbtedN+vvvqKjIwMhgwZkqu8YcOGhIWF5WozKSmJtWvXFtpmafp+83ESUzIIC/LjprbhZocjIiJS6kw/HRMdHc3w4cPp1KkTXbp0Yfr06aSmpjJy5EgAhg0bRt26dZk6dWqu/WbOnEn//v2pWbNmrnKLxcKYMWN47rnnaNq0KQ0bNmTChAmEh4fTv3//0npZF2UYBv9Z4bosd8SVkXjbTL9ISUREpNSZnoQMHDiQhIQEJk6cSFxcHO3bt2fBggU5E0uPHDmC1Zr7Q3rPnj2sWLGCRYsW5dvmE088QWpqKvfddx9nzpyhe/fuLFiwAD8/P4+/nqL4bW8Ce+NTqOJjY3CX+maHIyIiYgrTkxCA0aNHM3r06Hy3LV26NE9Z8+bNMQyjwPYsFgvPPPNMnvkiZcV/lrtuVDewc32C/XXuU0REKiedByhlO48nsWJ/IlYLjLwy0uxwRERETKMkpJT95/wS7de3qUNEDc+tQSIiIlLWlYnTMRWdw2mw7uAp9sUn892WYwDcd1Ujk6MSERExl5IQD1uwPZYpP+wk9uxfN8/zsVmIPXuOdhHVzAtMRETEZDod40ELtsfywOxNuRIQgEyHwQOzN7Fge6xJkYmIiJhPSYiHOJwGU37YScHX8MCUH3bicF6shoiISMWlJMRD1h08lecIyIUMIPZsOusOniq9oERERMoQJSEeciK54ASkJPVEREQqGiUhHlI7sGirsxa1noiISEWjJMRDujSsQZ1gPywFbLcAdYL96NKwRmmGJSIiUmYoCfEQm9XCpH6tAPIkItnPJ/Vrhc1aUJoiIiJSsSkJ8aC+revw3pDLCQvOfcolLNiP94ZcTt/WdUyKTERExHxarMzD+rauQ69WYaw7eIoTyenUDnSdgtEREBERqeyUhJQCm9VC18Y1zQ5DRESkTNHpGBERETGFkhARERExhZIQERERMYWSEBERETGFkhARERExhZIQERERMYUu0c2HYRgAJCUlmRxJ2WC320lLSyMpKQlvb2+zw6k0NO7m0LibQ+NuDk+Me/ZnZ/Zn6cUoCclHcnIyABERESZHIiIiUj4lJycTHBx80ToWoyipSiXjdDo5fvw4gYGBWCxa2TQpKYmIiAiOHj1KUFCQ2eFUGhp3c2jczaFxN4cnxt0wDJKTkwkPD8dqvfisDx0JyYfVaqVevXpmh1HmBAUF6Y+DCTTu5tC4m0Pjbg53j3thR0CyaWKqiIiImEJJiIiIiJhCSYgUytfXl0mTJuHr62t2KJWKxt0cGndzaNzNYfa4a2KqiIiImEJHQkRERMQUSkJERETEFEpCRERExBRKQkRERMQUSkKkQFOnTqVz584EBgZSu3Zt+vfvz549e8wOq1J58cUXsVgsjBkzxuxQKoVjx44xZMgQatasib+/P23atGHDhg1mh1WhORwOJkyYQMOGDfH396dx48Y8++yzRbrviBTdsmXL6NevH+Hh4VgsFr777rtc2w3DYOLEidSpUwd/f3969uzJvn37PB6XkhAp0G+//caDDz7ImjVrWLx4MXa7nd69e5Oammp2aJXC+vXref/992nbtq3ZoVQKp0+f5sorr8Tb25uff/6ZnTt38tprr1G9enWzQ6vQXnrpJd577z3efvttdu3axUsvvcTLL7/MW2+9ZXZoFUpqairt2rXjnXfeyXf7yy+/zJtvvsmMGTNYu3YtVapUoU+fPqSnp3s0Ll2iK0WWkJBA7dq1+e2337j66qvNDqdCS0lJ4fLLL+fdd9/lueeeo3379kyfPt3ssCq0sWPHsnLlSpYvX252KJXKTTfdRGhoKDNnzswpu/322/H392f27NkmRlZxWSwWvv32W/r37w+4joKEh4fz2GOP8fjjjwNw9uxZQkND+fjjjxk0aJDHYtGRECmys2fPAlCjRg2TI6n4HnzwQW688UZ69uxpdiiVxvz58+nUqRN33nkntWvXpkOHDnz44Ydmh1XhdevWjZiYGPbu3QvA1q1bWbFiBddff73JkVUeBw8eJC4uLtffm+DgYKKioli9erVH+9YN7KRInE4nY8aM4corr6R169Zmh1OhzZ07l02bNrF+/XqzQ6lUDhw4wHvvvUd0dDRPPfUU69ev5+GHH8bHx4fhw4ebHV6FNXbsWJKSkmjRogU2mw2Hw8Hzzz/P3XffbXZolUZcXBwAoaGhucpDQ0NztnmKkhApkgcffJDt27ezYsUKs0Op0I4ePcojjzzC4sWL8fPzMzucSsXpdNKpUydeeOEFADp06MD27duZMWOGkhAP+vLLL5kzZw6ff/45l112GVu2bGHMmDGEh4dr3CsBnY6RQo0ePZr//e9/LFmyhHr16pkdToW2ceNGTpw4weWXX46XlxdeXl789ttvvPnmm3h5eeFwOMwOscKqU6cOrVq1ylXWsmVLjhw5YlJElcO///1vxo4dy6BBg2jTpg1Dhw7l0UcfZerUqWaHVmmEhYUBEB8fn6s8Pj4+Z5unKAmRAhmGwejRo/n222/59ddfadiwodkhVXg9evRg27ZtbNmyJeenU6dO3H333WzZsgWbzWZ2iBXWlVdemecS9L1799KgQQOTIqoc0tLSsFpzfxTZbDacTqdJEVU+DRs2JCwsjJiYmJyypKQk1q5dS9euXT3at07HSIEefPBBPv/8c77//nsCAwNzzg0GBwfj7+9vcnQVU2BgYJ45N1WqVKFmzZqai+Nhjz76KN26deOFF15gwIABrFu3jg8++IAPPvjA7NAqtH79+vH8889Tv359LrvsMjZv3sy0adO45557zA6tQklJSWH//v05zw8ePMiWLVuoUaMG9evXZ8yYMTz33HM0bdqUhg0bMmHCBMLDw3OuoPEYQ6QAQL4/H330kdmhVSrXXHON8cgjj5gdRqXwww8/GK1btzZ8fX2NFi1aGB988IHZIVV4SUlJxiOPPGLUr1/f8PPzMxo1amQ8/fTTRkZGhtmhVShLlizJ9+/58OHDDcMwDKfTaUyYMMEIDQ01fH19jR49ehh79uzxeFxaJ0RERERMoTkhIiIiYgolISIiImIKJSEiIiJiCiUhIiIiYgolISIiImIKJSEiIiJiCiUhIiIiYgolISIiImIKJSEiUmlYLBa+++47s8MQkfOUhIhIqRgxYgQWiyXPT9++fc0OTURMohvYiUip6du3Lx999FGuMl9fX5OiERGz6UiIiJQaX19fwsLCcv1Ur14dcJ0qee+997j++uvx9/enUaNG/Pe//821/7Zt2/jHP/6Bv78/NWvW5L777iMlJSVXnVmzZnHZZZfh6+tLnTp1GD16dK7tiYmJ3HrrrQQEBNC0aVPmz5/v2RctIgVSEiIiZcaECRO4/fbb2bp1K3fffTeDBg1i165dAKSmptKnTx+qV6/O+vXr+eqrr/jll19yJRnvvfceDz74IPfddx/btm1j/vz5NGnSJFcfU6ZMYcCAAfz+++/ccMMN3H333Zw6dapUX6eInOfx+/SKiBiGMXz4cMNmsxlVqlTJ9fP8888bhmEYgHH//ffn2icqKsp44IEHDMMwjA8++MCoXr26kZKSkrP9xx9/NKxWqxEXF2cYhmGEh4cbTz/9dIExAMb48eNznqekpBiA8fPPP7vtdYpI0WlOiIiUmuuuu4733nsvV1mNGjVyHnft2jXXtq5du7JlyxYAdu3aRbt27ahSpUrO9iuvvBKn08mePXuwWCwcP36cHj16XDSGtm3b5jyuUqUKQUFBnDhxoqQvSUQugZIQESk1VapUyXN6xF38/f2LVM/b2zvXc4vFgtPp9ERIIlIIzQkRkTJjzZo1eZ63bNkSgJYtW7J161ZSU1Nztq9cuRKr1Urz5s0JDAwkMjKSmJiYUo1ZREpOR0JEpNRkZGQQFxeXq8zLy4tatWoB8NVXX9GpUye6d+/OnDlzWLduHTNnzgTg7rvvZtKkSQwfPpzJkyeTkJDAQw89xNChQwkNDQVg8uTJ3H///dSuXZvrr7+e5ORkVq5cyUMPPVS6L1REikRJiIiUmgULFlCnTp1cZc2bN2f37t2A68qVuXPn8n//93/UqVOHL774glatWgEQEBDAwoULeeSRR+jcuTMBAQHcfvvtTJs2Laet4cOHk56ezuuvv87jjz9OrVq1uOOOO0rvBYpIsVgMwzDMDkJExGKx8O2339K/f3+zQxGRUqI5ISIiImIKJSEiIiJiCs0JEZEyQWeGRSofHQkRERERUygJEREREVMoCRERERFTKAkRERERUygJEREREVMoCRERERFTKAkRERERUygJEREREVP8P7tHFxTU9GNbAAAAAElFTkSuQmCC\n"
           },
           "metadata": {}
         }
@@ -1490,14 +1699,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 107,
+      "execution_count": 36,
       "id": "91320217",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "91320217",
-        "outputId": "fe13ac80-a5e3-4046-d154-51bfc2cf4c76"
+        "outputId": "8a460cd4-20c4-48be-fbef-20accbaa8200"
       },
       "outputs": [
         {
@@ -1513,14 +1722,22 @@
       "source": [
         "# =========================\n",
         "# CELL 7: Load best checkpoint (local first, then Drive fallback)\n",
-        "# Works with per-run Drive folders and best_{USE_MODEL}.pt naming\n",
+        "# No build_model dependency (torchvision EfficientNet-B0 inline)\n",
         "# =========================\n",
         "from pathlib import Path\n",
         "import torch\n",
+        "import torch.nn as nn\n",
+        "from torchvision import models\n",
         "import shutil\n",
         "\n",
         "ARTIFACTS_DIR = Path(globals().get(\"ARTIFACTS_DIR\", \"artifacts\"))\n",
         "ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "# Ensure DEVICE is torch.device\n",
+        "if \"DEVICE\" in globals() and isinstance(DEVICE, str):\n",
+        "    DEVICE = torch.device(DEVICE)\n",
+        "elif \"DEVICE\" not in globals() or not isinstance(DEVICE, torch.device):\n",
+        "    DEVICE = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
         "\n",
         "def _find_drive_ckpt():\n",
         "    drive_root = Path(\"/content/drive/MyDrive\")\n",
@@ -1547,6 +1764,13 @@
         "    )\n",
         "    return candidates[0] if candidates else None\n",
         "\n",
+        "def _build_efficientnet_b0(num_classes: int = 2):\n",
+        "    weights = models.EfficientNet_B0_Weights.DEFAULT\n",
+        "    m = models.efficientnet_b0(weights=weights)\n",
+        "    in_features = m.classifier[1].in_features\n",
+        "    m.classifier[1] = nn.Linear(in_features, num_classes)\n",
+        "    return m\n",
+        "\n",
         "def load_best_checkpoint():\n",
         "    best_name = f\"best_{USE_MODEL}.pt\"\n",
         "    local_ckpt = ARTIFACTS_DIR / best_name\n",
@@ -1564,10 +1788,15 @@
         "            + \". Train first (the cell that saves best checkpoints).\"\n",
         "        )\n",
         "\n",
-        "    ckpt = torch.load(str(ckpt_path), map_location=DEVICE)\n",
+        "    ckpt = torch.load(str(ckpt_path), map_location=\"cpu\")\n",
         "\n",
-        "    model_name = ckpt.get(\"model_name\") or ckpt.get(\"arch\") or ckpt.get(\"model\") or USE_MODEL\n",
-        "    m = build_model(model_name, num_classes=2, freeze_backbone=False).to(DEVICE)\n",
+        "    model_name = (ckpt.get(\"model_name\") or ckpt.get(\"arch\") or ckpt.get(\"model\") or USE_MODEL or \"\").lower()\n",
+        "\n",
+        "    # This notebook path is EfficientNet-B0 only\n",
+        "    if model_name not in [\"efficientnet_b0\", \"effnet_b0\", \"efficientnet\", \"\"]:\n",
+        "        print(f\"Warning: checkpoint model_name='{model_name}'. Proceeding with EfficientNet-B0 loader anyway.\")\n",
+        "\n",
+        "    m = _build_efficientnet_b0(num_classes=2).to(DEVICE)\n",
         "    m.load_state_dict(ckpt[\"model_state\"])\n",
         "    m.eval()\n",
         "    return m, ckpt, ckpt_path\n",
@@ -1781,10 +2010,10 @@
           "height": 1000
         },
         "id": "bn9Bg3_z3Q9u",
-        "outputId": "affcc64a-6ade-40ba-a883-074af89efb85"
+        "outputId": "83152550-fc19-4cbc-dae5-840e68903fc9"
       },
       "id": "bn9Bg3_z3Q9u",
-      "execution_count": 108,
+      "execution_count": 33,
       "outputs": [
         {
           "output_type": "stream",
@@ -1795,10 +2024,10 @@
             "Confusion matrix (rows=actual, cols=pred):\n",
             "            pred_real  pred_fake\n",
             "actual_real          0         0\n",
-            "actual_fake          2       198\n",
-            "(tn=0, fp=0, fn=2, tp=198)\n",
-            "Accuracy: 0.9900\n",
-            "Recall on fake (sensitivity): 0.99\n",
+            "actual_fake          4       196\n",
+            "(tn=0, fp=0, fn=4, tp=196)\n",
+            "Accuracy: 0.9800\n",
+            "Recall on fake (sensitivity): 0.98\n",
             "Specificity: n/a\n",
             "\n",
             "Classification Report:\n",
@@ -1806,11 +2035,11 @@
             "              precision    recall  f1-score   support\n",
             "\n",
             "        real       0.00      0.00      0.00         0\n",
-            "        fake       1.00      0.99      0.99       200\n",
+            "        fake       1.00      0.98      0.99       200\n",
             "\n",
-            "    accuracy                           0.99       200\n",
-            "   macro avg       0.50      0.49      0.50       200\n",
-            "weighted avg       1.00      0.99      0.99       200\n",
+            "    accuracy                           0.98       200\n",
+            "   macro avg       0.50      0.49      0.49       200\n",
+            "weighted avg       1.00      0.98      0.99       200\n",
             "\n"
           ]
         },
@@ -1820,7 +2049,7 @@
             "text/plain": [
               "<Figure size 500x400 with 1 Axes>"
             ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAGGCAYAAACdXD2cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAK9NJREFUeJzt3XlcVPX+P/DXGZZhB1EQUAQMRQnFLU2/KqJgLrkvpV8T1MpEMxfUpF9peZX0pmJu2L2KSmkpFteLlmFXXNC6RdqiqSEoqJiYxs6wzOf3h18mx0EFAwb4vJ6Pxzwens/5zGfeZzie15xl5ihCCAEiIpKSytgFEBGR8TAEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEqEFJSkqCoiiIi4szdin1RmZmJiwsLJCcnPzIvrK8f88//zzGjx9v7DIaBIYAUQP3zjvvoEePHvif//kfXduuXbsQFRVlvKIe4uTJk+jduzesrKzg4uKC2bNnIz8/v0rPVRSl0se7776r12/RokXYt28ffvjhh9pYhEbF1NgFENHjy87Oxo4dO7Bjxw699l27duHnn3/GnDlzjFPYA5w5cwYDBgxA+/btsWbNGly9ehXvvfcefv31V3z++edVGiM4OBiTJ0/Wa+vcubPBdLdu3bB69Wrs3LmzxupvjBgCRA3Yhx9+CFNTUwwbNqxOXq+wsBBWVlaP/fyIiAg0adIESUlJsLOzAwB4enripZdewpdffomBAwc+coy2bdti0qRJj+w3fvx4LFmyBJs2bYKNjc1j19zY8XAQ6SxduhSKoiA1NRWhoaFwcHCAvb09pkyZgsLCQr2+MTEx6N+/P5ydnaFWq+Hr64vNmzcbjOnp6Ylnn30WJ06cQPfu3WFhYYHWrVtX+uksLS0N48aNg6OjI6ysrPD000/jwIEDldZaXl6OiIgIuLi4wNraGsOHD0dmZqZen+PHj2PcuHFo1aoV1Go13N3dMXfuXBQVFen1Cw0NhY2NDa5du4aRI0fCxsYGTk5OCA8PR3l5uV7f9957D7169ULTpk1haWmJrl27Vnp8XVEUzJo1C/Hx8fDz84NarcaTTz6JL774Qq/flStXEBYWBh8fH1haWqJp06YYN24cLl++XOly3y8+Ph49evTQ28j169cPBw4cwJUrV3SHSzw9PfWep9VqsXz5crRs2RIWFhYYMGAAUlNT9fr069cPfn5+SElJQd++fWFlZYWIiIgq1VWZ3NxcJCYmYtKkSboAAIDJkyfDxsYGe/bsqfJYRUVFKC4ufmif4OBgFBQUIDEx8bFrloIg+j9LliwRAETnzp3F6NGjxaZNm8SLL74oAIiFCxfq9X3qqadEaGioWLt2rVi/fr0YOHCgACA2bNig18/Dw0P4+PiI5s2bi4iICLFhwwbRpUsXoSiK+Pnnn3X9bty4IZo3by5sbW3FG2+8IdasWSP8/f2FSqUSn376qa7fkSNHBADRoUMH0bFjR7FmzRrx+uuvCwsLC9G2bVtRWFio6/vqq6+KIUOGiBUrVogtW7aIadOmCRMTEzF27Fi9GkNCQoSFhYV48sknxdSpU8XmzZvFmDFjBACxadMmvb4tW7YUYWFhYsOGDWLNmjWie/fuAoBISEjQ6wdA+Pv7C1dXV7Fs2TIRFRUlWrduLaysrMStW7d0/fbu3Sv8/f3FW2+9JT744AMREREhmjRpIjw8PERBQcFD/14lJSXC0tJSzJs3T6/9yy+/FJ06dRLNmjUTsbGxIjY2Vnz22Wd671/nzp1F165dxdq1a8XSpUuFlZWV6N69u944AQEBwsXFRTg5OYlXX31VbNmyRcTHxwshhMjLyxPZ2dmPfPzxxx+68U6cOCEAiE8++cRgWXr37i26dOny0OWteF+tra2FoigCgGjfvr346KOPKu1bWloqLC0txfz58x85rswYAqRTEQJTp07Vax81apRo2rSpXtu9G9sKzzzzjGjdurVem4eHhwAgjh07pmu7efOmUKvVev8558yZIwCI48eP69ry8vKEl5eX8PT0FOXl5UKIPzdiLVq0ELm5ubq+e/bsEQDEunXrHlpjZGSkUBRFXLlyRdcWEhIiAIh33nlHr2/FhvJhy11SUiL8/PxE//799doBCHNzc5Gamqpr++GHHwQAsX79+ofWeOrUKQFA7Ny502DevVJTUw3GqzB06FDh4eFh0F7x/rVv315oNBpd+7p16wQA8dNPP+naAgICBAARHR1tME7Fe/aoR0BAgO45e/fuNVgXKowbN064uLg8dHmFEKJXr14iKipK/Otf/xKbN28Wfn5+lYZ1hbZt24rBgwc/clyZ8ZwAGXjllVf0pvv06YPPPvsMubm5ut14S0tL3fycnByUlpYiICAAhw4dQk5ODuzt7XXzfX190adPH920k5MTfHx8kJaWpms7ePAgunfvjt69e+vabGxs8PLLL2Px4sU4d+4c/Pz8dPMmT54MW1tb3fTYsWPh6uqKgwcPYvbs2QY1FhQUoKioCL169YIQAqdPn0arVq0eudyxsbF6bfeOeefOHZSXl6NPnz7YvXu3wfsYFBSEJ554QjfdsWNH2NnZ6S33veOVlpYiNzcX3t7ecHBwwPfff48XXnjBYNwKv//+OwCgSZMmD+zzIFOmTIG5ubluuuLvk5aWpvc+q9VqTJkyxeD5CxcurNJx+XtrqzgMp1arDfpZWFgYHKarzP2XwU6dOhVdu3ZFREQEQkND9d7Pite/devWI8eVGUOADNy/caz4j3znzh1dCCQnJ2PJkiU4deqUwfmC+0Pg/vEqxrxz545u+sqVK+jRo4dBv/bt2+vm37txatOmjV4/RVHg7e2tdyw9IyMDb731Fvbv36/3WhU13svCwgJOTk4PrREAEhIS8Le//Q1nzpyBRqPRe/37VWW5i4qKEBkZiZiYGFy7dg3inhv93V/jg4jHuDngw/7G92rRooVeWFTw9fWFr69vtV6zYgN97/tWobi42GADXhXm5uaYNWsWXnnlFaSkpOh9iADuvjeV/W3oTwwBMmBiYlJpe8XG5tKlSxgwYADatWuHNWvWwN3dHebm5jh48CDWrl0LrVZbrfFqQ3l5OYKDg3H79m0sWrQI7dq1g7W1Na5du4bQ0NAq13iv48ePY/jw4ejbty82bdoEV1dXmJmZISYmBrt27TLoX5XlfvXVVxETE4M5c+agZ8+esLe3h6IoeP755w1qvF/Tpk0BGG64q6Kqf5MHbZhzcnKq9Mnd3Nwcjo6OAABXV1cAQFZWlkG/rKwsuLm5PXK8yri7uwMAbt++bTDvzp07Bh8YSB9DgKrt3//+NzQaDfbv36/3ifLIkSOPPaaHhwcuXLhg0H7+/Hnd/Hv9+uuvetNCCKSmpqJjx44AgJ9++gkXL17Ejh079K4p/ytXiuzbtw8WFhY4dOiQ3iGNmJiYxx4zLi4OISEhWL16ta6tuLgYf/zxxyOf26pVK1haWiI9Pd1gXm1/+n3ttdcMvptQmYCAACQlJQEA/Pz8YGpqiu+++07v27wlJSU4c+bMY3/Dt+Lw2v17cmVlZcjMzMTw4cMfa1xZMASo2io+Rd5/6OKvbAyHDBmCqKgonDp1Cj179gRw9zj+Bx98AE9PT4NDDzt37sTixYt15wXi4uKQlZWFRYsWPbBGIQTWrVv32DWamJhAURS9y0YvX76M+Pj4vzTm/Z++169fb3BpamXMzMzQrVs3fPfddwbzrK2tq3w46XE8zjkBe3t7BAUF4cMPP8Sbb76p+9vFxsYiPz8f48aN0/UtLCxERkYGmjVrhmbNmgG4+8W4+zf0eXl5iIqKQrNmzdC1a1e9eefOnUNxcTF69er12MspA4YAVdvAgQNhbm6OYcOGYfr06cjPz8c//vEPODs7V7qrXxWvv/46du/ejcGDB2P27NlwdHTEjh07kJ6ejn379kGl0v9Ki6OjI3r37o0pU6bgt99+Q1RUFLy9vfHSSy8BANq1a4cnnngC4eHhuHbtGuzs7LBv377HOnRSYejQoVizZg0GDRqEiRMn4ubNm9i4cSO8vb3x448/PtaYzz77LGJjY2Fvbw9fX1+cOnUKhw8f1h3qeZQRI0bgjTfe0DtpDwBdu3bFJ598gnnz5uGpp56CjY1NjX6h7HHOCQDA8uXL0atXLwQEBODll1/G1atXsXr1agwcOBCDBg3S9fvvf/+LwMBALFmyBEuXLgUAbNy4EfHx8Rg2bBhatWqFrKwsbNu2DRkZGYiNjTU4d5GYmAgrKysEBwf/pWVt9IxyTRLVSxWXiGZnZ+u1x8TECAAiPT1d17Z//37RsWNHYWFhITw9PcXKlSvFtm3bDPp5eHiIoUOHGrxWQECA3uWDQghx6dIlMXbsWOHg4CAsLCxE9+7dDa6/r7jEcffu3WLx4sXC2dlZWFpaiqFDh+pd9imEEOfOnRNBQUHCxsZGNGvWTLz00ku6yzRjYmJ0/UJCQoS1tfUD3497bd26VbRp00ao1WrRrl07ERMTU2k/AGLmzJkGY3p4eIiQkBDd9J07d8SUKVNEs2bNhI2NjXjmmWfE+fPnDfo9yG+//SZMTU1FbGysXnt+fr6YOHGicHBwEAB0l4tWvH979+7V65+enm7wvgQEBIgnn3zykTVU1/Hjx0WvXr2EhYWFcHJyEjNnztS73PfeOpcsWaJr+/LLL0VwcLBwcXERZmZmwsHBQQwcOFB89dVXlb5Ojx49xKRJk2q8/sZGEaIWz84RUa2bNm0aLl68iOPHjxu7lHrjzJkz6NKlC77//nt06tTJ2OXUawwBogYuIyMDbdu2xVdffaX3S6Iyq7i6qjo/RSErhgARkcT4A3JERBJjCBARSYwhQEQkMYYAEZHE+GWxB9Bqtbh+/TpsbW35A1RE1KAIIZCXlwc3NzeDL1rejyHwANevX9f9MBURUUOUmZmJli1bPrQPQ+ABKn7XpDeGwBRmRq6GiKjqylCKEziod8+NB2EIPEDFISBTmMFUYQgQUQPyf9/+qsqhbJ4YJiKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIomZGrsAavgyRSqu4CJKUAwb2MMHnWGvOBq7LGpEuI7VHin2BEJDQzFy5Ehjl9Eo3RCZuIgf0Rq+6I4g2MIBp3EcJaLY2KVRI8F1rHYZPQRCQ0OhKAoURYGZmRm8vLywcOFCFBfzD9wQZOAiWsALboonbBQ7tEMXmMAE13HZ2KVRI8F1rHbVi8NBgwYNQkxMDEpLS5GSkoKQkBAoioKVK1cauzR6CK3QIg9/wBPtdG2KosBRNMcf+N2IlVFjwXWs9hl9TwAA1Go1XFxc4O7ujpEjRyIoKAiJiYkAAK1Wi8jISHh5ecHS0hL+/v6Ii4vTPbe8vBzTpk3Tzffx8cG6deuMtShSKYUGAgLmsNBrN4caJeCeHP11XMdqX73YE7jXzz//jJMnT8LDwwMAEBkZiQ8//BDR0dFo06YNjh07hkmTJsHJyQkBAQHQarVo2bIl9u7di6ZNm+LkyZN4+eWX4erqivHjx1f5dTUaDTQajW46Nze3xpeNiKi+qRchkJCQABsbG5SVlUGj0UClUmHDhg3QaDRYsWIFDh8+jJ49ewIAWrdujRMnTmDLli0ICAiAmZkZ3n77bd1YXl5eOHXqFPbs2VOtEIiMjNQbhx7NDGooUAw+kZVAY/DJjehxcB2rffUiBAIDA7F582YUFBRg7dq1MDU1xZgxY3D27FkUFhYiODhYr39JSQk6d+6sm964cSO2bduGjIwMFBUVoaSkBJ06dapWDYsXL8a8efN007m5uXB3d/9Ly9XYqRQVbIUDbuMmnNECACCEwG3chDueMHJ11BhwHat99SIErK2t4e3tDQDYtm0b/P39sXXrVvj5+QEADhw4gBYtWug9R61WAwA+/vhjhIeHY/Xq1ejZsydsbW3x97//Hd988021alCr1boxqepaoS3O4VvYiSawhyMy8CvKUQZXeBq7NGokuI7VrnoRAvdSqVSIiIjAvHnzcPHiRajVamRkZCAgIKDS/snJyejVqxfCwsJ0bZcuXaqrcqXnorijVGiQhnPQoBi2sEdn9IZa4a461QyuY7Wr3oUAAIwbNw4LFizAli1bEB4ejrlz50Kr1aJ3797IyclBcnIy7OzsEBISgjZt2mDnzp04dOgQvLy8EBsbi2+//RZeXl7GXgxpuCvecIe3scugRozrWO2plyFgamqKWbNmYdWqVUhPT4eTkxMiIyORlpYGBwcHdOnSBREREQCA6dOn4/Tp03juueegKAomTJiAsLAwfP7550ZeCiKi+k8RQghjF1Ef5ebmwt7eHv0wAqaKmbHLISKqsjJRiiT8Czk5ObCzs3to33rxZTEiIjIOhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcQYAkREEmMIEBFJjCFARCQxhgARkcRMq9Jp//79VR5w+PDhj10MERHVrSqFwMiRI6s0mKIoKC8v/yv1EBFRHapSCGi12tqug4iIjIDnBIiIJFalPYH7FRQU4OjRo8jIyEBJSYnevNmzZ9dIYUREVPuqHQKnT5/GkCFDUFhYiIKCAjg6OuLWrVuwsrKCs7MzQ4CIqAGp9uGguXPnYtiwYbhz5w4sLS3x9ddf48qVK+jatSvee++92qiRiIhqSbVD4MyZM5g/fz5UKhVMTEyg0Wjg7u6OVatWISIiojZqJCKiWlLtEDAzM4NKdfdpzs7OyMjIAADY29sjMzOzZqsjIqJaVe1zAp07d8a3336LNm3aICAgAG+99RZu3bqF2NhY+Pn51UaNRERUS6q9J7BixQq4uroCAJYvX44mTZpgxowZyM7OxgcffFDjBRIRUe2p9p5At27ddP92dnbGF198UaMFERFR3eGXxYiIJFbtPQEvLy8oivLA+WlpaX+pICIiqjvVDoE5c+boTZeWluL06dP44osvsGDBgpqqi4iI6kC1Q+C1116rtH3jxo347rvv/nJBRERUd2rsnMDgwYOxb9++mhqOiIjqQI2FQFxcHBwdHWtqOCIiqgOP9WWxe08MCyFw48YNZGdnY9OmTTVaHBER1a5qh8CIESP0QkClUsHJyQn9+vVDu3btarS4ekFlAigmxq6CGqFDV1OMXQI1Url5WjRpW7W+1Q6BpUuXVvcpRERUT1X7nICJiQlu3rxp0P7777/DxISfmImIGpJqh4AQotJ2jUYDc3Pzv1wQERHVnSofDnr//fcBAIqi4J///CdsbGx088rLy3Hs2LHGeU6AiKgRq3IIrF27FsDdPYHo6Gi9Qz/m5ubw9PREdHR0zVdIRES1psohkJ6eDgAIDAzEp59+iiZNmtRaUUREVDeqfXXQkSNHaqMOIiIygmqfGB4zZgxWrlxp0L5q1SqMGzeuRooiIqK6Ue0QOHbsGIYMGWLQPnjwYBw7dqxGiiIiorpR7RDIz8+v9FJQMzMz5Obm1khRRERUN6odAh06dMAnn3xi0P7xxx/D19e3RooiIqK6Ue0Tw2+++SZGjx6NS5cuoX///gCAr776Crt27UJcXFyNF0hERLWn2iEwbNgwxMfHY8WKFYiLi4OlpSX8/f3xn//8hz8lTUTUwFQ7BABg6NChGDp0KAAgNzcXu3fvRnh4OFJSUlBeXl6jBRIRUe157JvKHDt2DCEhIXBzc8Pq1avRv39/fP311zVZGxER1bJq7QncuHED27dvx9atW5Gbm4vx48dDo9EgPj6eJ4WJiBqgKu8JDBs2DD4+Pvjxxx8RFRWF69evY/369bVZGxER1bIq7wl8/vnnmD17NmbMmIE2bdrUZk1ERFRHqrwncOLECeTl5aFr167o0aMHNmzYgFu3btVmbUREVMuqHAJPP/00/vGPfyArKwvTp0/Hxx9/DDc3N2i1WiQmJiIvL6826yQiolpQ7auDrK2tMXXqVJw4cQI//fQT5s+fj3fffRfOzs4YPnx4bdRIRES15LEvEQUAHx8frFq1ClevXsXu3btrqiYiIqojfykEKpiYmGDkyJHYv39/TQxHRER1pEZCgIiIGiaGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSa5AhsH37djg4OBi7DAKQrj2H/5Z/iSPl+3C0PB4/lJ9Agcg1dlnUABw7VYThk6+jZad0mLimIv7zfL35v2WXYcprv6Flp3TYeF3C4AnX8WtaiV6fGzfLMHnWb3DrmA7b1pfQLTgT+xL0x6GHM2oIhIaGQlEUg0dqaqoxy6Jq+ENko6XSBk+pgtBFFQAttDitPYpyUWbs0qieKyjUwt9XjfUrnAzmCSEwekoW0q+U4rPtrkhJdIdHS1MMHH8dBYVaXb+QV3/DxUsliN/hih+OtMKoIdZ4fvoNnP5JU5eL0qAZfU9g0KBByMrK0nt4eXkZuyyqos4mAXBTecFGsYet0gRPqrqjGIXIxW1jl0b13OAB1lj2elOMGmJjMO/XtFJ8naLBxpVOeKqTBXy8zbFppROKigV2f5an63fqu2LMnGqP7p0t0NrDDG/MdYSDvQopPxbX5aI0aEYPAbVaDRcXF73HunXr0KFDB1hbW8Pd3R1hYWHIz3/wLl52dja6deuGUaNGQaPRQKvVIjIyEl5eXrC0tIS/vz/i4uLqcKnkVYZSAIAZzI1cCTVkmhIBALBQ/7mJUqkUqNUKkv/75wa+ZzcL7Nmfj9t3yqHVCnwcn4fiYoF+vSzrvOaGyughUBmVSoX3338fZ8+exY4dO/Cf//wHCxcurLRvZmYm+vTpAz8/P8TFxUGtViMyMhI7d+5EdHQ0zp49i7lz52LSpEk4evRoHS+JXIQQuKg9DXs0g43iYOxyqAFr522OVi1MEbHid9z5oxwlJQKrNtzB1etlyPrtz0ONn3zggtJSASffdFh6XMKMhdnYt80V3l78EFJVpsYuICEhATY2f+4ODh48GHv37tVNe3p64m9/+xteeeUVbNq0Se+5Fy5cQHBwMEaNGoWoqCgoigKNRoMVK1bg8OHD6NmzJwCgdevWOHHiBLZs2YKAgIBK69BoNNBo/jyOmJvLk5vVdV6kIB856KYaYOxSqIEzM1MQt9UFL82/iWbt02FiAgzoY4VB/a0gxJ/93lp1Gzm5Wny5xw3NHE3wry8K8Pz0Gzga3wId2quNtwANiNFDIDAwEJs3b9ZNW1tb4/Dhw4iMjMT58+eRm5uLsrIyFBcXo7CwEFZWVgCAoqIi9OnTBxMnTkRUVJTu+ampqSgsLERwcLDe65SUlKBz584PrCMyMhJvv/12zS6cRM5rU3BLXEc3VX9YKFbGLocaga7+Fvj+cCvk5JajpARwamaCnkMy0dXfAgBw6XIpNm7LwY9J7njS5+4G3/9JNU58U4RNMTnYvMrZmOU3GEY/HGRtbQ1vb2/dQ6PR4Nlnn0XHjh2xb98+pKSkYOPGjQDubsgrqNVqBAUFISEhAdeuXdO1V5w7OHDgAM6cOaN7nDt37qHnBRYvXoycnBzdIzMzs5aWuHERQuC8NgXZ4hq6qgJhqRie5CP6K+ztTODUzAS/ppXgux80GP6MNQCgsOjuVUIqRdHrr1IBWq3BMPQARt8TuF9KSgq0Wi1Wr14NlepuRu3Zs8egn0qlQmxsLCZOnIjAwEAkJSXBzc0Nvr6+UKvVyMjIeOChn8qo1Wqo1dx9rK4LIgU3RAb8Vb1hAlNoRBEAwBRmMFHq3epF9Uh+gRap6aW66csZZTjzswaODiq0ammGvf/Oh1NTFVq1MMNPv2gw981bGDHIGgP73d3TbOdtDm8vM8xYeBOrljRD0yYm+NcX+Th8rAj7Yx2MtFQNT737X+rt7Y3S0lKsX78ew4YNQ3JyMqKjoyvta2Jigo8++ggTJkxA//79kZSUBBcXF4SHh2Pu3LnQarXo3bs3cnJykJycDDs7O4SEhNTxEjVuV8UlAECK9oheu6/SHW4KL/WlB/vuh2IMGHNdNz1/6S0AwOTxtohZ1xw3fitD+NI/8Ft2GVydTfHCOFv8v7mOuv5mZgoSPnTF4uW/Y8TkLOQXaOHtZYaYdc4YMsC6zpenoap3IeDv7481a9Zg5cqVWLx4Mfr27YvIyEhMnjy50v6mpqbYvXs3nnvuOV0QLFu2DE5OToiMjERaWhocHBzQpUsXRERE1PHSNH5BJs8ZuwRqoPr1skJ5lvcD57/6ogNefdHhoWO0aW2OuK2uNVyZXBQh7j3XThVyc3Nhb2+PfqrRMFXMjF0ONUKHrqYYuwRqpHLztGjSNg05OTmws7N7aF+jnxgmIiLjYQgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSMzV2AfWVEAIAUCZKjVwJNVa5eVpjl0CNVG7+3XWrYjv2MAyBB8jLywMAnBD/Bh79PhJVW5O2xq6AGru8vDzY29s/tI8iqhIVEtJqtbh+/TpsbW2hKIqxy6n3cnNz4e7ujszMTNjZ2Rm7HGpkuH5VjxACeXl5cHNzg0r18KP+3BN4AJVKhZYtWxq7jAbHzs6O/0mp1nD9qrpH7QFU4IlhIiKJMQSIiCTGEKAaoVarsWTJEqjVamOXQo0Q16/awxPDREQS454AEZHEGAJERBJjCJBRhIaGYuTIkcYugxqQ7du3w8HBwdhlNDoMATIQGhoKRVGgKArMzMzg5eWFhQsXori42NilUSNw7/p17yM1NdXYpUmJXxajSg0aNAgxMTEoLS1FSkoKQkJCoCgKVq5caezSqBGoWL/u5eTkZKRq5MY9AaqUWq2Gi4sL3N3dMXLkSAQFBSExMRHA3Z/UiIyMhJeXFywtLeHv74+4uDjdc8vLyzFt2jTdfB8fH6xbt85Yi0L1UMX6de9j3bp16NChA6ytreHu7o6wsDDk5+c/cIzs7Gx069YNo0aNgkajeeR6SZXjngA90s8//4yTJ0/Cw8MDABAZGYkPP/wQ0dHRaNOmDY4dO4ZJkybByckJAQEB0Gq1aNmyJfbu3YumTZvi5MmTePnll+Hq6orx48cbeWmovlKpVHj//ffh5eWFtLQ0hIWFYeHChdi0aZNB38zMTAQHB+Ppp5/G1q1bYWJiguXLlz90vaQHEET3CQkJESYmJsLa2lqo1WoBQKhUKhEXFyeKi4uFlZWVOHnypN5zpk2bJiZMmPDAMWfOnCnGjBmj9xojRoyorUWgeuze9aviMXbsWIN+e/fuFU2bNtVNx8TECHt7e3H+/Hnh7u4uZs+eLbRarRBCPPZ6SUJwT4AqFRgYiM2bN6OgoABr166FqakpxowZg7Nnz6KwsBDBwcF6/UtKStC5c2fd9MaNG7Ft2zZkZGSgqKgIJSUl6NSpUx0vBdVXFetXBWtraxw+fBiRkZE4f/48cnNzUVZWhuLiYhQWFsLKygoAUFRUhD59+mDixImIiorSPT81NbVK6yUZYghQpaytreHt7Q0A2LZtG/z9/bF161b4+fkBAA4cOIAWLVroPafiK/0ff/wxwsPDsXr1avTs2RO2trb4+9//jm+++aZuF4LqrXvXLwC4fPkynn32WcyYMQPLly+Ho6MjTpw4gWnTpqGkpEQXAmq1GkFBQUhISMCCBQt062DFuYOHrZdUOYYAPZJKpUJERATmzZuHixcvQq1WIyMj44HHWZOTk9GrVy+EhYXp2i5dulRX5VIDlJKSAq1Wi9WrV+t+/37Pnj0G/VQqFWJjYzFx4kQEBgYiKSkJbm5u8PX1feR6SZVjCFCVjBs3DgsWLMCWLVsQHh6OuXPnQqvVonfv3sjJyUFycjLs7OwQEhKCNm3aYOfOnTh06BC8vLwQGxuLb7/9Fl5eXsZeDKqnvL29UVpaivXr12PYsGFITk5GdHR0pX1NTEzw0UcfYcKECejfvz+SkpLg4uLyyPWSKscQoCoxNTXFrFmzsGrVKqSnp8PJyQmRkZFIS0uDg4MDunTpgoiICADA9OnTcfr0aTz33HNQFAUTJkxAWFgYPv/8cyMvBdVX/v7+WLNmDVauXInFixejb9++iIyMxOTJkyvtb2pqit27d+O5557TBcGyZcseul5S5fgrokREEuOXxYiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIjqwP33VO7Xrx/mzJlT53UkJSVBURT88ccfdf7aVD8xBEhq997v1tzcHN7e3njnnXdQVlZWq6/76aefYtmyZVXqyw031Sb+dhBJr+J+txqNBgcPHsTMmTNhZmaGxYsX6/UrKSmBubl5jbymo6NjjYxD9FdxT4CkV3G/Ww8PD8yYMQNBQUHYv3+/7hDO8uXL4ebmBh8fHwB3b204fvx4ODg4wNHRESNGjMDly5d145WXl2PevHlwcHBA06ZNsXDhQtz/E133Hw7SaDRYtGgR3N3doVar4e3tja1bt+Ly5csIDAwEADRp0gSKoiA0NBTAo+/1DAAHDx5E27ZtYWlpicDAQL06iQCGAJEBS0tLlJSUAAC++uorXLhwAYmJiUhISEBpaSmeeeYZ2Nra4vjx40hOToaNjQ0GDRqke87q1auxfft2bNu2DSdOnMDt27fx2WefPfQ1J0+ejN27d+P999/HL7/8gi1btsDGxgbu7u7Yt28fAODChQvIysrCunXrANy91/POnTsRHR2Ns2fPYu7cuZg0aRKOHj0K4G5YjR49GsOGDcOZM2fw4osv4vXXX6+tt40aKiPf3pLIqO6917FWqxWJiYlCrVaL8PBwERISIpo3by40Go2uf2xsrPDx8dHd21YIITQajbC0tBSHDh0SQgjh6uoqVq1apZtfWloqWrZsqXdP5YCAAPHaa68JIYS4cOGCACASExMrrfHIkSMCgLhz546urSr31F28eLHw9fXVm79o0SKDsUhuPCdA0ktISICNjQ1KS0uh1WoxceJELF26FDNnzkSHDh30zgP88MMPSE1Nha2trd4YxcXFuHTpEnJycpCVlYUePXro5pmamqJbt24Gh4QqnDlzBiYmJtW6I1ZV7qn7yy+/6NUBAD179qzya5AcGAIkvYqbnpubm8PNzQ2mpn/+t7C2ttbrm5+fj65du+Kjjz4yGMfJyemxXt/S0rLaz+E9dammMARIevff9PxhunTpgk8++QTOzs6ws7OrtI+rqyu++eYb9O3bFwBQVlaGlJQUdOnSpdL+HTp0gFarxdGjRxEUFGQwv2JPpLy8XNdWlXvqtm/fHvv379dr+/rrrx+9kCQVnhgmqob//d//RbNmzTBixAgcP34c6enpSEpKwuzZs3H16lUAwGuvvYZ3330X8fHxOH/+PMLCwh56jb+npydCQkIwdepUxMfH68asuNG6h4cHFEVBQkICsrOzkZ+fD1tbW909dXfs2IFLly7h+++/x/r167Fjxw4AwCuvvIJff/0VCxYswIULF7Br1y5s3769tt8iamAYAkTVYGVlhWPHjqFVq1YYPXo02rdvj2nTpqG4uFi3ZzB//ny88MILCAkJQc+ePWFra4tRo0Y9dNzNmzdj7NixCAsLQ7t27fDSSy+hoKAAANCiRQu8/fbbeP3119G8eXPMmjULALBs2TK8+eabiIyMRPv27TFo0CAcOHAAXl5eAIBWrVph3759iI+Ph7+/P6Kjo7FixYpafHeoIeI9homIJMY9ASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGL/H8jMo9ahTZuAAAAAAElFTkSuQmCC\n"
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAGGCAYAAACdXD2cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAK6NJREFUeJzt3XlcVGXfP/DPGZZhB1EUUAQMRRHF7db0UREFcwmXXEozQS1LNFfUpF9pdStpobhjPYpKaSkWt7dLhhUpaN5pWmm5ICi4lJrIIjAsc/3+8GFux0EFAwa4Pu/Xa151rnOda75nOM5nzjJzFCGEABERSUll7AKIiMh4GAJERBJjCBARSYwhQEQkMYYAEZHEGAJERBJjCBARSYwhQEQkMYYAEZHEGAJUpyQlJUFRFMTHxxu7lFojMzMTFhYWSElJeWxfWV6/F154AaNHjzZ2GXUCQ4Cojnv33XfRrVs3/M///I+ubdu2bYiOjjZeUY9w5MgR9OzZE1ZWVnB2dsb06dORl5dXoWUVRSn38f777+v1mz9/Pnbt2oWff/65OlahXjE1dgFE9ORu3ryJLVu2YMuWLXrt27Ztw+nTpzFz5kzjFPYQp06dQr9+/dCmTRssX74cV65cwYcffogLFy5g//79FRojKCgI48eP12vr2LGjwXSXLl0QFRWFrVu3Vln99RFDgKgO++STT2Bqaorg4OAaeb78/HxYWVk98fIRERFo0KABkpKSYGdnBwDw8PDAK6+8gq+//hr9+/d/7BitWrXCuHHjHttv9OjRWLhwIdatWwcbG5snrrm+4+Eg0lm0aBEURUFqaipCQ0Ph4OAAe3t7TJgwAfn5+Xp9Y2Nj0bdvXzRu3BhqtRo+Pj5Yv369wZgeHh549tlnkZycjK5du8LCwgItWrQo99NZWloaRo0aBUdHR1hZWeHpp5/G3r17y621tLQUERERcHZ2hrW1NYYMGYLMzEy9PocPH8aoUaPQvHlzqNVquLm5YdasWSgoKNDrFxoaChsbG1y9ehXDhg2DjY0NnJycEB4ejtLSUr2+H374IXr06IGGDRvC0tISnTt3Lvf4uqIomDZtGhISEuDr6wu1Wo22bdviq6++0ut3+fJlhIWFwdvbG5aWlmjYsCFGjRqFS5culbveD0pISEC3bt303uT69OmDvXv34vLly7rDJR4eHnrLabVaLF68GM2aNYOFhQX69euH1NRUvT59+vSBr68vTpw4gd69e8PKygoREREVqqs8OTk5SExMxLhx43QBAADjx4+HjY0NduzYUeGxCgoKUFhY+Mg+QUFBuHv3LhITE5+4ZikIov+zcOFCAUB07NhRPPfcc2LdunXi5ZdfFgDEvHnz9Pr+4x//EKGhoWLFihVi9erVon///gKAWLNmjV4/d3d34e3tLZo0aSIiIiLEmjVrRKdOnYSiKOL06dO6fn/88Ydo0qSJsLW1FW+++aZYvny58PPzEyqVSnzxxRe6ft99950AINq1ayfat28vli9fLt544w1hYWEhWrVqJfLz83V9X3/9dTFo0CCxZMkSsWHDBjFp0iRhYmIiRo4cqVdjSEiIsLCwEG3bthUTJ04U69evFyNGjBAAxLp16/T6NmvWTISFhYk1a9aI5cuXi65duwoAYs+ePXr9AAg/Pz/h4uIi3nvvPREdHS1atGghrKysxK1bt3T9du7cKfz8/MTbb78tPvroIxERESEaNGgg3N3dxd27dx/59yoqKhKWlpZi9uzZeu1ff/216NChg2jUqJGIi4sTcXFx4ssvv9R7/Tp27Cg6d+4sVqxYIRYtWiSsrKxE165d9cbx9/cXzs7OwsnJSbz++utiw4YNIiEhQQghRG5urrh58+ZjH3fu3NGNl5ycLACIzz//3GBdevbsKTp16vTI9S17Xa2trYWiKAKAaNOmjfj000/L7VtcXCwsLS3FnDlzHjuuzBgCpFMWAhMnTtRrHz58uGjYsKFe2/1vtmWeeeYZ0aJFC702d3d3AUAcOnRI13bjxg2hVqv1/nHOnDlTABCHDx/WteXm5gpPT0/h4eEhSktLhRD/fRNr2rSpyMnJ0fXdsWOHACBWrlz5yBojIyOFoiji8uXLuraQkBABQLz77rt6fcveKB+13kVFRcLX11f07dtXrx2AMDc3F6mpqbq2n3/+WQAQq1evfmSNR48eFQDE1q1bDebdLzU11WC8MoMHDxbu7u4G7WWvX5s2bYRGo9G1r1y5UgAQv/76q67N399fABAxMTEG45S9Zo97+Pv765bZuXOnwbZQZtSoUcLZ2fmR6yuEED169BDR0dHiX//6l1i/fr3w9fUtN6zLtGrVSgwcOPCx48qM5wTIwGuvvaY33atXL3z55ZfIycnR7cZbWlrq5mdnZ6O4uBj+/v44cOAAsrOzYW9vr5vv4+ODXr166aadnJzg7e2NtLQ0Xdu+ffvQtWtX9OzZU9dmY2ODyZMnY8GCBfjtt9/g6+urmzd+/HjY2trqpkeOHAkXFxfs27cP06dPN6jx7t27KCgoQI8ePSCEwMmTJ9G8efPHrndcXJxe2/1jZmVlobS0FL169cL27dsNXsfAwEA89dRTuun27dvDzs5Ob73vH6+4uBg5OTnw8vKCg4MDfvrpJ7z00ksG45b566+/AAANGjR4aJ+HmTBhAszNzXXTZX+ftLQ0vddZrVZjwoQJBsvPmzevQsfl76+t7DCcWq026GdhYWFwmK48D14GO3HiRHTu3BkREREIDQ3Vez3Lnv/WrVuPHVdmDAEy8OCbY9k/5KysLF0IpKSkYOHChTh69KjB+YIHQ+DB8crGzMrK0k1fvnwZ3bp1M+jXpk0b3fz735xatmyp109RFHh5eekdS8/IyMDbb7+N3bt36z1XWY33s7CwgJOT0yNrBIA9e/bgn//8J06dOgWNRqP3/A+qyHoXFBQgMjISsbGxuHr1KsR9N/p7sMaHEU9wc8BH/Y3v17RpU72wKOPj4wMfH59KPWfZG/T9r1uZwsJCgzfwijA3N8e0adPw2muv4cSJE3ofIoB7r015fxv6L4YAGTAxMSm3vezN5uLFi+jXrx9at26N5cuXw83NDebm5ti3bx9WrFgBrVZbqfGqQ2lpKYKCgnD79m3Mnz8frVu3hrW1Na5evYrQ0NAK13i/w4cPY8iQIejduzfWrVsHFxcXmJmZITY2Ftu2bTPoX5H1fv311xEbG4uZM2eie/fusLe3h6IoeOGFFwxqfFDDhg0BGL5xV0RF/yYPe2POzs6u0Cd3c3NzODo6AgBcXFwAANevXzfod/36dbi6uj52vPK4ubkBAG7fvm0wLysry+ADA+ljCFCl/fvf/4ZGo8Hu3bv1PlF+9913Tzymu7s7zp07Z9B+9uxZ3fz7XbhwQW9aCIHU1FS0b98eAPDrr7/i/Pnz2LJli9415X/nSpFdu3bBwsICBw4c0DukERsb+8RjxsfHIyQkBFFRUbq2wsJC3Llz57HLNm/eHJaWlkhPTzeYV92ffmfMmGHw3YTy+Pv7IykpCQDg6+sLU1NTHD9+XO/bvEVFRTh16tQTf8O37PDag3tyJSUlyMzMxJAhQ55oXFkwBKjSyj5FPnjo4u+8GQ4aNAjR0dE4evQounfvDuDecfyPPvoIHh4eBocetm7digULFujOC8THx+P69euYP3/+Q2sUQmDlypVPXKOJiQkURdG7bPTSpUtISEj4W2M++Ol79erVBpemlsfMzAxdunTB8ePHDeZZW1tX+HDSk3iScwL29vYIDAzEJ598grfeekv3t4uLi0NeXh5GjRql65ufn4+MjAw0atQIjRo1AnDvi3EPvtHn5uYiOjoajRo1QufOnfXm/fbbbygsLESPHj2eeD1lwBCgSuvfvz/Mzc0RHByMV199FXl5efj444/RuHHjcnf1K+KNN97A9u3bMXDgQEyfPh2Ojo7YsmUL0tPTsWvXLqhU+l9pcXR0RM+ePTFhwgT8+eefiI6OhpeXF1555RUAQOvWrfHUU08hPDwcV69ehZ2dHXbt2vVEh07KDB48GMuXL8eAAQMwduxY3LhxA2vXroWXlxd++eWXJxrz2WefRVxcHOzt7eHj44OjR4/i4MGDukM9jzN06FC8+eabeiftAaBz5874/PPPMXv2bPzjH/+AjY1NlX6h7EnOCQDA4sWL0aNHD/j7+2Py5Mm4cuUKoqKi0L9/fwwYMEDX7z//+Q8CAgKwcOFCLFq0CACwdu1aJCQkIDg4GM2bN8f169exadMmZGRkIC4uzuDcRWJiIqysrBAUFPS31rXeM8o1SVQrlV0ievPmTb322NhYAUCkp6fr2nbv3i3at28vLCwshIeHh1i6dKnYtGmTQT93d3cxePBgg+fy9/fXu3xQCCEuXrwoRo4cKRwcHISFhYXo2rWrwfX3ZZc4bt++XSxYsEA0btxYWFpaisGDB+td9imEEL/99psIDAwUNjY2olGjRuKVV17RXaYZGxur6xcSEiKsra0f+nrcb+PGjaJly5ZCrVaL1q1bi9jY2HL7ARBTp041GNPd3V2EhIToprOyssSECRNEo0aNhI2NjXjmmWfE2bNnDfo9zJ9//ilMTU1FXFycXnteXp4YO3ascHBwEAB0l4uWvX47d+7U65+enm7wuvj7+4u2bds+tobKOnz4sOjRo4ewsLAQTk5OYurUqXqX+95f58KFC3VtX3/9tQgKChLOzs7CzMxMODg4iP79+4tvvvmm3Ofp1q2bGDduXJXXX98oQlTj2TkiqnaTJk3C+fPncfjwYWOXUmucOnUKnTp1wk8//YQOHToYu5xajSFAVMdlZGSgVatW+Oabb/R+SVRmZVdXVeanKGTFECAikhh/QI6ISGIMASIiiTEEiIgkxhAgIpIYvyz2EFqtFteuXYOtrS1/gIqI6hQhBHJzc+Hq6mrwRcsHMQQe4tq1a7ofpiIiqosyMzPRrFmzR/ZhCDxE2e+a9MQgmMLMyNUQEVVcCYqRjH1699x4GIbAQ5QdAjKFGUwVhgAR1SH/9+2vihzK5olhIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikpipsQugui9TpOIyzqMIhbCBPbzREfaKo7HLonqE21j1kWJPIDQ0FMOGDTN2GfXSHyIT5/ELWsAHXREIWzjgJA6jSBQauzSqJ7iNVS+jh0BoaCgURYGiKDAzM4OnpyfmzZuHwkL+geuCDJxHU3jCVfGAjWKH1ugEE5jgGi4ZuzSqJ7iNVa9acThowIABiI2NRXFxMU6cOIGQkBAoioKlS5cauzR6BK3QIhd34IHWujZFUeAomuAO/jJiZVRfcBurfkbfEwAAtVoNZ2dnuLm5YdiwYQgMDERiYiIAQKvVIjIyEp6enrC0tISfnx/i4+N1y5aWlmLSpEm6+d7e3li5cqWxVkUqxdBAQMAcFnrt5lCjCNyTo7+P21j1qxV7Avc7ffo0jhw5And3dwBAZGQkPvnkE8TExKBly5Y4dOgQxo0bBycnJ/j7+0Or1aJZs2bYuXMnGjZsiCNHjmDy5MlwcXHB6NGjK/y8Go0GGo1GN52Tk1Pl60ZEVNvUihDYs2cPbGxsUFJSAo1GA5VKhTVr1kCj0WDJkiU4ePAgunfvDgBo0aIFkpOTsWHDBvj7+8PMzAzvvPOObixPT08cPXoUO3bsqFQIREZG6o1Dj2cGNRQoBp/IiqAx+ORG9CS4jVW/WhECAQEBWL9+Pe7evYsVK1bA1NQUI0aMwJkzZ5Cfn4+goCC9/kVFRejYsaNueu3atdi0aRMyMjJQUFCAoqIidOjQoVI1LFiwALNnz9ZN5+TkwM3N7W+tV32nUlSwFQ64jRtojKYAACEEbuMG3PCUkauj+oDbWPWrFSFgbW0NLy8vAMCmTZvg5+eHjRs3wtfXFwCwd+9eNG3aVG8ZtVoNAPjss88QHh6OqKgodO/eHba2tvjggw9w7NixStWgVqt1Y1LFNUcr/IYfYScawB6OyMAFlKIELvAwdmlUT3Abq161IgTup1KpEBERgdmzZ+P8+fNQq9XIyMiAv79/uf1TUlLQo0cPhIWF6douXrxYU+VKz1lxQ7HQIA2/QYNC2MIeHdETaoW76lQ1uI1Vr1oXAgAwatQozJ07Fxs2bEB4eDhmzZoFrVaLnj17Ijs7GykpKbCzs0NISAhatmyJrVu34sCBA/D09ERcXBx+/PFHeHp6Gns1pOGmeMENXsYug+oxbmPVp1aGgKmpKaZNm4Zly5YhPT0dTk5OiIyMRFpaGhwcHNCpUydEREQAAF599VWcPHkSzz//PBRFwZgxYxAWFob9+/cbeS2IiGo/RQghjF1EbZSTkwN7e3v0wVCYKmbGLoeIqMJKRDGS8C9kZ2fDzs7ukX1rxZfFiIjIOBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSM61Ip927d1d4wCFDhjxxMUREVLMqFALDhg2r0GCKoqC0tPTv1ENERDWoQiGg1Wqruw4iIjICnhMgIpJYhfYEHnT37l18//33yMjIQFFRkd686dOnV0lhRERU/SodAidPnsSgQYOQn5+Pu3fvwtHREbdu3YKVlRUaN27MECAiqkMqfTho1qxZCA4ORlZWFiwtLfHDDz/g8uXL6Ny5Mz788MPqqJGIiKpJpUPg1KlTmDNnDlQqFUxMTKDRaODm5oZly5YhIiKiOmokIqJqUukQMDMzg0p1b7HGjRsjIyMDAGBvb4/MzMyqrY6IiKpVpc8JdOzYET/++CNatmwJf39/vP3227h16xbi4uLg6+tbHTUSEVE1qfSewJIlS+Di4gIAWLx4MRo0aIApU6bg5s2b+Oijj6q8QCIiqj6V3hPo0qWL7v8bN26Mr776qkoLIiKimsMvixERSazSewKenp5QFOWh89PS0v5WQUREVHMqHQIzZ87Umy4uLsbJkyfx1VdfYe7cuVVVFxER1YBKh8CMGTPKbV+7di2OHz/+twsiIqKaU2XnBAYOHIhdu3ZV1XBERFQDqiwE4uPj4ejoWFXDERFRDXiiL4vdf2JYCIE//vgDN2/exLp166q0OCIiql6VDoGhQ4fqhYBKpYKTkxP69OmD1q1bV2lxtYGiVkNRzIxdBtVDX6UfM3YJVE/l5GrRoFXF+lY6BBYtWlTZRYiIqJaq9DkBExMT3Lhxw6D9r7/+gomJSZUURURENaPSISCEKLddo9HA3Nz8bxdEREQ1p8KHg1atWgUAUBQF//u//wsbGxvdvNLSUhw6dKhenhMgIqrPKhwCK1asAHBvTyAmJkbv0I+5uTk8PDwQExNT9RUSEVG1qXAIpKenAwACAgLwxRdfoEGDBtVWFBER1YxKXx303XffVUcdRERkBJU+MTxixAgsXbrUoH3ZsmUYNWpUlRRFREQ1o9IhcOjQIQwaNMigfeDAgTh06FCVFEVERDWj0iGQl5dX7qWgZmZmyMnJqZKiiIioZlQ6BNq1a4fPP//coP2zzz6Dj49PlRRFREQ1o9Inht966y0899xzuHjxIvr27QsA+Oabb7Bt2zbEx8dXeYFERFR9Kh0CwcHBSEhIwJIlSxAfHw9LS0v4+fnh22+/5U9JExHVMZUOAQAYPHgwBg8eDADIycnB9u3bER4ejhMnTqC0tLRKCyQiourzxDeVOXToEEJCQuDq6oqoqCj07dsXP/zwQ1XWRkRE1axSewJ//PEHNm/ejI0bNyInJwejR4+GRqNBQkICTwoTEdVBFd4TCA4Ohre3N3755RdER0fj2rVrWL16dXXWRkRE1azCewL79+/H9OnTMWXKFLRs2bI6ayIiohpS4T2B5ORk5ObmonPnzujWrRvWrFmDW7duVWdtRERUzSocAk8//TQ+/vhjXL9+Ha+++io+++wzuLq6QqvVIjExEbm5udVZJxERVYNKXx1kbW2NiRMnIjk5Gb/++ivmzJmD999/H40bN8aQIUOqo0YiIqomT3yJKAB4e3tj2bJluHLlCrZv315VNRERUQ35WyFQxsTEBMOGDcPu3burYjgiIqohVRICRERUNzEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpIYQ4CISGIMASIiiTEEiIgkxhAgIpJYnQyBzZs3w8HBwdhl0APSS84gsfBTnCs+buxSqA44dLQAQ8ZfQ7MO6TBxSUXC/jy9+X/eLMGEGX+iWYd02HhexMAx13AhrchgnKPHCxA48ipsW1yEQ8uL6DPsCgoKtDW1GnWeUUMgNDQUiqIYPFJTU41ZFj2BbO1fuFJ6ATaKg7FLoTribr4Wfj5qrF7iZDBPCIHnJlxH+uVifLnZBScS3eDezBT9R1/D3fz/vsEfPV6AQWOvI8jfCj/sb4Zj+90QNtEeKpVSk6tSp5kau4ABAwYgNjZWr83JyXCjoNqrRBTjdHEKfEy7Ib3ktLHLoTpiYD9rDOxnXe68C2nF+OGEBr8kuaGttxoAsG6pE1zbX8L2L3Px8ov2AIA5C2/h9Un2mP96A92y3l7m1V98PWL0w0FqtRrOzs56j5UrV6Jdu3awtraGm5sbwsLCkJeX99Axbt68iS5dumD48OHQaDTQarWIjIyEp6cnLC0t4efnh/j4+BpcK7mcLf4RjVRN0dDExdilUD2hKRIAAAv1f9+iVCoFarWClP8UAgBu3CrBsZ80aNzIBD2Dr8ClXToChl9B8rECo9RcVxk9BMqjUqmwatUqnDlzBlu2bMG3336LefPmlds3MzMTvXr1gq+vL+Lj46FWqxEZGYmtW7ciJiYGZ86cwaxZszBu3Dh8//33Nbwm9d8fpZeQK27Dy7SDsUuheqS1lzmaNzVFxJK/kHWnFEVFAsvWZOHKtRJc/7MEAJB2+d5/34m6jUkv2mHfNld0bKdG0Oir5Z47oPIZ/XDQnj17YGNjo5seOHAgdu7cqZv28PDAP//5T7z22mtYt26d3rLnzp1DUFAQhg8fjujoaCiKAo1GgyVLluDgwYPo3r07AKBFixZITk7Ghg0b4O/vX24dGo0GGo1GN52Tk1OVq1kvFYq7OFd8Ap3M+8JEMTF2OVSPmJkpiN/ojFfm3ECjNukwMQH69bLCgL5WEPd2EqDV3vufyePsMeEFOwBAx3ZO+Da5ALHbc7DkzUbGKr9OMXoIBAQEYP369bppa2trHDx4EJGRkTh79ixycnJQUlKCwsJC5Ofnw8rKCgBQUFCAXr16YezYsYiOjtYtn5qaivz8fAQFBek9T1FRETp27PjQOiIjI/HOO+9U7crVczna2yhCIY4V7de1CQhkld5AZul59FO/AEWplTubVAd09rPATwebIzunFEVFgFMjE3QflInOfhYAAJcm996+2rTSPwfQuqU5Mq6W1Hi9dZXRQ8Da2hpeXl666UuXLuHZZ5/FlClTsHjxYjg6OiI5ORmTJk1CUVGRLgTUajUCAwOxZ88ezJ07F02bNgUA3bmDvXv36trKqNXqh9axYMECzJ49Wzedk5MDNze3KlvP+shR5Yzu5oP12s4UH4W1YgcP07YMAKoS9nb39jIvpBXh+M8avDOvIQDAw80Urs4mOH9R/9DPhbQiDAgo/4QzGTJ6CDzoxIkT0Gq1iIqKgkp1701kx44dBv1UKhXi4uIwduxYBAQEICkpCa6urvDx8YFarUZGRsZDD/2UR61WPzIkyJCpYmZwSagJTGGmqGGjcih3GaIyeXe1SE0v1k1fyijBqdMaODqo0LyZGXb+Ow9ODVVo3tQMv/6uway3bmHoAGv073Pvg6CiKAif0gCLPryN9m3V6NDWHFt35OJsajF2fGxnrNWqc2pdCHh5eaG4uBirV69GcHAwUlJSEBMTU25fExMTfPrppxgzZgz69u2LpKQkODs7Izw8HLNmzYJWq0XPnj2RnZ2NlJQU2NnZISQkpIbXiIjKc/znQvQbcU03PWfRLQDA+NG2iF3ZBH/8WYLwRXfw580SuDQ2xUujbPH/ZjnqjTFjsgMKNQJzFt7C7axS+LVV48BnrnjKw6xG16UuU4QoO81S80JDQ3Hnzh0kJCTota9YsQIffPAB7ty5g969e+PFF1/E+PHjkZWVBQcHB2zevBkzZ87EnTt3AAAlJSV4/vnn8fvvvyMpKQlOTk5YtWoV1q9fj7S0NDg4OKBTp06IiIhA7969K1RbTk4O7O3tEaAeDVOFGxRVva/Sjxm7BKqncnK1aNAqDdnZ2bCze/RekVFDoDZjCFB1YwhQdalMCPDMHRGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxBgCREQSYwgQEUmMIUBEJDGGABGRxEyNXUBtJYQAAJSIYiNXQvVVTq7W2CVQPZWTd2/bKnsfexSGwEPk5uYCAA4XfWnkSqi+atDK2BVQfZebmwt7e/tH9lFERaJCQlqtFteuXYOtrS0URTF2ObVeTk4O3NzckJmZCTs7O2OXQ/UMt6/KEUIgNzcXrq6uUKkefdSfewIPoVKp0KxZM2OXUefY2dnxHylVG25fFfe4PYAyPDFMRCQxhgARkcQYAlQl1Go1Fi5cCLVabexSqB7i9lV9eGKYiEhi3BMgIpIYQ4CISGIMATKK0NBQDBs2zNhlUB2yefNmODg4GLuMeochQAZCQ0OhKAoURYGZmRk8PT0xb948FBYWGrs0qgfu377uf6Smphq7NCnxy2JUrgEDBiA2NhbFxcU4ceIEQkJCoCgKli5dauzSqB4o277u5+TkZKRq5MY9ASqXWq2Gs7Mz3NzcMGzYMAQGBiIxMRHAvZ/UiIyMhKenJywtLeHn54f4+HjdsqWlpZg0aZJuvre3N1auXGmsVaFaqGz7uv+xcuVKtGvXDtbW1nBzc0NYWBjy8vIeOsbNmzfRpUsXDB8+HBqN5rHbJZWPewL0WKdPn8aRI0fg7u4OAIiMjMQnn3yCmJgYtGzZEocOHcK4cePg5OQEf39/aLVaNGvWDDt37kTDhg1x5MgRTJ48GS4uLhg9erSR14ZqK5VKhVWrVsHT0xNpaWkICwvDvHnzsG7dOoO+mZmZCAoKwtNPP42NGzfCxMQEixcvfuR2SQ8hiB4QEhIiTExMhLW1tVCr1QKAUKlUIj4+XhQWFgorKytx5MgRvWUmTZokxowZ89Axp06dKkaMGKH3HEOHDq2uVaBa7P7tq+wxcuRIg347d+4UDRs21E3HxsYKe3t7cfbsWeHm5iamT58utFqtEEI88XZJQnBPgMoVEBCA9evX4+7du1ixYgVMTU0xYsQInDlzBvn5+QgKCtLrX1RUhI4dO+qm165di02bNiEjIwMFBQUoKipChw4dangtqLYq277KWFtb4+DBg4iMjMTZs2eRk5ODkpISFBYWIj8/H1ZWVgCAgoIC9OrVC2PHjkV0dLRu+dTU1Aptl2SIIUDlsra2hpeXFwBg06ZN8PPzw8aNG+Hr6wsA2Lt3L5o2baq3TNlX+j/77DOEh4cjKioK3bt3h62tLT744AMcO3asZleCaq37ty8AuHTpEp599llMmTIFixcvhqOjI5KTkzFp0iQUFRXpQkCtViMwMBB79uzB3Llzddtg2bmDR22XVD6GAD2WSqVCREQEZs+ejfPnz0OtViMjI+Ohx1lTUlLQo0cPhIWF6douXrxYU+VSHXTixAlotVpERUXpfv9+x44dBv1UKhXi4uIwduxYBAQEICkpCa6urvDx8XnsdknlYwhQhYwaNQpz587Fhg0bEB4ejlmzZkGr1aJnz57Izs5GSkoK7OzsEBISgpYtW2Lr1q04cOAAPD09ERcXhx9//BGenp7GXg2qpby8vFBcXIzVq1cjODgYKSkpiImJKbeviYkJPv30U4wZMwZ9+/ZFUlISnJ2dH7tdUvkYAlQhpqammDZtGpYtW4b09HQ4OTkhMjISaWlpcHBwQKdOnRAREQEAePXVV3Hy5Ek8//zzUBQFY8aMQVhYGPbv32/ktaDays/PD8uXL8fSpUuxYMEC9O7dG5GRkRg/fny5/U1NTbF9+3Y8//zzuiB47733HrldUvn4K6JERBLjl8WIiCTGECAikhhDgIhIYgwBIiKJMQSIiCTGECAikhhDgIhIYgwBIiKJMQSIasCD91Tu06cPZs6cWeN1JCUlQVEU3Llzp8afm2onhgBJ7f773Zqbm8PLywvvvvsuSkpKqvV5v/jiC7z33nsV6ss3bqpO/O0gkl7Z/W41Gg327duHqVOnwszMDAsWLNDrV1RUBHNz8yp5TkdHxyoZh+jv4p4ASa/sfrfu7u6YMmUKAgMDsXv3bt0hnMWLF8PV1RXe3t4A7t3acPTo0XBwcICjoyOGDh2KS5cu6cYrLS3F7Nmz4eDggIYNG2LevHl48Ce6HjwcpNFoMH/+fLi5uUGtVsPLywsbN27EpUuXEBAQAABo0KABFEVBaGgogMff6xkA9u3bh1atWsHS0hIBAQF6dRIBDAEiA5aWligqKgIAfPPNNzh37hwSExOxZ88eFBcX45lnnoGtrS0OHz6MlJQU2NjYYMCAAbploqKisHnzZmzatAnJycm4ffs2vvzyy0c+5/jx47F9+3asWrUKv//+OzZs2AAbGxu4ublh165dAIBz587h+vXrWLlyJYB793reunUrYmJicObMGcyaNQvjxo3D999/D+BeWD333HMIDg7GqVOn8PLLL+ONN96orpeN6ioj396SyKjuv9exVqsViYmJQq1Wi/DwcBESEiKaNGkiNBqNrn9cXJzw9vbW3dtWCCE0Go2wtLQUBw4cEEII4eLiIpYtW6abX1xcLJo1a6Z3T2V/f38xY8YMIYQQ586dEwBEYmJiuTV+9913AoDIysrStVXknroLFiwQPj4+evPnz59vMBbJjecESHp79uyBjY0NiouLodVqMXbsWCxatAhTp05Fu3bt9M4D/Pzzz0hNTYWtra3eGIWFhbh48SKys7Nx/fp1dOvWTTfP1NQUXbp0MTgkVObUqVMwMTGp1B2xKnJP3d9//12vDgDo3r17hZ+D5MAQIOmV3fTc3Nwcrq6uMDX97z8La2trvb55eXno3LkzPv30U4NxnJycnuj5LS0tK70M76lLVYUhQNJ78Kbnj9KpUyd8/vnnaNy4Mezs7Mrt4+LigmPHjqF3794AgJKSEpw4cQKdOnUqt3+7du2g1Wrx/fffIzAw0GB+2Z5IaWmprq0i99Rt06YNdu/erdf2ww8/PH4lSSo8MUxUCS+++CIaNWqEoUOH4vDhw0hPT0dSUhKmT5+OK1euAABmzJiB999/HwkJCTh79izCwsIeeY2/h4cHQkJCMHHiRCQkJOjGLLvRuru7OxRFwZ49e3Dz5k3k5eXB1tZWd0/dLVu24OLFi/jpp5+wevVqbNmyBQDw2muv4cKFC5g7dy7OnTuHbdu2YfPmzdX9ElEdwxAgqgQrKyscOnQIzZs3x3PPPYc2bdpg0qRJKCws1O0ZzJkzBy+99BJCQkLQvXt32NraYvjw4Y8cd/369Rg5ciTCwsLQunVrvPLKK7h79y4AoGnTpnjnnXfwxhtvoEmTJpg2bRoA4L333sNbb72FyMhItGnTBgMGDMDevXvh6ekJAGjevDl27dqFhIQE+Pn5ISYmBkuWLKnGV4fqIt5jmIhIYtwTICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJMYQICKSGEOAiEhiDAEiIokxBIiIJPb/AWH8ff5rv56aAAAAAElFTkSuQmCC\n"
           },
           "metadata": {}
         },
@@ -1830,16 +2059,16 @@
           "text": [
             "Saved predictions CSV: artifacts/manual_gen/nanobanana/predictions.csv\n",
             "Saved confusion matrix PNG: artifacts/manual_gen/nanobanana/confusion_matrix.png\n",
-            "Backed up to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/artifacts/manual_gen/nanobanana\n",
+            "Backed up to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/artifacts/manual_gen/nanobanana\n",
             "\n",
             "[dalle] n=200 batch_size=64 num_workers=2\n",
             "Confusion matrix (rows=actual, cols=pred):\n",
             "            pred_real  pred_fake\n",
             "actual_real          0         0\n",
-            "actual_fake          2       198\n",
-            "(tn=0, fp=0, fn=2, tp=198)\n",
-            "Accuracy: 0.9900\n",
-            "Recall on fake (sensitivity): 0.99\n",
+            "actual_fake          6       194\n",
+            "(tn=0, fp=0, fn=6, tp=194)\n",
+            "Accuracy: 0.9700\n",
+            "Recall on fake (sensitivity): 0.97\n",
             "Specificity: n/a\n",
             "\n",
             "Classification Report:\n",
@@ -1847,11 +2076,11 @@
             "              precision    recall  f1-score   support\n",
             "\n",
             "        real       0.00      0.00      0.00         0\n",
-            "        fake       1.00      0.99      0.99       200\n",
+            "        fake       1.00      0.97      0.98       200\n",
             "\n",
-            "    accuracy                           0.99       200\n",
-            "   macro avg       0.50      0.49      0.50       200\n",
-            "weighted avg       1.00      0.99      0.99       200\n",
+            "    accuracy                           0.97       200\n",
+            "   macro avg       0.50      0.48      0.49       200\n",
+            "weighted avg       1.00      0.97      0.98       200\n",
             "\n"
           ]
         },
@@ -1861,7 +2090,7 @@
             "text/plain": [
               "<Figure size 500x400 with 1 Axes>"
             ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAGGCAYAAACdXD2cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJ7tJREFUeJzt3Xl0VPXdx/HPTJbJnrAEIRAgNIAgNGyWQsGwLyoCKiiUEpS6ECwKAgotBfWBCC0CIhDah11FIbQpgoqoLBLUagouKCgQDBRUUMxCyGSZ+/zBk5GYAAkmmYTf+3VOznHu3LnzvfEy79yZScZmWZYlAICR7J4eAADgOUQAAAxGBADAYEQAAAxGBADAYEQAAAxGBADAYEQAAAxGBADAYEQA1d6sWbNks9mu6rY9evRQjx493JePHTsmm82m1atXV8xw/+/48ePy8/NTSkrKFdfduXOnbDabkpKSKnSG6ubuu+/W8OHDPT0GroAIABXgySefVOfOnfWb3/zGvezFF1/UwoULPTfUZezdu1fdunVTQECA6tevrwkTJig7O7tMt7XZbKV+Pf3008XWe+yxx7Rp0yZ99NFHlbELqCDenh4AqOlOnz6tNWvWaM2aNcWWv/jii/r000/1yCOPeGawS9i/f7969+6tVq1a6ZlnntGJEyf017/+VV9++aVee+21Mm2jb9++Gj16dLFl7du3L3G5U6dOmj9/vtauXVth86NiEQHgZ3r++efl7e2tQYMGVcn95eTkKCAg4KpvP336dNWqVUs7d+5USEiIJKlp06a677779MYbb6hfv35X3EaLFi00atSoK643fPhwzZw5U0uXLlVQUNBVz4zKw9NBqFb27NmjG2+8UX5+fvrFL36h5cuXl7reqlWr1KtXL9WrV08Oh0OtW7fWsmXLrvp+Dx48qDvvvFO1a9eWn5+fOnXqpM2bN5fptsnJyercuXOxB7kePXpo69at+uqrr9xPlzRt2rTY7Vwul2bPnq1GjRrJz89PvXv31uHDh4ut06NHD7Vp00apqam66aabFBAQoOnTp1/1fmZmZmr79u0aNWqUOwCSNHr0aAUFBWnDhg1l3tb58+eVm5t72XX69u2rc+fOafv27Vc9MyoXZwKoNj755BP169dP4eHhmjVrlgoKCjRz5kxdd911JdZdtmyZbrjhBt12223y9vbWK6+8ovj4eLlcLo0fP75c93vgwAH95je/UcOGDfX4448rMDBQGzZs0JAhQ7Rp0yYNHTr0krfNz8/XBx98oHHjxhVb/sc//lEZGRk6ceKEFixYIEklfhJ++umnZbfbNXnyZGVkZGjevHn67W9/q/fff7/Yet99950GDhyou+++W6NGjXJ/P7Kzs6/4ICxJPj4+Cg0NlXThe1xQUKBOnToVW8fX11ft2rXTvn37rrg9SVq9erWWLl0qy7LUqlUr/elPf9LIkSNLrNe6dWv5+/srJSXlst9HeJAFVBNDhgyx/Pz8rK+++sq97LPPPrO8vLysnx6qOTk5JW7fv39/q1mzZsWWxcbGWrGxse7LaWlpliRr1apV7mW9e/e22rZta+Xm5rqXuVwuq2vXrlbz5s0vO/Phw4ctSdbixYtLXHfLLbdYTZo0KbF8x44dliSrVatWltPpdC9ftGiRJcn65JNPis0vyUpMTCyxnbi4OEvSFb8u3v+NGzdakqzdu3eX2N6wYcOs+vXrX3Z/Lcuyunbtai1cuND617/+ZS1btsxq06aNJclaunRpqeu3aNHCGjhw4BW3C8/gTADVQmFhobZt26YhQ4aocePG7uWtWrVS//799eqrrxZb39/f3/3fGRkZys/PV2xsrLZt26aMjAz3T75X8v333+vtt9/Wk08+qaysLGVlZbmv69+/v2bOnKn//ve/atiwYam3/+677yRJtWrVKvO+Frnnnnvk6+vrvty9e3dJ0tGjR9WmTRv3cofDoXvuuafE7adOnVqm5+Uvnu38+fPubf6Un5+f+/rL+enbYO+991517NhR06dP15gxY4r9vym6/zNnzlxxu/AMIoBq4fTp0zp//ryaN29e4rqWLVuWiEBKSopmzpypd999Vzk5OcWuK08EDh8+LMuyNGPGDM2YMaPUdb799ttLRqCIdRUf0Hdx7KQfH6zPnj1bbHnDhg2LxaJI69at1bp163LdZ9EDtNPpLHFdbm5uiQfwsvD19dVDDz2kBx98UKmpqerWrVux6y3Luurf80DlIwKocY4cOaLevXvr+uuv1zPPPKPIyEj5+vrq1Vdf1YIFC+Ryucq8raJ1J0+erP79+5e6TnR09CVvX6dOHUklH7jLwsvLq9TlPw3KpR6YMzIyyvSTu6+vr2rXri1JatCggSTp1KlTJdY7deqUIiIirri90kRGRkq6cGb1U2fPni017qgeiACqhfDwcPn7++vLL78scd2hQ4eKXX7llVfkdDq1efPmYj9N79ixo9z326xZM0kXXjzt06dPuW/fuHFj+fv7Ky0trcR1lf3T78MPP1zidxNKExsbq507d0qS2rRpI29vb3344YfFfps3Ly9P+/fvv+rf8D169KikC/8fL1ZQUKDjx4/rtttuu6rtovIRAVQLXl5e6t+/v5KTk5Wenu5+cP/888+1bdu2EutKxX9izsjI0KpVq8p9v/Xq1VOPHj20fPly/eEPf3D/pFzk9OnTJR7YLubj46NOnTrpww8/LHFdYGCgMjIyyj1TWV3NawKhoaHq06ePnn/+ec2YMUPBwcGSpHXr1ik7O1vDhg1zr5uTk6P09HTVrVtXdevWlVT69yMrK0sLFy5U3bp11bFjx2LXffbZZ8rNzVXXrl2vej9RuYgAqo0nnnhCr7/+urp37674+HgVFBRo8eLFuuGGG/Txxx+71+vXr598fX01aNAgPfDAA8rOztbf//531atXr9SnOa5kyZIl6tatm9q2bav77rtPzZo10zfffKN3331XJ06cuOKfPRg8eLD++Mc/KjMzs9h77zt27KiXX35ZkyZN0o033qigoKAK/YWyq3lNQJJmz56trl27KjY2Vvfff79OnDih+fPnq1+/fhowYIB7vX//+9/q2bOnZs6cqVmzZkm68L1KTk7WoEGD1LhxY506dUorV65Uenq61q1bV+K1i+3btysgIEB9+/b9WfuKSuTR9yYBP7Fr1y6rY8eOlq+vr9WsWTMrMTHRmjlzZom3iG7evNn65S9/afn5+VlNmza15s6da61cudKSZKWlpbnXK8tbRC3Lso4cOWKNHj3aql+/vuXj42M1bNjQuvXWW62kpKQrzvzNN99Y3t7e1rp164otz87OtkaOHGmFhYVZktxvFy16i+jGjRuLrV/abLGxsdYNN9xwxRnK65133rG6du1q+fn5WeHh4db48eOtzMzMYusUzTlz5kz3sjfeeMPq27ev+/sUFhZm9evXz3rrrbdKvZ/OnTtbo0aNqvD5UXFslnUVb2sAUMzYsWP1xRdf6J133vH0KNXG/v371aFDB/3nP/9Ru3btPD0OLoEIABUgPT1dLVq00FtvvVXsL4ma7O6775bL5SrXn6JA1SMCAGAw/oAcABiMCACAwYgAABiMCACAwfhlsUtwuVw6efKkgoOD+eNXAGoUy7KUlZWliIgI2e2X/1mfCFzCyZMn3X8UCwBqouPHj6tRo0aXXYcIXELR31TpppvlLR8PTwMAZVegfO3Rq+7HscshApdQ9BSQt3zkbSMCAGqQ///tr7I8lc0LwwBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMG9PD4Ca77h1WF/pC+UpV0EKVUu1V6ittqfHwjWEY6zyGHEmMGbMGA0ZMsTTY1yTvraO6wt9rGZqrV+pj4IVpn16R3lWrqdHwzWCY6xyeTwCY8aMkc1mk81mk4+Pj6KiojR16lTl5vI/uCZI1xdqqChF2JoqyBai69VBXvLSSR3z9Gi4RnCMVa5q8XTQgAEDtGrVKuXn5ys1NVVxcXGy2WyaO3eup0fDZbgsl7L0g5rqevcym82m2tZ1+kHfeXAyXCs4xiqfx88EJMnhcKh+/fqKjIzUkCFD1KdPH23fvl2S5HK5lJCQoKioKPn7+ysmJkZJSUnu2xYWFmrs2LHu61u2bKlFixZ5aleMki+nLFnylV+x5b5yKE+cyeHn4xirfNXiTOBin376qfbu3asmTZpIkhISEvT8888rMTFRzZs31+7duzVq1CiFh4crNjZWLpdLjRo10saNG1WnTh3t3btX999/vxo0aKDhw4eX+X6dTqecTqf7cmZmZoXvGwBUN9UiAlu2bFFQUJAKCgrkdDplt9v13HPPyel0as6cOXrzzTfVpUsXSVKzZs20Z88eLV++XLGxsfLx8dETTzzh3lZUVJTeffddbdiwoVwRSEhIKLYdXJmPHLLJVuInsjw5S/zkBlwNjrHKVy0i0LNnTy1btkznzp3TggUL5O3trTvuuEMHDhxQTk6O+vbtW2z9vLw8tW/f3n15yZIlWrlypdLT03X+/Hnl5eWpXbt25Zph2rRpmjRpkvtyZmamIiMjf9Z+XevsNruCrTB9r29VTw0lSZZl6Xt9q0j9wsPT4VrAMVb5qkUEAgMDFR0dLUlauXKlYmJitGLFCrVp00aStHXrVjVs2LDYbRwOhyTppZde0uTJkzV//nx16dJFwcHB+stf/qL333+/XDM4HA73NlF2jdVCn+kDhVi1FKraSteXKlSBGqipp0fDNYJjrHJViwhczG63a/r06Zo0aZK++OILORwOpaenKzY2ttT1U1JS1LVrV8XHx7uXHTlypKrGNV59W6TyLaeO6jM5latghaq9uslh41QdFYNjrHJVuwhI0rBhwzRlyhQtX75ckydP1sSJE+VyudStWzdlZGQoJSVFISEhiouLU/PmzbV27Vpt27ZNUVFRWrdunT744ANFRUV5ejeMEWmLVqSiPT0GrmEcY5WnWkbA29tbDz30kObNm6e0tDSFh4crISFBR48eVVhYmDp06KDp06dLkh544AHt27dPd911l2w2m0aMGKH4+Hi99tprHt4LAKj+bJZlWZ4eojrKzMxUaGioemiwvG0+nh4HAMqswMrXTv1LGRkZCgkJuey61eKXxQAAnkEEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBg3mVZafPmzWXe4G233XbVwwAAqlaZIjBkyJAybcxms6mwsPDnzAMAqEJlioDL5arsOQAAHsBrAgBgsDKdCfzUuXPntGvXLqWnpysvL6/YdRMmTKiQwQAAla/cEdi3b59uvvlm5eTk6Ny5c6pdu7bOnDmjgIAA1atXjwgAQA1S7qeDJk6cqEGDBuns2bPy9/fXe++9p6+++kodO3bUX//618qYEQBQScodgf379+vRRx+V3W6Xl5eXnE6nIiMjNW/ePE2fPr0yZgQAVJJyR8DHx0d2+4Wb1atXT+np6ZKk0NBQHT9+vGKnAwBUqnK/JtC+fXt98MEHat68uWJjY/XnP/9ZZ86c0bp169SmTZvKmBEAUEnKfSYwZ84cNWjQQJI0e/Zs1apVS+PGjdPp06f1t7/9rcIHBABUnnKfCXTq1Mn93/Xq1dPrr79eoQMBAKoOvywGAAYr95lAVFSUbDbbJa8/evTozxoIAFB1yh2BRx55pNjl/Px87du3T6+//rqmTJlSUXMBAKpAuSPw8MMPl7p8yZIl+vDDD3/2QACAqlNhrwkMHDhQmzZtqqjNAQCqQIVFICkpSbVr166ozQEAqsBV/bLYxS8MW5alr7/+WqdPn9bSpUsrdDgAQOUqdwQGDx5cLAJ2u13h4eHq0aOHrr/++godrlqwe0k2L09PgWvQthOpnh4B16jMLJdqtSjbuuWOwKxZs8p7EwBANVXu1wS8vLz07bffllj+3XffycuLn5gBoCYpdwQsyyp1udPplK+v788eCABQdcr8dNCzzz4rSbLZbPrf//1fBQUFua8rLCzU7t27r83XBADgGlbmCCxYsEDShTOBxMTEYk/9+Pr6qmnTpkpMTKz4CQEAlabMEUhLS5Mk9ezZU//4xz9Uq1atShsKAFA1yv3uoB07dlTGHAAADyj3C8N33HGH5s6dW2L5vHnzNGzYsAoZCgBQNcodgd27d+vmm28usXzgwIHavXt3hQwFAKga5Y5AdnZ2qW8F9fHxUWZmZoUMBQCoGuWOQNu2bfXyyy+XWP7SSy+pdevWFTIUAKBqlPuF4RkzZuj222/XkSNH1KtXL0nSW2+9pRdffFFJSUkVPiAAoPKUOwKDBg1ScnKy5syZo6SkJPn7+ysmJkZvv/02f0oaAGqYckdAkm655RbdcsstkqTMzEytX79ekydPVmpqqgoLCyt0QABA5bnqD5XZvXu34uLiFBERofnz56tXr1567733KnI2AEAlK9eZwNdff63Vq1drxYoVyszM1PDhw+V0OpWcnMyLwgBQA5X5TGDQoEFq2bKlPv74Yy1cuFAnT57U4sWLK3M2AEAlK/OZwGuvvaYJEyZo3Lhxat68eWXOBACoImU+E9izZ4+ysrLUsWNHde7cWc8995zOnDlTmbMBACpZmSPw61//Wn//+9916tQpPfDAA3rppZcUEREhl8ul7du3KysrqzLnBABUgnK/OygwMFD33nuv9uzZo08++USPPvqonn76adWrV0+33XZbZcwIAKgkV/0WUUlq2bKl5s2bpxMnTmj9+vUVNRMAoIr8rAgU8fLy0pAhQ7R58+aK2BwAoIpUSAQAADUTEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADBYjYzA6tWrFRYW5ukxICnN9Zn+XfiGdhRu0q7CZH1UuEfnrExPj4UaYPe753Xb6JNq1C5NXg0OK/m17GLXf3O6QPc8/I0atUtTUNQRDRxxUl8ezSu2ztffFmj0Q98o4pdpCm52RJ36HtemLcW3g8vzaATGjBkjm81W4uvw4cOeHAvl8IN1Wo1szXWjvY862GPlkkv7XLtUaBV4ejRUc+dyXIpp7dDiOeElrrMsS7ffc0ppX+Xrn6sbKHV7pJo08la/4Sd1LsflXi/uD9/oiyN5Sl7TQB/taKyhNwfq7ge+1r5PnFW5KzWax88EBgwYoFOnThX7ioqK8vRYKKP2XrGKsEcpyBaqYFst3WD/lXKVo0x97+nRUM0N7B2opx6vo6E3B5W47suj+Xov1aklc8N1Yzs/tYz21dK54Tqfa2n9P7Pc6737Ya7G3xuqX7X3U7MmPvrjxNoKC7Ur9ePcqtyVGs3jEXA4HKpfv36xr0WLFqlt27YKDAxUZGSk4uPjlZ196VO806dPq1OnTho6dKicTqdcLpcSEhIUFRUlf39/xcTEKCkpqQr3ylwFypck+cjXw5OgJnPmWZIkP8ePD1F2u00Oh00p//7xAb5LJz9t2Jyt788WyuWy9FJylnJzLfXo6l/lM9dUHo9Aaex2u5599lkdOHBAa9as0dtvv62pU6eWuu7x48fVvXt3tWnTRklJSXI4HEpISNDatWuVmJioAwcOaOLEiRo1apR27dpVxXtiFsuy9IVrn0JVV0G2ME+Pgxrs+mhfNW7orelzvtPZHwqVl2dp3nNndeJkgU598+NTjS//rb7y8y2Ft06Tf5MjGjf1tDatbKDoKH4IKStvTw+wZcsWBQX9eDo4cOBAbdy40X25adOm+p//+R89+OCDWrp0abHbHjp0SH379tXQoUO1cOFC2Ww2OZ1OzZkzR2+++aa6dOkiSWrWrJn27Nmj5cuXKzY2ttQ5nE6nnM4fn0fMzOTFzfI6aKUqWxnqZO/t6VFQw/n42JS0or7ue/Rb1W2VJi8vqXf3AA3oFSDL+nG9P8/7XhmZLr2xIUJ1a3vpX6+f090PfK1dyQ3VtpXDcztQg3g8Aj179tSyZcvclwMDA/Xmm28qISFBBw8eVGZmpgoKCpSbm6ucnBwFBARIks6fP6/u3btr5MiRWrhwofv2hw8fVk5Ojvr27VvsfvLy8tS+fftLzpGQkKAnnniiYnfOIAddqTpjnVQney/52QI8PQ6uAR1j/PSfNxsrI7NQeXlSeF0vdbn5uDrG+EmSjhzL15KVGfp4Z6RuaHnhAT/mBof2vH9eS1dlaNm8ep4cv8bw+NNBgYGBio6Odn85nU7deuut+uUvf6lNmzYpNTVVS5YskXThgbyIw+FQnz59tGXLFv33v/91Ly967WDr1q3av3+/++uzzz677OsC06ZNU0ZGhvvr+PHjlbTH1xbLsnTQlarT1n/V0d5T/raSL/IBP0doiJfC63rpy6N5+vAjp27rHyhJyjl/4V1Cdput2Pp2u+RyldgMLsHjZwI/lZqaKpfLpfnz58tuv9CoDRs2lFjPbrdr3bp1GjlypHr27KmdO3cqIiJCrVu3lsPhUHp6+iWf+imNw+GQw8HpY3kdslL1tZWuGHs3eclbTuu8JMlbPvKyVbvDC9VI9jmXDqfluy8fSy/Q/k+dqh1mV+NGPtr4SrbC69jVuKGPPvncqYkzzmjwgED163HhTPP6aF9FR/lo3NRvNW9mXdWp5aV/vZ6tN3ef1+Z1YR7aq5qn2v0rjY6OVn5+vhYvXqxBgwYpJSVFiYmJpa7r5eWlF154QSNGjFCvXr20c+dO1a9fX5MnT9bEiRPlcrnUrVs3ZWRkKCUlRSEhIYqLi6viPbq2nbCOSJJSXTuKLW9t+5UibLzVF5f24Ue56n3HSfflR2edkSSNHh6sVYuu09ffFGjyrB/0zekCNajnrd8NC9afJtZ2r+/jY9OW5xto2uzvNHj0KWWfcyk6ykerFtXTzb0Dq3x/aqpqF4GYmBg988wzmjt3rqZNm6abbrpJCQkJGj16dKnre3t7a/369brrrrvcIXjqqacUHh6uhIQEHT16VGFhYerQoYOmT59exXtz7evjdZenR0AN1aNrgApPRV/y+j/8Pkx/+H3YZbfRvJmvklY0qODJzGKzrItfa0eRzMxMhYaGqof9dnnbfDw9Dq5B206kenoEXKMys1yq1eKoMjIyFBISctl1Pf7CMADAc4gAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwbw9PUB1ZVmWJKnAyvfwJLhWZWa5PD0CrlGZ2ReOraLHscshApeQlZUlSdpjvSJd+fsIlFutFp6eANe6rKwshYaGXnYdm1WWVBjI5XLp5MmTCg4Ols1m8/Q41V5mZqYiIyN1/PhxhYSEeHocXGM4vsrHsixlZWUpIiJCdvvln/XnTOAS7Ha7GjVq5OkxapyQkBD+kaLScHyV3ZXOAIrwwjAAGIwIAIDBiAAqhMPh0MyZM+VwODw9Cq5BHF+VhxeGAcBgnAkAgMGIAAAYjAjAI8aMGaMhQ4Z4egzUIKtXr1ZYWJinx7jmEAGUMGbMGNlsNtlsNvn4+CgqKkpTp05Vbm6up0fDNeDi4+vir8OHD3t6NCPxy2Io1YABA7Rq1Srl5+crNTVVcXFxstlsmjt3rqdHwzWg6Pi6WHh4uIemMRtnAiiVw+FQ/fr1FRkZqSFDhqhPnz7avn27pAt/UiMhIUFRUVHy9/dXTEyMkpKS3LctLCzU2LFj3de3bNlSixYt8tSuoBoqOr4u/lq0aJHatm2rwMBARUZGKj4+XtnZ2ZfcxunTp9WpUycNHTpUTqfzisclSseZAK7o008/1d69e9WkSRNJUkJCgp5//nklJiaqefPm2r17t0aNGqXw8HDFxsbK5XKpUaNG2rhxo+rUqaO9e/fq/vvvV4MGDTR8+HAP7w2qK7vdrmeffVZRUVE6evSo4uPjNXXqVC1durTEusePH1ffvn3161//WitWrJCXl5dmz5592eMSl2ABPxEXF2d5eXlZgYGBlsPhsCRZdrvdSkpKsnJzc62AgABr7969xW4zduxYa8SIEZfc5vjx46077rij2H0MHjy4snYB1djFx1fR15133llivY0bN1p16tRxX161apUVGhpqHTx40IqMjLQmTJhguVwuy7Ksqz4uYVmcCaBUPXv21LJly3Tu3DktWLBA3t7euuOOO3TgwAHl5OSob9++xdbPy8tT+/bt3ZeXLFmilStXKj09XefPn1deXp7atWtXxXuB6qro+CoSGBioN998UwkJCTp48KAyMzNVUFCg3Nxc5eTkKCAgQJJ0/vx5de/eXSNHjtTChQvdtz98+HCZjkuURARQqsDAQEVHR0uSVq5cqZiYGK1YsUJt2rSRJG3dulUNGzYsdpuiX+l/6aWXNHnyZM2fP19dunRRcHCw/vKXv+j999+v2p1AtXXx8SVJx44d06233qpx48Zp9uzZql27tvbs2aOxY8cqLy/PHQGHw6E+ffpoy5YtmjJlivsYLHrt4HLHJUpHBHBFdrtd06dP16RJk/TFF1/I4XAoPT39ks+zpqSkqGvXroqPj3cvO3LkSFWNixooNTVVLpdL8+fPd//9+w0bNpRYz263a926dRo5cqR69uypnTt3KiIiQq1bt77icYnSEQGUybBhwzRlyhQtX75ckydP1sSJE+VyudStWzdlZGQoJSVFISEhiouLU/PmzbV27Vpt27ZNUVFRWrdunT744ANFRUV5ejdQTUVHRys/P1+LFy/WoEGDlJKSosTExFLX9fLy0gsvvKARI0aoV69e2rlzp+rXr3/F4xKlIwIoE29vbz300EOaN2+e0tLSFB4eroSEBB09elRhYWHq0KGDpk+fLkl64IEHtG/fPt11112y2WwaMWKE4uPj9dprr3l4L1BdxcTE6JlnntHcuXM1bdo03XTTTUpISNDo0aNLXd/b21vr16/XXXfd5Q7BU089ddnjEqXjr4gCgMH4ZTEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQGgCvz0M5V79OihRx55pMrn2Llzp2w2m3744Ycqv29UT0QARrv48259fX0VHR2tJ598UgUFBZV6v//4xz/01FNPlWldHrhRmfjbQTBe0efdOp1Ovfrqqxo/frx8fHw0bdq0Yuvl5eXJ19e3Qu6zdu3aFbId4OfiTADGK/q82yZNmmjcuHHq06ePNm/e7H4KZ/bs2YqIiFDLli0lXfhow+HDhyssLEy1a9fW4MGDdezYMff2CgsLNWnSJIWFhalOnTqaOnWqfvonun76dJDT6dRjjz2myMhIORwORUdHa8WKFTp27Jh69uwpSapVq5ZsNpvGjBkj6cqf9SxJr776qlq0aCF/f3/17Nmz2JyARASAEvz9/ZWXlydJeuutt3To0CFt375dW7ZsUX5+vvr376/g4GC98847SklJUVBQkAYMGOC+zfz587V69WqtXLlSe/bs0ffff69//vOfl73P0aNHa/369Xr22Wf1+eefa/ny5QoKClJkZKQ2bdokSTp06JBOnTqlRYsWSbrwWc9r165VYmKiDhw4oIkTJ2rUqFHatWuXpAuxuv322zVo0CDt379fv//97/X4449X1rcNNZWHP94S8KiLP+vY5XJZ27dvtxwOhzV58mQrLi7Ouu666yyn0+lef926dVbLli3dn21rWZbldDotf39/a9u2bZZlWVaDBg2sefPmua/Pz8+3GjVqVOwzlWNjY62HH37YsizLOnTokCXJ2r59e6kz7tixw5JknT171r2sLJ+pO23aNKt169bFrn/sscdKbAtm4zUBGG/Lli0KCgpSfn6+XC6XRo4cqVmzZmn8+PFq27ZtsdcBPvroIx0+fFjBwcHFtpGbm6sjR44oIyNDp06dUufOnd3XeXt7q1OnTiWeEiqyf/9+eXl5lesTscrymbqff/55sTkkqUuXLmW+D5iBCMB4RR967uvrq4iICHl7//jPIjAwsNi62dnZ6tixo1544YUS2wkPD7+q+/f39y/3bfhMXVQUIgDj/fRDzy+nQ4cOevnll1WvXj2FhISUuk6DBg30/vvv66abbpIkFRQUKDU1VR06dCh1/bZt28rlcmnXrl3q06dPieuLzkQKCwvdy8rymbqtWrXS5s2biy177733rryTMAovDAPl8Nvf/lZ169bV4MGD9c477ygtLU07d+7UhAkTdOLECUnSww8/rKefflrJyck6ePCg4uPjL/se/6ZNmyouLk733nuvkpOT3dss+qD1Jk2ayGazacuWLTp9+rSys7MVHBzs/kzdNWvW6MiRI/rPf/6jxYsXa82aNZKkBx98UF9++aWmTJmiQ4cO6cUXX9Tq1asr+1uEGoYIAOUQEBCg3bt3q3Hjxrr99tvVqlUrjR07Vrm5ue4zg0cffVS/+93vFBcXpy5duig4OFhDhw697HaXLVumO++8U/Hx8br++ut133336dy5c5Kkhg0b6oknntDjjz+u6667Tg899JAk6amnntKMGTOUkJCgVq1aacCAAdq6dauioqIkSY0bN9amTZuUnJysmJgYJSYmas6cOZX43UFNxGcMA4DBOBMAAIMRAQAwGBEAAIMRAQAwGBEAAIMRAQAwGBEAAIMRAQAwGBEAAIMRAQAwGBEAAIMRAQAw2P8B91desmC/e2MAAAAASUVORK5CYII=\n"
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAGGCAYAAACdXD2cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJ11JREFUeJzt3Xl4VPXdv/H3TJbJnhAIAiFAKIsgNGz9USgYwo6KgAoKUoJSF4JFQUCh5QG1EKFFQBRC+7CrKISWIogUlYAEtYrggoKsBgoqKGYhZLLM+f3BkykxARJMMkm+9+u6cl3OmTNnPhOOc8+ZJWOzLMsSAMBIdk8PAADwHCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCKAKm/mzJmy2WzXddkePXqoR48e7tMnTpyQzWbTypUry2e4/3Py5En5+fkpNTX1muumpKTIZrMpOTm5XGeoau655x4NGzbM02PgGogAUA6efvppde7cWb/5zW/cy1555RUtWLDAc0NdxZ49e9StWzcFBASoXr16Gj9+vLKyskp1WZvNVuLPs88+W2S9J554Qhs2bNAnn3xSETcB5cTb0wMA1d3Zs2e1atUqrVq1qsjyV155RZ9//rkee+wxzwx2Bfv371evXr3UqlUrPffcczp16pT+8pe/6PDhw9q6dWupttGnTx+NGjWqyLL27dsXO92pUyfNmzdPq1evLrf5Ub6IAPAzvfTSS/L29tbAgQMr5fqys7MVEBBw3ZefNm2aatWqpZSUFIWEhEiSmjRpogceeED/+te/1Ldv32tuo0WLFho5cuQ11xs2bJhmzJihxYsXKygo6LpnRsXh6SBUKbt379avfvUr+fn56Re/+IWWLl1a4norVqxQz549VbduXTkcDrVu3VpLliy57us9ePCg7rrrLoWHh8vPz0+dOnXSpk2bSnXZjRs3qnPnzkXu5Hr06KEtW7bo66+/dj9d0qRJkyKXc7lcmjVrlho2bCg/Pz/16tVLR44cKbJOjx491KZNG+3du1c333yzAgICNG3atOu+nRkZGdq+fbtGjhzpDoAkjRo1SkFBQVq3bl2pt3Xx4kXl5ORcdZ0+ffrowoUL2r59+3XPjIrFkQCqjM8++0x9+/ZVRESEZs6cqfz8fM2YMUM33HBDsXWXLFmim266Sbfffru8vb31+uuvKyEhQS6XS+PGjSvT9R44cEC/+c1vFBkZqSeffFKBgYFat26dBg8erA0bNmjIkCFXvGxeXp4+/PBDjR07tsjyP/zhD0pPT9epU6c0f/58SSr2SPjZZ5+V3W7XpEmTlJ6errlz5+ree+/VBx98UGS977//XgMGDNA999yjkSNHun8fWVlZ17wTliQfHx+FhoZKuvQ7zs/PV6dOnYqs4+vrq3bt2mnfvn3X3J4krVy5UosXL5ZlWWrVqpX++Mc/asSIEcXWa926tfz9/ZWamnrV3yM8yAKqiMGDB1t+fn7W119/7V72xRdfWF5eXtZPd9Xs7Oxil+/Xr5/VtGnTIstiY2Ot2NhY9+njx49bkqwVK1a4l/Xq1ctq27atlZOT417mcrmsrl27Ws2bN7/qzEeOHLEkWYsWLSp23q233mo1bty42PIdO3ZYkqxWrVpZTqfTvXzhwoWWJOuzzz4rMr8kKykpqdh24uPjLUnX/Ln89q9fv96SZO3atavY9oYOHWrVq1fvqrfXsiyra9eu1oIFC6x//vOf1pIlS6w2bdpYkqzFixeXuH6LFi2sAQMGXHO78AyOBFAlFBQUaNu2bRo8eLAaNWrkXt6qVSv169dPb7zxRpH1/f393f+dnp6uvLw8xcbGatu2bUpPT3c/8r2WH374Qe+8846efvppZWZmKjMz031ev379NGPGDP3nP/9RZGRkiZf//vvvJUm1atUq9W0tdN9998nX19d9unv37pKkY8eOqU2bNu7lDodD9913X7HLT5kypVTPy18+28WLF93b/Ck/Pz/3+Vfz07fB3n///erYsaOmTZum0aNHF/m3Kbz+c+fOXXO78AwigCrh7Nmzunjxopo3b17svJYtWxaLQGpqqmbMmKH33ntP2dnZRc4rSwSOHDkiy7I0ffp0TZ8+vcR1vvvuuytGoJB1HV/Qd3nspP/eWZ8/f77I8sjIyCKxKNS6dWu1bt26TNdZeAftdDqLnZeTk1PsDrw0fH199cgjj+jhhx/W3r171a1btyLnW5Z13Z/zQMUjAqh2jh49ql69eunGG2/Uc889p6ioKPn6+uqNN97Q/Pnz5XK5Sr2twnUnTZqkfv36lbhOs2bNrnj52rVrSyp+x10aXl5eJS7/aVCudMecnp5eqkfuvr6+Cg8PlyTVr19fknTmzJli6505c0YNGjS45vZKEhUVJenSkdVPnT9/vsS4o2ogAqgSIiIi5O/vr8OHDxc779ChQ0VOv/7663I6ndq0aVORR9M7duwo8/U2bdpU0qUXT3v37l3myzdq1Ej+/v46fvx4sfMq+tHvo48+WuyzCSWJjY1VSkqKJKlNmzby9vbWRx99VOTTvLm5udq/f/91f8L32LFjki79O14uPz9fJ0+e1O23335d20XFIwKoEry8vNSvXz9t3LhRaWlp7jv3L7/8Utu2bSu2rlT0EXN6erpWrFhR5uutW7euevTooaVLl+r3v/+9+5FyobNnzxa7Y7ucj4+POnXqpI8++qjYeYGBgUpPTy/zTKV1Pa8JhIaGqnfv3nrppZc0ffp0BQcHS5LWrFmjrKwsDR061L1udna20tLSVKdOHdWpU0dSyb+PzMxMLViwQHXq1FHHjh2LnPfFF18oJydHXbt2ve7biYpFBFBlPPXUU3rzzTfVvXt3JSQkKD8/X4sWLdJNN92kTz/91L1e37595evrq4EDB+qhhx5SVlaW/va3v6lu3bolPs1xLS+++KK6deumtm3b6oEHHlDTpk317bff6r333tOpU6eu+WcPBg0apD/84Q/KyMgo8t77jh076rXXXtPEiRP1q1/9SkFBQeX6gbLreU1AkmbNmqWuXbsqNjZWDz74oE6dOqV58+apb9++6t+/v3u9f//734qLi9OMGTM0c+ZMSZd+Vxs3btTAgQPVqFEjnTlzRsuXL1daWprWrFlT7LWL7du3KyAgQH369PlZtxUVyKPvTQJ+YufOnVbHjh0tX19fq2nTplZSUpI1Y8aMYm8R3bRpk/XLX/7S8vPzs5o0aWLNmTPHWr58uSXJOn78uHu90rxF1LIs6+jRo9aoUaOsevXqWT4+PlZkZKR12223WcnJydec+dtvv7W8vb2tNWvWFFmelZVljRgxwgoLC7Mkud8uWvgW0fXr1xdZv6TZYmNjrZtuuumaM5TVu+++a3Xt2tXy8/OzIiIirHHjxlkZGRlF1imcc8aMGe5l//rXv6w+ffq4f09hYWFW3759rbfffrvE6+ncubM1cuTIcp8f5cdmWdfxtgYARYwZM0ZfffWV3n33XU+PUmXs379fHTp00Mcff6x27dp5ehxcAREAykFaWppatGiht99+u8hfEjXZPffcI5fLVaY/RYHKRwQAwGD8ATkAMBgRAACDEQEAMBgRAACD8WGxK3C5XDp9+rSCg4P541cAqhXLspSZmakGDRrIbr/6Y30icAWnT592/1EsAKiOTp48qYYNG151HSJwBYV/U6WbbpG3fDw8DQCUXr7ytFtvuO/HroYIXEHhU0De8pG3jQgAqEb+79NfpXkqmxeGAcBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBg3p4eANXfSeuIvtZXylWOghSqlmqvUFu4p8dCDcI+VnGMOBIYPXq0Bg8e7OkxaqRvrJP6Sp+qqVrr/6m3ghWmfXpXuVaOp0dDDcE+VrE8HoHRo0fLZrPJZrPJx8dH0dHRmjJlinJy+AeuDtL0lSIVrQa2JgqyhehGdZCXvHRaJzw9GmoI9rGKVSWeDurfv79WrFihvLw87d27V/Hx8bLZbJozZ46nR8NVuCyXMvWjmuhG9zKbzaZw6wb9qO89OBlqCvaxiufxIwFJcjgcqlevnqKiojR48GD17t1b27dvlyS5XC4lJiYqOjpa/v7+iomJUXJysvuyBQUFGjNmjPv8li1bauHChZ66KUbJk1OWLPnKr8hyXzmUK47k8POxj1W8KnEkcLnPP/9ce/bsUePGjSVJiYmJeumll5SUlKTmzZtr165dGjlypCIiIhQbGyuXy6WGDRtq/fr1ql27tvbs2aMHH3xQ9evX17Bhw0p9vU6nU06n0306IyOj3G8bAFQ1VSICmzdvVlBQkPLz8+V0OmW32/XCCy/I6XRq9uzZeuutt9SlSxdJUtOmTbV7924tXbpUsbGx8vHx0VNPPeXeVnR0tN577z2tW7euTBFITEwssh1cm48csslW7BFZrpzFHrkB14N9rOJViQjExcVpyZIlunDhgubPny9vb2/deeedOnDggLKzs9WnT58i6+fm5qp9+/bu0y+++KKWL1+utLQ0Xbx4Ubm5uWrXrl2ZZpg6daomTpzoPp2RkaGoqKifdbtqOrvNrmArTD/oO9VVpCTJsiz9oO8UpV94eDrUBOxjFa9KRCAwMFDNmjWTJC1fvlwxMTFatmyZ2rRpI0nasmWLIiMji1zG4XBIkl599VVNmjRJ8+bNU5cuXRQcHKw///nP+uCDD8o0g8PhcG8TpddILfSFPlSIVUuhCleaDqtA+aqvJp4eDTUE+1jFqhIRuJzdbte0adM0ceJEffXVV3I4HEpLS1NsbGyJ66empqpr165KSEhwLzt69GhljWu8erYo5VlOHdMXcipHwQpVe3WTw8ahOsoH+1jFqnIRkKShQ4dq8uTJWrp0qSZNmqQJEybI5XKpW7duSk9PV2pqqkJCQhQfH6/mzZtr9erV2rZtm6Kjo7VmzRp9+OGHio6O9vTNMEaUrZmi1MzTY6AGYx+rOFUyAt7e3nrkkUc0d+5cHT9+XBEREUpMTNSxY8cUFhamDh06aNq0aZKkhx56SPv27dPdd98tm82m4cOHKyEhQVu3bvXwrQCAqs9mWZbl6SGqooyMDIWGhqqHBsnb5uPpcQCg1PKtPKXon0pPT1dISMhV160SHxYDAHgGEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAg3mXZqVNmzaVeoO33377dQ8DAKhcpYrA4MGDS7Uxm82mgoKCnzMPAKASlSoCLperoucAAHgArwkAgMFKdSTwUxcuXNDOnTuVlpam3NzcIueNHz++XAYDAFS8Mkdg3759uuWWW5Sdna0LFy4oPDxc586dU0BAgOrWrUsEAKAaKfPTQRMmTNDAgQN1/vx5+fv76/3339fXX3+tjh076i9/+UtFzAgAqCBljsD+/fv1+OOPy263y8vLS06nU1FRUZo7d66mTZtWETMCACpImSPg4+Mju/3SxerWrau0tDRJUmhoqE6ePFm+0wEAKlSZXxNo3769PvzwQzVv3lyxsbH6n//5H507d05r1qxRmzZtKmJGAEAFKfORwOzZs1W/fn1J0qxZs1SrVi2NHTtWZ8+e1V//+tdyHxAAUHHKfCTQqVMn93/XrVtXb775ZrkOBACoPHxYDAAMVuYjgejoaNlstiuef+zYsZ81EACg8pQ5Ao899liR03l5edq3b5/efPNNTZ48ubzmAgBUgjJH4NFHHy1x+YsvvqiPPvroZw8EAKg85faawIABA7Rhw4by2hwAoBKUWwSSk5MVHh5eXpsDAFSC6/qw2OUvDFuWpW+++UZnz57V4sWLy3U4AEDFKnMEBg0aVCQCdrtdERER6tGjh2688cZyHa4qsAf4y27z9fQYqIG2Htnj6RFQQ2VkulSrRenWLXMEZs6cWdaLAACqqDK/JuDl5aXvvvuu2PLvv/9eXl5e5TIUAKBylDkClmWVuNzpdMrXl6dNAKA6KfXTQc8//7wkyWaz6X//938VFBTkPq+goEC7du2qka8JAEBNVuoIzJ8/X9KlI4GkpKQiT/34+vqqSZMmSkpKKv8JAQAVptQROH78uCQpLi5Of//731WrVq0KGwoAUDnK/O6gHTt2VMQcAAAPKPMLw3feeafmzJlTbPncuXM1dOjQchkKAFA5yhyBXbt26ZZbbim2fMCAAdq1a1e5DAUAqBxljkBWVlaJbwX18fFRRkZGuQwFAKgcZY5A27Zt9dprrxVb/uqrr6p169blMhQAoHKU+YXh6dOn64477tDRo0fVs2dPSdLbb7+tV155RcnJyeU+IACg4pQ5AgMHDtTGjRs1e/ZsJScny9/fXzExMXrnnXf4U9IAUM2UOQKSdOutt+rWW2+VJGVkZGjt2rWaNGmS9u7dq4KCgnIdEABQca77S2V27dql+Ph4NWjQQPPmzVPPnj31/vvvl+dsAIAKVqYjgW+++UYrV67UsmXLlJGRoWHDhsnpdGrjxo28KAwA1VCpjwQGDhyoli1b6tNPP9WCBQt0+vRpLVq0qCJnAwBUsFIfCWzdulXjx4/X2LFj1bx584qcCQBQSUp9JLB7925lZmaqY8eO6ty5s1544QWdO3euImcDAFSwUkfg17/+tf72t7/pzJkzeuihh/Tqq6+qQYMGcrlc2r59uzIzMytyTgBABSjzu4MCAwN1//33a/fu3frss8/0+OOP69lnn1XdunV1++23V8SMAIAKct1vEZWkli1bau7cuTp16pTWrl1bXjMBACrJz4pAIS8vLw0ePFibNm0qj80BACpJuUQAAFA9EQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDVcsIrFy5UmFhYZ4eA5JyXNn6LOdd7bjwqt668LL2ZG9SesE5T4+FamDXexd1+6jTatjuuLzqH9HGrVlFzv/2bL7ue/RbNWx3XEHRRzVg+GkdPpZb4rYsy9ItI06XuB1cnUcjMHr0aNlstmI/R44c8eRYKKU8y6l/52yVzWZXB7/e6up/u1r4dpKPzeHp0VANXMh2Kaa1Q4tmRxQ7z7Is3XHfGR3/Ok//WFlfe7dHqXFDb/UddloXsl3F1l/413TZbJUxdc3j7ekB+vfvrxUrVhRZFhFRfKdA1XM873P52QLVxvEb97IAe7AHJ0J1MqBXoAb0CizxvMPH8vT+Xqc+TYnSTS0vPahYPCdCDX55Qmv/kanf3RvqXnf/5049t/S8/v1mlCJjTlTG6DWKx58OcjgcqlevXpGfhQsXqm3btgoMDFRUVJQSEhKUlXXlQ7yzZ8+qU6dOGjJkiJxOp1wulxITExUdHS1/f3/FxMQoOTm5Em+VGc7mn1KIvbY+ydmpHRfW6b2Lr+tU3leeHgs1gDPXkiT5Of57F2W32+Rw2JT67xz3suxsl0YmfKNFsyNUr67HH9NWSx6PQEnsdruef/55HThwQKtWrdI777yjKVOmlLjuyZMn1b17d7Vp00bJyclyOBxKTEzU6tWrlZSUpAMHDmjChAkaOXKkdu7cWcm3pGa7aGXqVP4hBdiD1dGvl6K8W+pg7of6T95RT4+Gau7GZr5qFOmtabO/1/kfC5Sba2nuC+d16nS+znyb715v4oxz6vIrfw3qH+TBaas3j6dz8+bNCgr67z/ggAEDtH79evfpJk2a6E9/+pMefvhhLV68uMhlDx06pD59+mjIkCFasGCBbDabnE6nZs+erbfeektdunSRJDVt2lS7d+/W0qVLFRsbW+IcTqdTTqfTfTojI6M8b2aNZEkKsddWc98OkqQQr9rKcv2oU/mHFOnzC88Oh2rNx8em5GX19MDj36lOq+Py8pJ6dQ9Q/54Bsi4dJGjTtgvakXpRe7dHeXbYas7jEYiLi9OSJUvcpwMDA/XWW28pMTFRBw8eVEZGhvLz85WTk6Ps7GwFBARIki5evKju3btrxIgRWrBggfvyR44cUXZ2tvr06VPkenJzc9W+ffsrzpGYmKinnnqqfG9cDeew+SvIHlpkWaA9VN8WfO2hiVCTdIzx08dvNVJ6RoFyc6WIOl7qcstJdYzxkyTt2J2toyfyFN7yWJHLDf3dN+re2U/v/L2hJ8audjwegcDAQDVr1sx9+sSJE7rttts0duxYzZo1S+Hh4dq9e7fGjBmj3NxcdwQcDod69+6tzZs3a/LkyYqMjJQk92sHW7ZscS8r5HBc+V0rU6dO1cSJE92nMzIyFBXFI4yrCbNH6IKr6BHTBVeG/GwcmqP8hIZ4SZIOH8vVR5849dSU2pKkJ35fS2PuDSmybkzcST33VB3d1rfkF5xRnMcj8FN79+6Vy+XSvHnzZLdfesli3bp1xdaz2+1as2aNRowYobi4OKWkpKhBgwZq3bq1HA6H0tLSrvjUT0kcDsdVI4HiGvu01r9ztupY7meq591Y6a5zOpV/WDc5fu3p0VANZF1w6cjxPPfpE2n52v+5U+FhdjVq6KP1r2cporZdjSJ99NmXTk2Yfk6D+geqb49LDwTr1fUu8cXgqEhvRTfyqbTbUd1VuQg0a9ZMeXl5WrRokQYOHKjU1FQlJSWVuK6Xl5defvllDR8+XD179lRKSorq1aunSZMmacKECXK5XOrWrZvS09OVmpqqkJAQxcfHV/ItqrlCveqonSNOh3M/1rG8T+RvC9aNvp1U37upp0dDNfDRJznqdedp9+nHZ176kOGoYcFasfAGffNtvibN/FHfns1X/bre+u3QYP1xQrinxq2xqlwEYmJi9Nxzz2nOnDmaOnWqbr75ZiUmJmrUqFElru/t7a21a9fq7rvvdofgmWeeUUREhBITE3Xs2DGFhYWpQ4cOmjZtWiXfmpovwruhIrx57hVl16NrgArONLvi+b//XZh+/7uwMm3zattDyWyWVfhaOy6XkZGh0NBQ9Qy4R942X0+Pgxpo65E9nh4BNVRGpku1WhxTenq6QkJCrrpulfycAACgchABADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAg3l7eoCqyrIsSVK+lefhSVBTZWS6PD0CaqiMrEv7VuH92NUQgSvIzMyUJO26uMHDk6CmqtXC0xOgpsvMzFRoaOhV17FZpUmFgVwul06fPq3g4GDZbDZPj1PlZWRkKCoqSidPnlRISIinx0ENw/5VNpZlKTMzUw0aNJDdfvVn/TkSuAK73a6GDRt6eoxqJyQkhP9JUWHYv0rvWkcAhXhhGAAMRgQAwGBEAOXC4XBoxowZcjgcnh4FNRD7V8XhhWEAMBhHAgBgMCIAAAYjAvCI0aNHa/DgwZ4eA9XIypUrFRYW5ukxahwigGJGjx4tm80mm80mHx8fRUdHa8qUKcrJyfH0aKgBLt+/Lv85cuSIp0czEh8WQ4n69++vFStWKC8vT3v37lV8fLxsNpvmzJnj6dFQAxTuX5eLiIjw0DRm40gAJXI4HKpXr56ioqI0ePBg9e7dW9u3b5d06U9qJCYmKjo6Wv7+/oqJiVFycrL7sgUFBRozZoz7/JYtW2rhwoWeuimoggr3r8t/Fi5cqLZt2yowMFBRUVFKSEhQVlbWFbdx9uxZderUSUOGDJHT6bzmfomScSSAa/r888+1Z88eNW7cWJKUmJiol156SUlJSWrevLl27dqlkSNHKiIiQrGxsXK5XGrYsKHWr1+v2rVra8+ePXrwwQdVv359DRs2zMO3BlWV3W7X888/r+joaB07dkwJCQmaMmWKFi9eXGzdkydPqk+fPvr1r3+tZcuWycvLS7NmzbrqfokrsICfiI+Pt7y8vKzAwEDL4XBYkiy73W4lJydbOTk5VkBAgLVnz54ilxkzZow1fPjwK25z3Lhx1p133lnkOgYNGlRRNwFV2OX7V+HPXXfdVWy99evXW7Vr13afXrFihRUaGmodPHjQioqKssaPH2+5XC7Lsqzr3i9hWRwJoERxcXFasmSJLly4oPnz58vb21t33nmnDhw4oOzsbPXp06fI+rm5uWrfvr379Isvvqjly5crLS1NFy9eVG5urtq1a1fJtwJVVeH+VSgwMFBvvfWWEhMTdfDgQWVkZCg/P185OTnKzs5WQECAJOnixYvq3r27RowYoQULFrgvf+TIkVLtlyiOCKBEgYGBatasmSRp+fLliomJ0bJly9SmTRtJ0pYtWxQZGVnkMoUf6X/11Vc1adIkzZs3T126dFFwcLD+/Oc/64MPPqjcG4Eq6/L9S5JOnDih2267TWPHjtWsWbMUHh6u3bt3a8yYMcrNzXVHwOFwqHfv3tq8ebMmT57s3gcLXzu42n6JkhEBXJPdbte0adM0ceJEffXVV3I4HEpLS7vi86ypqanq2rWrEhIS3MuOHj1aWeOiGtq7d69cLpfmzZvn/vv369atK7ae3W7XmjVrNGLECMXFxSklJUUNGjRQ69atr7lfomREAKUydOhQTZ48WUuXLtWkSZM0YcIEuVwudevWTenp6UpNTVVISIji4+PVvHlzrV69Wtu2bVN0dLTWrFmjDz/8UNHR0Z6+GaiimjVrpry8PC1atEgDBw5UamqqkpKSSlzXy8tLL7/8soYPH66ePXsqJSVF9erVu+Z+iZIRAZSKt7e3HnnkEc2dO1fHjx9XRESEEhMTdezYMYWFhalDhw6aNm2aJOmhhx7Svn37dPfdd8tms2n48OFKSEjQ1q1bPXwrUFXFxMToueee05w5czR16lTdfPPNSkxM1KhRo0pc39vbW2vXrtXdd9/tDsEzzzxz1f0SJeOviAKAwfiwGAAYjAgAgMGIAAAYjAgAgMGIAAAYjAgAgMGIAAAYjAgAgMGIAFAJfvqdyj169NBjjz1W6XOkpKTIZrPpxx9/rPTrRtVEBGC0y7/v1tfXV82aNdPTTz+t/Pz8Cr3ev//973rmmWdKtS533KhI/O0gGK/w+26dTqfeeOMNjRs3Tj4+Ppo6dWqR9XJzc+Xr61su1xkeHl4u2wF+Lo4EYLzC77tt3Lixxo4dq969e2vTpk3up3BmzZqlBg0aqGXLlpIufbXhsGHDFBYWpvDwcA0aNEgnTpxwb6+goEATJ05UWFiYateurSlTpuinf6Lrp08HOZ1OPfHEE4qKipLD4VCzZs20bNkynThxQnFxcZKkWrVqyWazafTo0ZKu/V3PkvTGG2+oRYsW8vf3V1xcXJE5AYkIAMX4+/srNzdXkvT222/r0KFD2r59uzZv3qy8vDz169dPwcHBevfdd5WamqqgoCD179/ffZl58+Zp5cqVWr58uXbv3q0ffvhB//jHP656naNGjdLatWv1/PPP68svv9TSpUsVFBSkqKgobdiwQZJ06NAhnTlzRgsXLpR06bueV69eraSkJB04cEATJkzQyJEjtXPnTkmXYnXHHXdo4MCB2r9/v373u9/pySefrKhfG6orD3+9JeBRl3/XscvlsrZv3245HA5r0qRJVnx8vHXDDTdYTqfTvf6aNWusli1bur/b1rIsy+l0Wv7+/ta2bdssy7Ks+vXrW3PnznWfn5eXZzVs2LDIdyrHxsZajz76qGVZlnXo0CFLkrV9+/YSZ9yxY4clyTp//rx7WWm+U3fq1KlW69ati5z/xBNPFNsWzMZrAjDe5s2bFRQUpLy8PLlcLo0YMUIzZ87UuHHj1LZt2yKvA3zyySc6cuSIgoODi2wjJydHR48eVXp6us6cOaPOnTu7z/P29lanTp2KPSVUaP/+/fLy8irTN2KV5jt1v/zyyyJzSFKXLl1KfR0wAxGA8Qq/9NzX11cNGjSQt/d//7cIDAwssm5WVpY6duyol19+udh2IiIiruv6/f39y3wZvlMX5YUIwHg//dLzq+nQoYNee+011a1bVyEhISWuU79+fX3wwQe6+eabJUn5+fnau3evOnToUOL6bdu2lcvl0s6dO9W7d+9i5xceiRQUFLiXleY7dVu1aqVNmzYVWfb+++9f+0bCKLwwDJTBvffeqzp16mjQoEF69913dfz4caWkpGj8+PE6deqUJOnRRx/Vs88+q40bN+rgwYNKSEi46nv8mzRpovj4eN1///3auHGje5uFX7TeuHFj2Ww2bd68WWfPnlVWVpaCg4Pd36m7atUqHT16VB9//LEWLVqkVatWSZIefvhhHT58WJMnT9ahQ4f0yiuvaOXKlRX9K0I1QwSAMggICNCuXbvUqFEj3XHHHWrVqpXGjBmjnJwc95HB448/rt/+9reKj49Xly5dFBwcrCFDhlx1u0uWLNFdd92lhIQE3XjjjXrggQd04cIFSVJkZKSeeuopPfnkk7rhhhv0yCOPSJKeeeYZTZ8+XYmJiWrVqpX69++vLVu2KDo6WpLUqFEjbdiwQRs3blRMTIySkpI0e/bsCvztoDriO4YBwGAcCQCAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABjs/wNHxRByBFovdQAAAABJRU5ErkJggg==\n"
           },
           "metadata": {}
         },
@@ -1871,16 +2100,16 @@
           "text": [
             "Saved predictions CSV: artifacts/manual_gen/dalle/predictions.csv\n",
             "Saved confusion matrix PNG: artifacts/manual_gen/dalle/confusion_matrix.png\n",
-            "Backed up to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/artifacts/manual_gen/dalle\n",
+            "Backed up to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/artifacts/manual_gen/dalle\n",
             "\n",
             "[bing] n=54 batch_size=64 num_workers=2\n",
             "Confusion matrix (rows=actual, cols=pred):\n",
             "            pred_real  pred_fake\n",
             "actual_real          0         0\n",
-            "actual_fake          0        54\n",
-            "(tn=0, fp=0, fn=0, tp=54)\n",
-            "Accuracy: 1.0000\n",
-            "Recall on fake (sensitivity): 1.0\n",
+            "actual_fake          2        52\n",
+            "(tn=0, fp=0, fn=2, tp=52)\n",
+            "Accuracy: 0.9630\n",
+            "Recall on fake (sensitivity): 0.9629629629629629\n",
             "Specificity: n/a\n",
             "\n",
             "Classification Report:\n",
@@ -1888,11 +2117,11 @@
             "              precision    recall  f1-score   support\n",
             "\n",
             "        real       0.00      0.00      0.00         0\n",
-            "        fake       1.00      1.00      1.00        54\n",
+            "        fake       1.00      0.96      0.98        54\n",
             "\n",
-            "    accuracy                           1.00        54\n",
-            "   macro avg       0.50      0.50      0.50        54\n",
-            "weighted avg       1.00      1.00      1.00        54\n",
+            "    accuracy                           0.96        54\n",
+            "   macro avg       0.50      0.48      0.49        54\n",
+            "weighted avg       1.00      0.96      0.98        54\n",
             "\n"
           ]
         },
@@ -1902,7 +2131,7 @@
             "text/plain": [
               "<Figure size 500x400 with 1 Axes>"
             ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAGGCAYAAACdXD2cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJbxJREFUeJzt3Xt8jHfe//H35DRyJsQhBOlGlR9NHXYt1UZaWrpVh5ZWWLG121YopaGld29sS7B1LqL3OmtVadd6UNVom6rYdq2lu7SlcQo37qKaCDI5zPX7w21u04QkJJnI9/V8PPJ4dK655prPxNV55ZprkrFZlmUJAGAkL08PAADwHCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCKAKmfSpEmy2Ww6e/Zsies2bdpUQ4YMqfihruP48eOqUaOG0tPTS1w3LS1NNptN69evr4TJPOepp55S//79PT0GSokIALfgj3/8ozp06KB7773Xteydd97RnDlzPDfUDezcuVOdO3dWQECA6tevr5EjRyonJ6dUt7XZbMV+TZs2zW29l156Se+//76+/vrringIKGc+nh4AuBUHDhyQl5dnfpY5c+aMVqxYoRUrVrgtf+edd7Rv3z698MILHpnrevbu3asHH3xQLVq00KxZs3TixAm98cYb+v7777Vly5ZSbaNbt24aPHiw27I2bdoUudy+fXvNnDlTK1euLLf5UTGIAG5rdrvdY/e9evVq+fj4qGfPnpVyf5cuXVJAQMBN337ChAmqVauW0tLSFBISIunKy2l/+MMf9PHHH+uhhx4qcRt33nmnBg0aVOJ6/fv318SJE7Vw4UIFBQXd9MyoeLwchCrr7Nmz6t+/v0JCQlS7dm2NGjVKubm5buv8/JzA8uXLZbPZlJ6erjFjxig8PFyBgYHq06ePzpw543Zbp9OpSZMmKSIiQgEBAYqLi9M333xT6vMMGzZsUIcOHdye5Lp06aLNmzfr2LFjrpdLmjZtWuR+p0yZokaNGqlGjRp68MEHlZGR4bZOly5d1KpVK+3evVv333+/AgICNGHChNJ944qRnZ2t1NRUDRo0yBUASRo8eLCCgoL03nvvlXpbly9fLvLv8HPdunXTxYsXlZqaetMzo3JwJIAqq3///mratKmSk5P15Zdfat68eTp//nypXmJ4/vnnVatWLU2cOFFHjx7VnDlzNGLECK1du9a1zvjx4zVjxgz17NlTDz/8sL7++ms9/PDDJT7BSVJ+fr527dqlYcOGuS1/5ZVXlJWVpRMnTmj27NmSVOQn4WnTpsnLy0tJSUnKysrSjBkzNHDgQH311Vdu6507d049evTQU089pUGDBqlevXqSpJycnFLN6Ovrq9DQUEnSv//9bxUUFKh9+/Zu6/j5+emee+7Rnj17StyedCWyCxculGVZatGihf7jP/5D8fHxRdZr2bKl/P39lZ6erj59+pRq2/AMIoAqKyoqSn/9618lScOHD1dISIgWLlyopKQk3X333Te8be3atfXxxx/LZrNJuvLT97x585SVlaXQ0FD9z//8j2bNmqXevXvrL3/5i+t2kydP1qRJk0qcLTMzU5cvX1ZUVJTb8m7duqlhw4Y6f/78dV82yc3N1d69e+Xn5ydJqlWrlkaNGqV9+/apVatWrvVOnz6tlJQUPfvss263HzFiRJHzEMWJjY1VWlqaJOnUqVOSpAYNGhRZr0GDBvriiy9K3F6nTp3Uv39/RUVF6eTJk1qwYIEGDhyorKysIjH08fFRZGSkvvnmmxK3C88iAqiyhg8f7nb5+eef18KFC/Xhhx+WGIFnnnnGFQBJuu+++zR79mwdO3ZMd999tz755BMVFBQoMTGxyH2UJgLnzp2TdOUJvKx+97vfuQJwdTZJOnz4sFsE7Ha7fve73xW5/bhx40r1uvy1s12+fNm1zZ+rUaOG6/ob+fnbYJ9++mm1a9dOEyZM0JAhQ+Tv71/k/kvzNl94FhFAldWsWTO3y7/4xS/k5eWlo0ePlnjbxo0bu12++oR4/vx5SdKxY8ckSdHR0W7rhYWFlemJ/WY+mK+k2a5q2LChWyyuatmypVq2bFmm+7z6BO1wOIpcl5ubW+QJvDT8/Pw0YsQIPffcc9q9e7c6d+7sdr1lWW4hRtVEBHDbKMsTire3d7HLy+vTVGvXri2p6BN3aZR2tus9MWdlZZXqJ3c/Pz+FhYVJ+r+Xga6+LHStU6dOKSIiosTtFScyMlKS9OOPPxa57vz580VCjqqHdwehyvr+++/dLmdkZMjpdBZ5t83NaNKkiWub1zp37lypntgbN24sf39/HTlypMh1Ff3T76hRo9SgQYMSv/r27eu6TatWreTj46N//OMfbtvKy8vT3r17dc8999zULIcPH5YkhYeHuy0vKCjQ8ePH1aJFi5vaLioPRwKoshYsWOD23vX58+dLknr06HHL237wwQfl4+OjRYsWqVu3bq7lb775Zqlu7+vrq/bt2xd5UpWkwMBAZWVl3fKM13Mz5wRCQ0PVtWtXrV69Wq+++qqCg4MlSatWrVJOTo769evnWvfSpUvKzMxUnTp1VKdOHUlXfjHu50/0Fy5c0Jw5c1SnTh21a9fO7bpvvvlGubm56tSp000/TlQOIoAq68iRI3rsscfUvXt3/e1vf9Pq1asVHx+vmJiYW952vXr1NGrUKM2cOdN1H19//bW2bNmiOnXqlOqn+V69eumVV15Rdna223vv27Vrp7Vr12rMmDH65S9/qaCgoHL9hbKbOScgSVOmTFGnTp0UGxurZ555RidOnNDMmTP10EMPqXv37q71/v73vysuLk4TJ050nSRfsGCBNmzYoJ49e6px48Y6deqUli5dqszMTK1atarIuYvU1FQFBAS4BRZVEy8Hocpau3at7Ha7Xn75ZW3evFkjRozQkiVLym3706dP16uvvqpdu3YpKSlJGRkZ+vjjj2VZlmrUqFHi7X/729+qsLBQGzdudFuemJio+Ph4LVu2TPHx8Xr++efLbeZb0bZtW23btk3+/v4aPXq03nrrLQ0dOrRUf9Du3nvvVd26dfXnP/9Zw4cP1+zZs9W8eXNt27ZNAwcOLLL+unXr1LdvX9cRB6oum1VeZ8qAauCnn35SrVq19Prrr+uVV14pcf2hQ4fq4MGDpXqfvSn27t2rtm3b6p///OdNn2tA5eFIAMYq7h02V//6Z5cuXUq1jYkTJ2rXrl2l+lPSppg2bZqeeOIJAnCb4EgAxlq+fLmWL1+uRx55REFBQdqxY4fWrFmjhx56SFu3bvX0eECl4MQwjHX33XfLx8dHM2bMUHZ2tutk8euvv+7p0YBKw5EAABiMcwIAYDAiAAAG45zAdTidTp08eVLBwcH8ESwAtxXLsnThwgVFRESU+PGrROA6Tp486frjWABwOzp+/LgaNWp0w3WIwHVc/U3HznpEPvL18DQAUHoFytcOfViq39gmAtdx9SUgH/nKx0YEANxG/vc9n6V5KZsTwwBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMB9PD4Db33ErQ8d0UHnKVZBC1VxtFGoL8/RYqEbYxyqOEUcCQ4YMUe/evT09RrV02jqug/qX7lBL/UpdFaya2qMvlGfleno0VBPsYxXL4xEYMmSIbDabbDabfH19FRUVpXHjxik3l3/g20GmDqqhohRha6ogW4juUlt5y1snddTTo6GaYB+rWFXi5aDu3btr2bJlys/P1+7du5WQkCCbzabp06d7ejTcgNNy6oJ+UlPd5Vpms9kUZtXTTzrnwclQXbCPVTyPHwlIkt1uV/369RUZGanevXura9euSk1NlSQ5nU4lJycrKipK/v7+iomJ0fr16123LSws1NChQ13XN2/eXHPnzvXUQzFKvhyyZMlPNdyW+8muPHEkh1vHPlbxqsSRwLX27dunnTt3qkmTJpKk5ORkrV69WikpKWrWrJm2b9+uQYMGKTw8XLGxsXI6nWrUqJHWrVun2rVra+fOnXrmmWfUoEED9e/fv9T363A45HA4XJezs7PL/bEBQFVTJSKwadMmBQUFqaCgQA6HQ15eXnrzzTflcDg0depUbdu2TR07dpQk3XHHHdqxY4cWL16s2NhY+fr6avLkya5tRUVF6W9/+5vee++9MkUgOTnZbTsoma/ssslW5CeyPDmK/OQG3Az2sYpXJSIQFxenRYsW6eLFi5o9e7Z8fHz0+OOPa//+/bp06ZK6devmtn5eXp7atGnjurxgwQItXbpUmZmZunz5svLy8nTPPfeUaYbx48drzJgxrsvZ2dmKjIy8pcdV3XnZvBRs1dSP+kF11VCSZFmWftQPitQvPDwdqgP2sYpXJSIQGBio6OhoSdLSpUsVExOjJUuWqFWrVpKkzZs3q2HDhm63sdvtkqR3331XSUlJmjlzpjp27Kjg4GD96U9/0ldffVWmGex2u2ubKL3GulPfaJdCrFoKVZgy9b0KVaAGaurp0VBNsI9VrCoRgWt5eXlpwoQJGjNmjA4ePCi73a7MzEzFxsYWu356ero6deqkxMRE17JDhw5V1rjGq2+LVL7l0GF9I4dyFaxQtVFn2W0cqqN8sI9VrCoXAUnq16+fxo4dq8WLFyspKUmjR4+W0+lU586dlZWVpfT0dIWEhCghIUHNmjXTypUrtXXrVkVFRWnVqlXatWuXoqKiPP0wjBFpi1akoj09Bqox9rGKUyUj4OPjoxEjRmjGjBk6cuSIwsPDlZycrMOHD6tmzZpq27atJkyYIEl69tlntWfPHj355JOy2WwaMGCAEhMTtWXLFg8/CgCo+myWZVmeHqIqys7OVmhoqLqol3xsvp4eBwBKrcDKV5r+qqysLIWEhNxw3Srxy2IAAM8gAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMCIAAAYjAgBgMJ/SrLRx48ZSb/Cxxx676WEAAJWrVBHo3bt3qTZms9lUWFh4K/MAACpRqSLgdDoreg4AgAdwTgAADFaqI4Gfu3jxoj7//HNlZmYqLy/P7bqRI0eWy2AAgIpX5gjs2bNHjzzyiC5duqSLFy8qLCxMZ8+eVUBAgOrWrUsEAOA2UuaXg0aPHq2ePXvq/Pnz8vf315dffqljx46pXbt2euONNypiRgBABSlzBPbu3asXX3xRXl5e8vb2lsPhUGRkpGbMmKEJEyZUxIwAgApS5gj4+vrKy+vKzerWravMzExJUmhoqI4fP16+0wEAKlSZzwm0adNGu3btUrNmzRQbG6v//M//1NmzZ7Vq1Sq1atWqImYEAFSQMh8JTJ06VQ0aNJAkTZkyRbVq1dKwYcN05swZvfXWW+U+IACg4pT5SKB9+/au/65bt64++uijch0IAFB5+GUxADBYmY8EoqKiZLPZrnv94cOHb2kgAEDlKXMEXnjhBbfL+fn52rNnjz766CONHTu2vOYCAFSCMkdg1KhRxS5fsGCB/vGPf9zyQACAylNu5wR69Oih999/v7w2BwCoBOUWgfXr1yssLKy8NgcAqAQ39cti154YtixLp0+f1pkzZ7Rw4cJyHQ4AULHKHIFevXq5RcDLy0vh4eHq0qWL7rrrrnIdDqjOtp7c6+kRUE1lX3Cq1p2lW7fMEZg0aVJZbwIAqKLKfE7A29tbP/zwQ5Hl586dk7e3d7kMBQCoHGWOgGVZxS53OBzy8/O75YEAAJWn1C8HzZs3T5Jks9n05z//WUFBQa7rCgsLtX37ds4JAMBtptQRmD17tqQrRwIpKSluL/34+fmpadOmSklJKf8JAQAVptQROHLkiCQpLi5OH3zwgWrVqlVhQwEAKkeZ3x302WefVcQcAAAPKPOJ4ccff1zTp08vsnzGjBnq169fuQwFAKgcZY7A9u3b9cgjjxRZ3qNHD23fvr1chgIAVI4yRyAnJ6fYt4L6+voqOzu7XIYCAFSOMkegdevWWrt2bZHl7777rlq2bFkuQwEAKkeZTwy/+uqr6tu3rw4dOqQHHnhAkvTJJ5/onXfe0fr168t9QABAxSlzBHr27KkNGzZo6tSpWr9+vfz9/RUTE6NPP/2UPyUNALeZMkdAkn7zm9/oN7/5jSQpOztba9asUVJSknbv3q3CwsJyHRAAUHFu+kNltm/froSEBEVERGjmzJl64IEH9OWXX5bnbACAClamI4HTp09r+fLlWrJkibKzs9W/f385HA5t2LCBk8IAcBsq9ZFAz5491bx5c/3rX//SnDlzdPLkSc2fP78iZwMAVLBSHwls2bJFI0eO1LBhw9SsWbOKnAkAUElKfSSwY8cOXbhwQe3atVOHDh305ptv6uzZsxU5GwCggpU6Ar/+9a/1X//1Xzp16pSeffZZvfvuu4qIiJDT6VRqaqouXLhQkXMCACpAmd8dFBgYqKefflo7duzQv//9b7344ouaNm2a6tatq8cee6wiZgQAVJCbfouoJDVv3lwzZszQiRMntGbNmvKaCQBQSW4pAld5e3urd+/e2rhxY3lsDgBQScolAgCA2xMRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMBgRAACDEQEAMNhtGYHly5erZs2anh4D/+u4laEd1of61PpAf7c+UZb1o6dHwm1o8hvn5N0gw+2rZedjRdazLEuPxJ+Ud4MMbdiS44FJqxePRmDIkCGy2WxFvjIyMjw5FsrgtHVcB/Uv3aGW+pW6Klg1tUdfKM/K9fRouA39v+Z++u+vm7q+tv+1UZF15r6VJZvNA8NVUz6eHqB79+5atmyZ27Lw8HAPTYOyytRBNVSUImxNJUl3WW11Vqd0UkfVVHd5djjcdnx8pPp1r/+0tHefQ7MWn9ffP4pUw5ijlTdYNebxl4Psdrvq16/v9jV37ly1bt1agYGBioyMVGJionJyrn/Yd+bMGbVv3159+vSRw+GQ0+lUcnKyoqKi5O/vr5iYGK1fv74SH5UZnJZTF/STwlTXtcxmsylM9fSTznlwMtyuvj+cr0b3HFF0h6MalHhamSfyXddduuTUoMTTmj81/IahQNl4PALF8fLy0rx587R//36tWLFCn376qcaNG1fsusePH9d9992nVq1aaf369bLb7UpOTtbKlSuVkpKi/fv3a/To0Ro0aJA+//zzSn4k1Vu+HLJkyU813Jb7ya488XIQyuZXbWpo6dx6+vCdCC2YFq6jxwsU2/u/dSHHKUkaM/GsOv7SX726B3l40urF4zndtGmTgoL+7x+1R48eWrdunety06ZN9frrr+u5557TwoUL3W574MABdevWTX369NGcOXNks9nkcDg0depUbdu2TR07dpQk3XHHHdqxY4cWL16s2NjYYudwOBxyOByuy9nZ2eX5MAGUoMeDga7/vrulXR3a1lDUL4/pvY05Cq/trc/SL2t3aqQHJ6yePB6BuLg4LVq0yHU5MDBQ27ZtU3Jysr777jtlZ2eroKBAubm5unTpkgICAiRJly9f1n333af4+HjNmTPHdfuMjAxdunRJ3bp1c7ufvLw8tWnT5rpzJCcna/LkyeX74Ko5X9llk63IT/15chQ5OgDKqmaot+68w1eHjuRp37eWDh3NV1jzw27r9Pv9ad3XoYY+/aDoCWSUjscjEBgYqOjoaNflo0eP6tFHH9WwYcM0ZcoUhYWFaceOHRo6dKjy8vJcEbDb7eratas2bdqksWPHqmHDhpLkOnewefNm17Kr7Hb7decYP368xowZ47qcnZ2tyEh+6rgRL5uXgq2a+lE/qK6ufK8ty9KP+kGR+oWHp8PtLueiU4eO5WvQE8Hq91iQhg4Mcbs+Ju64Zk2uo0cfCrzOFlAaHo/Az+3evVtOp1MzZ86Ul9eVUxbvvfdekfW8vLy0atUqxcfHKy4uTmlpaYqIiFDLli1lt9uVmZl53Zd+imO3228YCRSvse7UN9qlEKuWQhWmTH2vQhWogZp6ejTcZsZOPqtHuwWqSaSPTp4u0KQ3fpS3l/RU72CF1/Eu9mRwZEMfRTX29cC01UeVi0B0dLTy8/M1f/589ezZU+np6UpJSSl2XW9vb7399tsaMGCAHnjgAaWlpal+/fpKSkrS6NGj5XQ61blzZ2VlZSk9PV0hISFKSEio5EdUvdW3RSrfcuiwvpFDuQpWqNqos+w2Xg5C2Zw4VaCBiad17nyhwmt7695f+Wvn5kiF1/H29GjVWpWLQExMjGbNmqXp06dr/Pjxuv/++5WcnKzBgwcXu76Pj4/WrFmjJ5980hWC1157TeHh4UpOTtbhw4dVs2ZNtW3bVhMmTKjkR2OGSFu0IhVd8orADaxJqV+m9QtPsc+VB5tlWZanh6iKsrOzFRoaqi7qJR8bh5sof1tP7vX0CKimsi84VevOw8rKylJISMgN162SvycAAKgcRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgPp4eoKqyLEuSVKB8yfLwMKiWsi84PT0CqqnsnCv71tXnsRshAtdx4cIFSdIOfejhSVBd1brT0xOgurtw4YJCQ0NvuI7NKk0qDOR0OnXy5EkFBwfLZrN5epwqLzs7W5GRkTp+/LhCQkI8PQ6qGfavsrEsSxcuXFBERIS8vG78qj9HAtfh5eWlRo0aeXqM205ISAj/k6LCsH+VXklHAFdxYhgADEYEAMBgRADlwm63a+LEibLb7Z4eBdUQ+1fF4cQwABiMIwEAMBgRAACDEQF4xJAhQ9S7d29Pj4HbyPLly1WzZk1Pj1HtEAEUMWTIENlsNtlsNvn6+ioqKkrjxo1Tbm6up0dDNXDt/nXtV0ZGhqdHMxK/LIZide/eXcuWLVN+fr52796thIQE2Ww2TZ8+3dOjoRq4un9dKzw83EPTmI0jARTLbrerfv36ioyMVO/evdW1a1elpqZKuvInNZKTkxUVFSV/f3/FxMRo/fr1rtsWFhZq6NChruubN2+uuXPneuqhoAq6un9d+zV37ly1bt1agYGBioyMVGJionJycq67jTNnzqh9+/bq06ePHA5HifsliseRAEq0b98+7dy5U02aNJEkJScna/Xq1UpJSVGzZs20fft2DRo0SOHh4YqNjZXT6VSjRo20bt061a5dWzt37tQzzzyjBg0aqH///h5+NKiqvLy8NG/ePEVFRenw4cNKTEzUuHHjtHDhwiLrHj9+XN26ddOvf/1rLVmyRN7e3poyZcoN90tchwX8TEJCguXt7W0FBgZadrvdkmR5eXlZ69evt3Jzc62AgABr586dbrcZOnSoNWDAgOtuc/jw4dbjjz/udh+9evWqqIeAKuza/evq1xNPPFFkvXXr1lm1a9d2XV62bJkVGhpqfffdd1ZkZKQ1cuRIy+l0WpZl3fR+CcviSADFiouL06JFi3Tx4kXNnj1bPj4+evzxx7V//35dunRJ3bp1c1s/Ly9Pbdq0cV1esGCBli5dqszMTF2+fFl5eXm65557KvlRoKq6un9dFRgYqG3btik5OVnfffedsrOzVVBQoNzcXF26dEkBAQGSpMuXL+u+++5TfHy85syZ47p9RkZGqfZLFEUEUKzAwEBFR0dLkpYuXaqYmBgtWbJErVq1kiRt3rxZDRs2dLvN1V/pf/fdd5WUlKSZM2eqY8eOCg4O1p/+9Cd99dVXlfsgUGVdu39J0tGjR/Xoo49q2LBhmjJlisLCwrRjxw4NHTpUeXl5rgjY7XZ17dpVmzZt0tixY1374NVzBzfaL1E8IoASeXl5acKECRozZowOHjwou92uzMzM677Omp6erk6dOikxMdG17NChQ5U1Lm5Du3fvltPp1MyZM11///69994rsp6Xl5dWrVql+Ph4xcXFKS0tTREREWrZsmWJ+yWKRwRQKv369dPYsWO1ePFiJSUlafTo0XI6nercubOysrKUnp6ukJAQJSQkqFmzZlq5cqW2bt2qqKgorVq1Srt27VJUVJSnHwaqqOjoaOXn52v+/Pnq2bOn0tPTlZKSUuy63t7eevvttzVgwAA98MADSktLU/369UvcL1E8IoBS8fHx0YgRIzRjxgwdOXJE4eHhSk5O1uHDh1WzZk21bdtWEyZMkCQ9++yz2rNnj5588knZbDYNGDBAiYmJ2rJli4cfBaqqmJgYzZo1S9OnT9f48eN1//33Kzk5WYMHDy52fR8fH61Zs0ZPPvmkKwSvvfbaDfdLFI+/IgoABuOXxQDAYEQAAAxGBADAYEQAAAxGBADAYEQAAAxGBADAYEQAAAxGBIBK8PPPVO7SpYteeOGFSp8jLS1NNptNP/30U6XfN6omIgCjXft5t35+foqOjtYf//hHFRQUVOj9fvDBB3rttddKtS5P3KhI/O0gGO/q5906HA59+OGHGj58uHx9fTV+/Hi39fLy8uTn51cu9xkWFlYu2wFuFUcCMN7Vz7tt0qSJhg0bpq5du2rjxo2ul3CmTJmiiIgINW/eXNKVjzbs37+/atasqbCwMPXq1UtHjx51ba+wsFBjxoxRzZo1Vbt2bY0bN04//xNdP385yOFw6KWXXlJkZKTsdruio6O1ZMkSHT16VHFxcZKkWrVqyWazaciQIZJK/qxnSfrwww915513yt/fX3FxcW5zAhIRAIrw9/dXXl6eJOmTTz7RgQMHlJqaqk2bNik/P18PP/ywgoOD9cUXXyg9PV1BQUHq3r276zYzZ87U8uXLtXTpUu3YsUM//vij/vKXv9zwPgcPHqw1a9Zo3rx5+vbbb7V48WIFBQUpMjJS77//viTpwIEDOnXqlObOnSvpymc9r1y5UikpKdq/f79Gjx6tQYMG6fPPP5d0JVZ9+/ZVz549tXfvXv3+97/Xyy+/XFHfNtyuPPzxloBHXftZx06n00pNTbXsdruVlJRkJSQkWPXq1bMcDodr/VWrVlnNmzd3fbatZVmWw+Gw/P39ra1bt1qWZVkNGjSwZsyY4bo+Pz/fatSokdtnKsfGxlqjRo2yLMuyDhw4YEmyUlNTi53xs88+syRZ58+fdy0rzWfqjh8/3mrZsqXb9S+99FKRbcFsnBOA8TZt2qSgoCDl5+fL6XQqPj5ekyZN0vDhw9W6dWu38wBff/21MjIyFBwc7LaN3NxcHTp0SFlZWTp16pQ6dOjgus7Hx0ft27cv8pLQVXv37pW3t3eZPhGrNJ+p++2337rNIUkdO3Ys9X3ADEQAxrv6oed+fn6KiIiQj8///W8RGBjotm5OTo7atWunt99+u8h2wsPDb+r+/f39y3wbPlMX5YUIwHg//9DzG2nbtq3Wrl2runXrKiQkpNh1GjRooK+++kr333+/JKmgoEC7d+9W27Zti12/devWcjqd+vzzz9W1a9ci1189EiksLHQtK81n6rZo0UIbN250W/bll1+W/CBhFE4MA2UwcOBA1alTR7169dIXX3yhI0eOKC0tTSNHjtSJEyckSaNGjdK0adO0YcMGfffdd0pMTLzhe/ybNm2qhIQEPf3009qwYYNrm1c/aL1Jkyay2WzatGmTzpw5o5ycHAUHB7s+U3fFihU6dOiQ/vnPf2r+/PlasWKFJOm5557T999/r7Fjx+rAgQN65513tHz58or+FuE2QwSAMggICND27dvVuHFj9e3bVy1atNDQoUOVm5vrOjJ48cUX9dvf/lYJCQnq2LGjgoOD1adPnxtud9GiRXriiSeUmJiou+66S3/4wx908eJFSVLDhg01efJkvfzyy6pXr55GjBghSXrttdf06quvKjk5WS1atFD37t21efNmRUVFSZIaN26s999/Xxs2bFBMTIxSUlI0derUCvzu4HbEZwwDgME4EgAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADAYEQAAgxEBADDY/wdu0gKx/8CEKgAAAABJRU5ErkJggg==\n"
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAGGCAYAAACdXD2cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJiNJREFUeJzt3Xl8VPW9//H3TCYZsrMFSCBAbBDhgpGltVAUoqBgRRYVJSKhcl0ICIIBBWvBKgSoyCYQemVHEQFL+YFUwRqRoJZGsBUV2QMFWkDMQshkmfP7g8tcxwRIIMmEfF/PxyOPh3PmzJnP6HFeOXNmMjbLsiwBAIxk9/UAAADfIQIAYDAiAAAGIwIAYDAiAAAGIwIAYDAiAAAGIwIAYDAiAAAGIwKodiZNmiSbzabTp09fcd3mzZtryJAhlT/UJRw9elS1atVSenr6FddNS0uTzWbT2rVrq2Ay33n44Yc1YMAAX4+BMiICwDX4/e9/r1tvvVW/+tWvPMveeustzZo1y3dDXcaOHTvUpUsXBQUFqVGjRho5cqRyc3PLdFubzVbqz9SpU73We+6557Ru3Tp9+eWXlfEQUMEcvh4AuBZ79+6V3e6b32VOnTqlZcuWadmyZV7L33rrLX311Vd65plnfDLXpezevVt33nmnWrVqpddee03Hjh3Tq6++qn379mnz5s1l2kaPHj00ePBgr2Xt2rUrcbljx46aMWOGli9fXmHzo3IQAVzXnE6nz+575cqVcjgc6t27d5XcX15enoKCgq769hMmTFCdOnWUlpamsLAwSRdeTnv88cf1wQcf6K677rriNm688UYNGjToiusNGDBAEydO1Pz58xUSEnLVM6Py8XIQqq3Tp09rwIABCgsLU7169TRq1Cjl5+d7rfPTcwJLly6VzWZTenq6xowZo4iICAUHB6tfv346deqU123dbrcmTZqkqKgoBQUFKT4+Xl9//XWZzzOsX79et956q9eTXLdu3bRp0yYdOXLE83JJ8+bNS9zv5MmT1aRJE9WqVUt33nmn9u/f77VOt27d1KZNG2VkZOj2229XUFCQJkyYULZ/caXIzs7Wli1bNGjQIE8AJGnw4MEKCQnRO++8U+ZtnT9/vsR/h5/q0aOHzp07py1btlz1zKgaHAmg2howYICaN2+ulJQUffbZZ5ozZ47Onj1bppcYnn76adWpU0cTJ07U4cOHNWvWLI0YMUKrV6/2rDN+/HhNnz5dvXv31t13360vv/xSd9999xWf4CSpsLBQO3fu1LBhw7yWv/DCC8rKytKxY8c0c+ZMSSrxm/DUqVNlt9uVnJysrKwsTZ8+XY888og+//xzr/XOnDmjXr166eGHH9agQYPUsGFDSVJubm6ZZvT391d4eLgk6Z///KeKiorUsWNHr3UCAgJ0yy23aNeuXVfcnnQhsvPnz5dlWWrVqpV++9vfKiEhocR6rVu3VmBgoNLT09WvX78ybRu+QQRQbcXExOjPf/6zJGn48OEKCwvT/PnzlZycrJtvvvmyt61Xr54++OAD2Ww2SRd++54zZ46ysrIUHh6uf//733rttdfUt29f/elPf/Lc7qWXXtKkSZOuOFtmZqbOnz+vmJgYr+U9evRQ48aNdfbs2Uu+bJKfn6/du3crICBAklSnTh2NGjVKX331ldq0aeNZ7+TJk0pNTdWTTz7pdfsRI0aUOA9Rmq5duyotLU2SdOLECUlSZGRkifUiIyP1ySefXHF7nTt31oABAxQTE6Pjx49r3rx5euSRR5SVlVUihg6HQ9HR0fr666+vuF34FhFAtTV8+HCvy08//bTmz5+v995774oReOKJJzwBkKTbbrtNM2fO1JEjR3TzzTfrww8/VFFRkZKSkkrcR1kicObMGUkXnsDL6ze/+Y0nABdnk6SDBw96RcDpdOo3v/lNiduPGzeuTK/L/3i28+fPe7b5U7Vq1fJcfzk/fRvsY489pg4dOmjChAkaMmSIAgMDS9x/Wd7mC98iAqi2WrRo4XX5Zz/7mex2uw4fPnzF2zZt2tTr8sUnxLNnz0qSjhw5IkmKjY31Wq9u3brlemK/mi/mu9JsFzVu3NgrFhe1bt1arVu3Ltd9XnyCdrlcJa7Lz88v8QReFgEBARoxYoSeeuopZWRkqEuXLl7XW5blFWJUT0QA143yPKH4+fmVuryivk21Xr16kko+cZdFWWe71BNzVlZWmX5zDwgIUN26dSX938tAF18W+rETJ04oKirqitsrTXR0tCTp+++/L3Hd2bNnS4Qc1Q/vDkK1tW/fPq/L+/fvl9vtLvFum6vRrFkzzzZ/7MyZM2V6Ym/atKkCAwN16NChEtdV9m+/o0aNUmRk5BV/+vfv77lNmzZt5HA49Pe//91rWwUFBdq9e7duueWWq5rl4MGDkqSIiAiv5UVFRTp69KhatWp1VdtF1eFIANXWvHnzvN67PnfuXElSr169rnnbd955pxwOhxYsWKAePXp4lr/++utlur2/v786duxY4klVkoKDg5WVlXXNM17K1ZwTCA8PV/fu3bVy5Uq9+OKLCg0NlSStWLFCubm5evDBBz3r5uXlKTMzU/Xr11f9+vUlXfhg3E+f6HNycjRr1izVr19fHTp08Lru66+/Vn5+vjp37nzVjxNVgwig2jp06JDuu+8+9ezZU59++qlWrlyphIQExcXFXfO2GzZsqFGjRmnGjBme+/jyyy+1efNm1a9fv0y/zffp00cvvPCCsrOzvd5736FDB61evVpjxozRz3/+c4WEhFToB8qu5pyAJE2ePFmdO3dW165d9cQTT+jYsWOaMWOG7rrrLvXs2dOz3t/+9jfFx8dr4sSJnpPk8+bN0/r169W7d281bdpUJ06c0OLFi5WZmakVK1aUOHexZcsWBQUFeQUW1RMvB6HaWr16tZxOp55//nlt2rRJI0aM0KJFiyps+9OmTdOLL76onTt3Kjk5Wfv379cHH3wgy7JUq1atK97+0UcfVXFxsTZs2OC1PCkpSQkJCVqyZIkSEhL09NNPV9jM16J9+/baunWrAgMDNXr0aP3xj3/U0KFDy/QH7X71q1+pQYMGeuONNzR8+HDNnDlTLVu21NatW/XII4+UWH/NmjXq37+/54gD1ZfNqqgzZUAN8MMPP6hOnTp65ZVX9MILL1xx/aFDh+q7774r0/vsTbF79261b99eX3zxxVWfa0DV4UgAxirtHTYX//pnt27dyrSNiRMnaufOnWX6U9KmmDp1qh544AECcJ3gSADGWrp0qZYuXap77rlHISEh2r59u1atWqW77rpL77//vq/HA6oEJ4ZhrJtvvlkOh0PTp09Xdna252TxK6+84uvRgCrDkQAAGIxzAgBgMCIAAAbjnMAluN1uHT9+XKGhofwRLADXFcuylJOTo6ioqCt+/SoRuITjx497/jgWAFyPjh49qiZNmlx2HSJwCRc/6dhF98ghfx9PAwBlV6RCbdd7ZfrENhG4hIsvATnkL4eNCAC4jvzvez7L8lI2J4YBwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGAOXw+A699Ra7+O6DsVKF8hCldLtVO4ra6vx0INwj5WeYw4EhgyZIj69u3r6zFqpJPWUX2nf+gGtdYv1F2hqq1d+kQFVr6vR0MNwT5WuXwegSFDhshms8lms8nf318xMTEaN26c8vP5D3w9yNR3aqwYRdmaK8QWppvUXn7y03Ed9vVoqCHYxypXtXg5qGfPnlqyZIkKCwuVkZGhxMRE2Ww2TZs2zdej4TLclls5+kHNdZNnmc1mU12roX7QGR9OhpqCfazy+fxIQJKcTqcaNWqk6Oho9e3bV927d9eWLVskSW63WykpKYqJiVFgYKDi4uK0du1az22Li4s1dOhQz/UtW7bU7NmzffVQjFIolyxZClAtr+UBcqpAHMnh2rGPVb5qcSTwY1999ZV27NihZs2aSZJSUlK0cuVKpaamqkWLFtq2bZsGDRqkiIgIde3aVW63W02aNNGaNWtUr1497dixQ0888YQiIyM1YMCAMt+vy+WSy+XyXM7Ozq7wxwYA1U21iMDGjRsVEhKioqIiuVwu2e12vf7663K5XJoyZYq2bt2qTp06SZJuuOEGbd++XQsXLlTXrl3l7++vl156ybOtmJgYffrpp3rnnXfKFYGUlBSv7eDK/OWUTbYSv5EVyFXiNzfgarCPVb5qEYH4+HgtWLBA586d08yZM+VwOHT//fdrz549ysvLU48ePbzWLygoULt27TyX582bp8WLFyszM1Pnz59XQUGBbrnllnLNMH78eI0ZM8ZzOTs7W9HR0df0uGo6u82uUKu2vtd/1ECNJUmWZel7/UfR+pmPp0NNwD5W+apFBIKDgxUbGytJWrx4seLi4rRo0SK1adNGkrRp0yY1btzY6zZOp1OS9Pbbbys5OVkzZsxQp06dFBoaqj/84Q/6/PPPyzWD0+n0bBNl11Q36mvtVJhVR+Gqq0ztU7GKFKnmvh4NNQT7WOWqFhH4MbvdrgkTJmjMmDH67rvv5HQ6lZmZqa5du5a6fnp6ujp37qykpCTPsgMHDlTVuMZrZItWoeXSQX0tl/IVqnC1Uxc5bRyqo2Kwj1WuahcBSXrwwQc1duxYLVy4UMnJyRo9erTcbre6dOmirKwspaenKywsTImJiWrRooWWL1+u999/XzExMVqxYoV27typmJgYXz8MY0TbYhWtWF+PgRqMfazyVMsIOBwOjRgxQtOnT9ehQ4cUERGhlJQUHTx4ULVr11b79u01YcIESdKTTz6pXbt26aGHHpLNZtPAgQOVlJSkzZs3+/hRAED1Z7Msy/L1ENVRdna2wsPD1U195LD5+3ocACizIqtQafqzsrKyFBYWdtl1q8WHxQAAvkEEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgjrKstGHDhjJv8L777rvqYQAAVatMEejbt2+ZNmaz2VRcXHwt8wAAqlCZIuB2uyt7DgCAD3BOAAAMVqYjgZ86d+6cPv74Y2VmZqqgoMDrupEjR1bIYACAylfuCOzatUv33HOP8vLydO7cOdWtW1enT59WUFCQGjRoQAQA4DpS7peDRo8erd69e+vs2bMKDAzUZ599piNHjqhDhw569dVXK2NGAEAlKXcEdu/erWeffVZ2u11+fn5yuVyKjo7W9OnTNWHChMqYEQBQScodAX9/f9ntF27WoEEDZWZmSpLCw8N19OjRip0OAFCpyn1OoF27dtq5c6datGihrl276ne/+51Onz6tFStWqE2bNpUxIwCgkpT7SGDKlCmKjIyUJE2ePFl16tTRsGHDdOrUKf3xj3+s8AEBAJWn3EcCHTt29PxzgwYN9Je//KVCBwIAVB0+LAYABiv3kUBMTIxsNtslrz948OA1DQQAqDrljsAzzzzjdbmwsFC7du3SX/7yF40dO7ai5gIAVIFyR2DUqFGlLp83b57+/ve/X/NAAICqU2HnBHr16qV169ZV1OYAAFWgwiKwdu1a1a1bt6I2BwCoAlf1YbEfnxi2LEsnT57UqVOnNH/+/AodDgBQucodgT59+nhFwG63KyIiQt26ddNNN91UocNVB/bQENltAb4eAzXQ5r2f+HoE1FDZOW7VubFs65Y7ApMmTSrvTQAA1VS5zwn4+fnpP//5T4nlZ86ckZ+fX4UMBQCoGuWOgGVZpS53uVwKCOBlEwC4npT55aA5c+ZIkmw2m9544w2FhIR4risuLta2bdtq5DkBAKjJyhyBmTNnSrpwJJCamur10k9AQICaN2+u1NTUip8QAFBpyhyBQ4cOSZLi4+P17rvvqk6dOpU2FACgapT73UEfffRRZcwBAPCBcp8Yvv/++zVt2rQSy6dPn64HH3ywQoYCAFSNckdg27Ztuueee0os79Wrl7Zt21YhQwEAqka5I5Cbm1vqW0H9/f2VnZ1dIUMBAKpGuSPQtm1brV69usTyt99+W61bt66QoQAAVaPcJ4ZffPFF9e/fXwcOHNAdd9whSfrwww/11ltvae3atRU+IACg8pQ7Ar1799b69es1ZcoUrV27VoGBgYqLi9Nf//pX/pQ0AFxnyh0BSfr1r3+tX//615Kk7OxsrVq1SsnJycrIyFBxcXGFDggAqDxX/aUy27ZtU2JioqKiojRjxgzdcccd+uyzzypyNgBAJSvXkcDJkye1dOlSLVq0SNnZ2RowYIBcLpfWr1/PSWEAuA6V+Uigd+/eatmypf7xj39o1qxZOn78uObOnVuZswEAKlmZjwQ2b96skSNHatiwYWrRokVlzgQAqCJlPhLYvn27cnJy1KFDB9166616/fXXdfr06cqcDQBQycocgV/+8pf6n//5H504cUJPPvmk3n77bUVFRcntdmvLli3KycmpzDkBAJWg3O8OCg4O1mOPPabt27frn//8p5599llNnTpVDRo00H333VcZMwIAKslVv0VUklq2bKnp06fr2LFjWrVqVUXNBACoItcUgYv8/PzUt29fbdiwoSI2BwCoIhUSAQDA9YkIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGIwIAIDBiAAAGOy6jMDSpUtVu3ZtX48BSQdd/9Bnuf9PH2av0Ec5q7Qr70OdK87y9Vi4Dr306hn5Re73+mnd5Ygk6fuzxRr5wim16nJEwTEH1LzDYY367SllZRf7eOrrn8OXdz5kyBAtW7asxPJ9+/YpNjbWBxOhvM4WnVR0wE0K96svS5b2uTKUkfe+Oof0k8Pm7+vxcJ35r5YB+uCdKM9lh59NknT830U6frJI039XX61vDNCRY4VKeu6Ujp8s0po3In01bo3g0whIUs+ePbVkyRKvZRERET6aBuXVIfgur8ttat2mtNxVyi4+o7qORj6aCtcrh0Nq1KDk01Kbm5xau+j/nux/1txfLz9fT4NHnFRRkSWHw1aVY9YoPn85yOl0qlGjRl4/s2fPVtu2bRUcHKzo6GglJSUpNzf3kts4deqUOnbsqH79+snlcsntdislJUUxMTEKDAxUXFyc1q5dW4WPylxFKpAk+ducPp4E16N9BwvV5JZDir31sAYlnVTmscJLrpuVXaywEDsBuEY+j0Bp7Ha75syZoz179mjZsmX661//qnHjxpW67tGjR3XbbbepTZs2Wrt2rZxOp1JSUrR8+XKlpqZqz549Gj16tAYNGqSPP/64ih+JWSzL0rf5n6u2XwOF+tXx9Ti4zvyiXS0tnt1Q770VpXlTI3T4aJG69v2XcnLdJdY9faZYk2ee1eODwn0wac3i85eDNm7cqJCQEM/lXr16ac2aNZ7LzZs31yuvvKKnnnpK8+fP97rt3r171aNHD/Xr10+zZs2SzWaTy+XSlClTtHXrVnXq1EmSdMMNN2j79u1auHChunbtWuocLpdLLpfLczk7O7siH6YRvsn/VLnFP+gXwff4ehRch3rdGez555tbO3Vr+1qK+fkRvbMhV0MTwjzXZee41fvR42p1Y4AmJtf1xag1is8jEB8frwULFnguBwcHa+vWrUpJSdG3336r7OxsFRUVKT8/X3l5eQoKCpIknT9/XrfddpsSEhI0a9Ysz+3379+vvLw89ejRw+t+CgoK1K5du0vOkZKSopdeeqliH5xBvjn/qU4VHdXPg+9RLXvwlW8AXEHtcD/deIO/Dhwq8CzLyXXrnoTjCg2x693FjeTvz0tB18rnLwcFBwcrNjbW8+NyuXTvvffq5ptv1rp165SRkaF58+ZJuvBEfpHT6VT37t21ceNG/etf//Isv3juYNOmTdq9e7fn5+uvv77seYHx48crKyvL83P06NFKesQ1i2VZ+ub8p/pPUaY6BvVUkD3U1yOhhsg959aBI4WKbHjhd9XsHLd6PvwvBfhL65dGqlYtnz991Qg+PxL4qYyMDLndbs2YMUN2+4X/yO+8806J9ex2u1asWKGEhATFx8crLS1NUVFRat26tZxOpzIzMy/50k9pnE6nnE5OZpbXN/mf6WThQd0SdKccNn+53HmSJIctQH62ard7oRob+9Jp3dsjWM2iHTp+skiTXv1efnbp4b6hngDknbe0/PVGys51K/t/zxVE1POTnx9HBFer2v1fGhsbq8LCQs2dO1e9e/dWenq6UlNTS13Xz89Pb775pgYOHKg77rhDaWlpatSokZKTkzV69Gi53W516dJFWVlZSk9PV1hYmBITE6v4EdVsxwq/lST9PW+z1/L/qtVFjQNa+GIkXKeOnSjSI0kndeZssSLq+elXvwjUjk3Riqjvp7Qdefr8iwvn7G7sdMTrdgf+1kzNo/lMytWqdhGIi4vTa6+9pmnTpmn8+PG6/fbblZKSosGDB5e6vsPh0KpVq/TQQw95QvDyyy8rIiJCKSkpOnjwoGrXrq327dtrwoQJVfxoar67wn7j6xFQQ6xKvfTnSrp1DlLxCT5AWhlslmVZvh6iOsrOzlZ4eLjuCH1EDluAr8dBDbR57ye+HgE1VHaOW3VuPKisrCyFhYVddl3OrACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwYgAABiMCACAwRy+HqC6sixLklRkFfp4EtRU2TluX4+AGio798K+dfF57HKIwCXk5ORIkrblvuPjSVBT1bnR1xOgpsvJyVF4ePhl17FZZUmFgdxut44fP67Q0FDZbDZfj1PtZWdnKzo6WkePHlVYWJivx0ENw/5VPpZlKScnR1FRUbLbL/+qP0cCl2C329WkSRNfj3HdCQsL439SVBr2r7K70hHARZwYBgCDEQEAMBgRQIVwOp2aOHGinE6nr0dBDcT+VXk4MQwABuNIAAAMRgQAwGBEAD4xZMgQ9e3b19dj4DqydOlS1a5d29dj1DhEACUMGTJENptNNptN/v7+iomJ0bhx45Sfn+/r0VAD/Hj/+vHP/v37fT2akfiwGErVs2dPLVmyRIWFhcrIyFBiYqJsNpumTZvm69FQA1zcv34sIiLCR9OYjSMBlMrpdKpRo0aKjo5W37591b17d23ZskXShT+pkZKSopiYGAUGBiouLk5r16713La4uFhDhw71XN+yZUvNnj3bVw8F1dDF/evHP7Nnz1bbtm0VHBys6OhoJSUlKTc395LbOHXqlDp27Kh+/frJ5XJdcb9E6TgSwBV99dVX2rFjh5o1ayZJSklJ0cqVK5WamqoWLVpo27ZtGjRokCIiItS1a1e53W41adJEa9asUb169bRjxw498cQTioyM1IABA3z8aFBd2e12zZkzRzExMTp48KCSkpI0btw4zZ8/v8S6R48eVY8ePfTLX/5SixYtkp+fnyZPnnzZ/RKXYAE/kZiYaPn5+VnBwcGW0+m0JFl2u91au3atlZ+fbwUFBVk7duzwus3QoUOtgQMHXnKbw4cPt+6//36v++jTp09lPQRUYz/evy7+PPDAAyXWW7NmjVWvXj3P5SVLlljh4eHWt99+a0VHR1sjR4603G63ZVnWVe+XsCyOBFCq+Ph4LViwQOfOndPMmTPlcDh0//33a8+ePcrLy1OPHj281i8oKFC7du08l+fNm6fFixcrMzNT58+fV0FBgW655ZYqfhSori7uXxcFBwdr69atSklJ0bfffqvs7GwVFRUpPz9feXl5CgoKkiSdP39et912mxISEjRr1izP7ffv31+m/RIlEQGUKjg4WLGxsZKkxYsXKy4uTosWLVKbNm0kSZs2bVLjxo29bnPxI/1vv/22kpOTNWPGDHXq1EmhoaH6wx/+oM8//7xqHwSqrR/vX5J0+PBh3XvvvRo2bJgmT56sunXravv27Ro6dKgKCgo8EXA6nerevbs2btyosWPHevbBi+cOLrdfonREAFdkt9s1YcIEjRkzRt99952cTqcyMzMv+Tprenq6OnfurKSkJM+yAwcOVNW4uA5lZGTI7XZrxowZnr9//847Jb/QyW63a8WKFUpISFB8fLzS0tIUFRWl1q1bX3G/ROmIAMrkwQcf1NixY7Vw4UIlJydr9OjRcrvd6tKli7KyspSenq6wsDAlJiaqRYsWWr58ud5//33FxMRoxYoV2rlzp2JiYnz9MFBNxcbGqrCwUHPnzlXv3r2Vnp6u1NTUUtf18/PTm2++qYEDB+qOO+5QWlqaGjVqdMX9EqUjAigTh8OhESNGaPr06Tp06JAiIiKUkpKigwcPqnbt2mrfvr0mTJggSXryySe1a9cuPfTQQ7LZbBo4cKCSkpK0efNmHz8KVFdxcXF67bXXNG3aNI0fP1633367UlJSNHjw4FLXdzgcWrVqlR566CFPCF5++eXL7pcoHX9FFAAMxofFAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEAMBgRAAADEYEgCrw0+9U7tatm5555pkqnyMtLU02m00//PBDld83qiciAKP9+PtuAwICFBsbq9///vcqKiqq1Pt999139fLLL5dpXZ64UZn420Ew3sXvu3W5XHrvvfc0fPhw+fv7a/z48V7rFRQUKCAgoELus27duhWyHeBacSQA4138vttmzZpp2LBh6t69uzZs2OB5CWfy5MmKiopSy5YtJV34asMBAwaodu3aqlu3rvr06aPDhw97tldcXKwxY8aodu3aqlevnsaNG6ef/omun74c5HK59Nxzzyk6OlpOp1OxsbFatGiRDh8+rPj4eElSnTp1ZLPZNGTIEElX/q5nSXrvvfd04403KjAwUPHx8V5zAhIRAEoIDAxUQUGBJOnDDz/U3r17tWXLFm3cuFGFhYW6++67FRoaqk8++UTp6ekKCQlRz549PbeZMWOGli5dqsWLF2v79u36/vvv9ac//emy9zl48GCtWrVKc+bM0TfffKOFCxcqJCRE0dHRWrdunSRp7969OnHihGbPni3pwnc9L1++XKmpqdqzZ49Gjx6tQYMG6eOPP5Z0IVb9+/dX7969tXv3bv33f/+3nn/++cr614brlY+/3hLwqR9/17Hb7ba2bNliOZ1OKzk52UpMTLQaNmxouVwuz/orVqywWrZs6fluW8uyLJfLZQUGBlrvv/++ZVmWFRkZaU2fPt1zfWFhodWkSROv71Tu2rWrNWrUKMuyLGvv3r2WJGvLli2lzvjRRx9ZkqyzZ896lpXlO3XHjx9vtW7d2uv65557rsS2YDbOCcB4GzduVEhIiAoLC+V2u5WQkKBJkyZp+PDhatu2rdd5gC+//FL79+9XaGio1zby8/N14MABZWVl6cSJE7r11ls91zkcDnXs2LHES0IX7d69W35+fuX6RqyyfKfuN9984zWHJHXq1KnM9wEzEAEY7+KXngcEBCgqKkoOx//9bxEcHOy1bm5urjp06KA333yzxHYiIiKu6v4DAwPLfRu+UxcVhQjAeD/90vPLad++vVavXq0GDRooLCys1HUiIyP1+eef6/bbb5ckFRUVKSMjQ+3bty91/bZt28rtduvjjz9W9+7dS1x/8UikuLjYs6ws36nbqlUrbdiwwWvZZ599duUHCaNwYhgoh0ceeUT169dXnz599Mknn+jQoUNKS0vTyJEjdezYMUnSqFGjNHXqVK1fv17ffvutkpKSLvse/+bNmysxMVGPPfaY1q9f79nmxS9ab9asmWw2mzZu3KhTp04pNzdXoaGhnu/UXbZsmQ4cOKAvvvhCc+fO1bJlyyRJTz31lPbt26exY8dq7969euutt7R06dLK/leE6wwRAMohKChI27ZtU9OmTdW/f3+1atVKQ4cOVX5+vufI4Nlnn9Wjjz6qxMREderUSaGhoerXr99lt7tgwQI98MADSkpK0k033aTHH39c586dkyQ1btxYL730kp5//nk1bNhQI0aMkCS9/PLLevHFF5WSkqJWrVqpZ8+e2rRpk2JiYiRJTZs21bp167R+/XrFxcUpNTVVU6ZMqcR/O7ge8R3DAGAwjgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAMRgQAwGBEAAAM9v8BGgpDK8ITD7EAAAAASUVORK5CYII=\n"
           },
           "metadata": {}
         },
@@ -1912,10 +2141,267 @@
           "text": [
             "Saved predictions CSV: artifacts/manual_gen/bing/predictions.csv\n",
             "Saved confusion matrix PNG: artifacts/manual_gen/bing/confusion_matrix.png\n",
-            "Backed up to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/artifacts/manual_gen/bing\n"
+            "Backed up to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/artifacts/manual_gen/bing\n"
           ]
         }
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# =========================\n",
+        "# Real-only evaluation on OpenImagesV7 (all labels = 0)\n",
+        "# Reports false positive rate + fake-probability stats\n",
+        "# Also saves top-K most \"fake-looking\" real images to artifacts/\n",
+        "# =========================\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "from pathlib import Path\n",
+        "import shutil\n",
+        "\n",
+        "DEVICE = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+        "model = model.to(DEVICE)\n",
+        "model.eval()\n",
+        "\n",
+        "FAKE_IDX = 1\n",
+        "threshold = float(globals().get(\"THRESHOLD\", 0.5))\n",
+        "\n",
+        "# You should already have this from the earlier dataset cell\n",
+        "# openimages_real_loader yields (tensor, 0) for every image\n",
+        "if \"openimages_real_loader\" not in globals():\n",
+        "    raise NameError(\"openimages_real_loader not found. Run the OpenImagesV7 real-only loader cell first.\")\n",
+        "\n",
+        "# Optional: dataset with file paths for saving top-K examples\n",
+        "openimages_paths = None\n",
+        "if \"openimages_real_ds\" in globals() and hasattr(openimages_real_ds, \"paths\"):\n",
+        "    openimages_paths = openimages_real_ds.paths\n",
+        "\n",
+        "all_probs = []\n",
+        "all_preds = []\n",
+        "all_true = []\n",
+        "\n",
+        "# Track indices for top-K highest fake probability\n",
+        "TOP_K = int(globals().get(\"TOP_K\", 25))\n",
+        "top_scores = []\n",
+        "top_indices = []\n",
+        "\n",
+        "idx_base = 0\n",
+        "\n",
+        "with torch.inference_mode():\n",
+        "    for imgs, labels in openimages_real_loader:\n",
+        "        bs = imgs.size(0)\n",
+        "        imgs = imgs.to(DEVICE, non_blocking=True)\n",
+        "        labels = labels.to(DEVICE, non_blocking=True)\n",
+        "\n",
+        "        logits = model(imgs)\n",
+        "        probs_fake = torch.softmax(logits, dim=1)[:, FAKE_IDX]\n",
+        "\n",
+        "        preds = (probs_fake >= threshold).long()\n",
+        "\n",
+        "        probs_np = probs_fake.detach().cpu().numpy()\n",
+        "        preds_np = preds.detach().cpu().numpy()\n",
+        "        labels_np = labels.detach().cpu().numpy()\n",
+        "\n",
+        "        all_probs.append(probs_np)\n",
+        "        all_preds.append(preds_np)\n",
+        "        all_true.append(labels_np)\n",
+        "\n",
+        "        # Update top-K\n",
+        "        for i in range(bs):\n",
+        "            score = float(probs_np[i])\n",
+        "            global_idx = idx_base + i\n",
+        "            if len(top_scores) < TOP_K:\n",
+        "                top_scores.append(score)\n",
+        "                top_indices.append(global_idx)\n",
+        "            else:\n",
+        "                j = int(np.argmin(top_scores))\n",
+        "                if score > top_scores[j]:\n",
+        "                    top_scores[j] = score\n",
+        "                    top_indices[j] = global_idx\n",
+        "\n",
+        "        idx_base += bs\n",
+        "\n",
+        "probs = np.concatenate(all_probs)\n",
+        "preds = np.concatenate(all_preds)\n",
+        "true  = np.concatenate(all_true)  # should be all zeros\n",
+        "\n",
+        "# Metrics (real-only)\n",
+        "fpr = float((preds == 1).mean())\n",
+        "tnr = 1.0 - fpr\n",
+        "\n",
+        "print(\"=== OpenImagesV7 real-only evaluation ===\")\n",
+        "print(\"num images:\", len(true))\n",
+        "print(\"threshold:\", threshold)\n",
+        "print(\"false positive rate (pred fake on real):\", round(fpr, 4))\n",
+        "print(\"true negative rate / specificity:\", round(tnr, 4))\n",
+        "\n",
+        "print(\"\\nFake probability stats:\")\n",
+        "print(\"mean:\", round(float(probs.mean()), 4))\n",
+        "print(\"median:\", round(float(np.median(probs)), 4))\n",
+        "print(\"p90:\", round(float(np.quantile(probs, 0.90)), 4))\n",
+        "print(\"p95:\", round(float(np.quantile(probs, 0.95)), 4))\n",
+        "print(\"p99:\", round(float(np.quantile(probs, 0.99)), 4))\n",
+        "print(\"max:\", round(float(probs.max()), 4))\n",
+        "\n",
+        "# Save top-K images (most fake-looking) if we have paths\n",
+        "ARTIFACTS_DIR = Path(globals().get(\"ARTIFACTS_DIR\", \"artifacts\"))\n",
+        "out_dir = ARTIFACTS_DIR / \"openimages_real_topk\"\n",
+        "out_dir.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "if openimages_paths is not None:\n",
+        "    order = np.argsort(-np.array(top_scores))\n",
+        "    print(f\"\\nTop-{TOP_K} most fake-looking real images saved to: {out_dir}\")\n",
+        "    for rank, pos in enumerate(order, start=1):\n",
+        "        gi = int(top_indices[pos])\n",
+        "        score = float(top_scores[pos])\n",
+        "        src = Path(openimages_paths[gi])\n",
+        "        dst = out_dir / f\"{rank:02d}_p{score:.4f}__{src.name}\"\n",
+        "        try:\n",
+        "            shutil.copy2(src, dst)\n",
+        "        except Exception as e:\n",
+        "            print(\"copy failed:\", src, \"->\", dst, \"err:\", e)\n",
+        "else:\n",
+        "    print(\"\\nNote: could not save top-K images because dataset paths were not found (openimages_real_ds.paths missing).\")\n",
+        "\n",
+        "print(\"Checkpoint label_map:\", ckpt.get(\"label_map\"))\n",
+        "print(\"FAKE_IDX used:\", 1)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "uatBA79WRAqh",
+        "outputId": "a715e8c9-9ef4-4b23-d078-7610f4902ffe"
+      },
+      "id": "uatBA79WRAqh",
+      "execution_count": 35,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "=== OpenImagesV7 real-only evaluation ===\n",
+            "num images: 224\n",
+            "threshold: 0.5\n",
+            "false positive rate (pred fake on real): 0.5357\n",
+            "true negative rate / specificity: 0.4643\n",
+            "\n",
+            "Fake probability stats:\n",
+            "mean: 0.5099\n",
+            "median: 0.5516\n",
+            "p90: 0.9466\n",
+            "p95: 0.9607\n",
+            "p99: 0.9788\n",
+            "max: 0.9942\n",
+            "\n",
+            "Top-25 most fake-looking real images saved to: artifacts/openimages_real_topk\n",
+            "Checkpoint label_map: {'0': 'real', '1': 'fake'}\n",
+            "FAKE_IDX used: 1\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# =========================\n",
+        "# CELL A: Persist OpenImages prob_fake array for later threshold calibration\n",
+        "# Place right after the OpenImages real-only eval cell\n",
+        "# =========================\n",
+        "import numpy as np\n",
+        "\n",
+        "# If your eval cell already created `probs` as a numpy array, this keeps it.\n",
+        "if \"probs\" not in globals():\n",
+        "    raise NameError(\"Expected `probs` from OpenImages eval cell. Re-run the OpenImages real-only eval cell first.\")\n",
+        "\n",
+        "openimages_probs = np.array(probs, dtype=np.float32)\n",
+        "globals()[\"openimages_probs\"] = openimages_probs\n",
+        "\n",
+        "print(\"Saved openimages_probs with shape:\", openimages_probs.shape)\n",
+        "print(\"example values:\", openimages_probs[:5].tolist())"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Y9cMldI9WlQ8",
+        "outputId": "089e2597-097c-42a2-bb9a-9b50a39204f5"
+      },
+      "id": "Y9cMldI9WlQ8",
+      "execution_count": 43,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Saved openimages_probs with shape: (224,)\n",
+            "example values: [0.4485655725002289, 0.5918363332748413, 0.12234754115343094, 0.9718182682991028, 0.7128788232803345]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# =========================\n",
+        "# CELL B: Threshold calibration on OpenImages (real-only)\n",
+        "# Place after Cell A\n",
+        "# =========================\n",
+        "import numpy as np\n",
+        "\n",
+        "if \"openimages_probs\" not in globals():\n",
+        "    raise NameError(\"openimages_probs not found. Run Cell A first.\")\n",
+        "\n",
+        "p = openimages_probs\n",
+        "\n",
+        "targets = [0.20, 0.10, 0.05, 0.01]\n",
+        "print(\"Target FPR -> threshold -> actual FPR\")\n",
+        "for target in targets:\n",
+        "    thr = float(np.quantile(p, 1.0 - target))\n",
+        "    actual = float((p >= thr).mean())\n",
+        "    print(f\"{target:0.2f} -> {thr:.4f} -> {actual:.4f}\")\n",
+        "\n",
+        "# Pick one default recommendation (5% by default)\n",
+        "TARGET_FPR = float(globals().get(\"TARGET_FPR\", 0.05))\n",
+        "thr_reco = float(np.quantile(p, 1.0 - TARGET_FPR))\n",
+        "globals()[\"OPENIMAGES_THRESHOLD_RECOMMENDED\"] = thr_reco\n",
+        "\n",
+        "print(\"\\nRecommended threshold for target FPR =\", TARGET_FPR, \"is\", round(thr_reco, 4))"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Lu4gaXLVWm2a",
+        "outputId": "24fb0814-2d60-42c2-b960-c426b9413488"
+      },
+      "id": "Lu4gaXLVWm2a",
+      "execution_count": 44,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Target FPR -> threshold -> actual FPR\n",
+            "0.20 -> 0.8900 -> 0.2009\n",
+            "0.10 -> 0.9466 -> 0.1027\n",
+            "0.05 -> 0.9607 -> 0.0536\n",
+            "0.01 -> 0.9788 -> 0.0134\n",
+            "\n",
+            "Recommended threshold for target FPR = 0.05 is 0.9607\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "pQ1223nUWp9X"
+      },
+      "id": "pQ1223nUWp9X",
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1930,270 +2416,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 109,
+      "execution_count": null,
       "id": "7ba147a8",
       "metadata": {
-        "id": "7ba147a8",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 213
-        },
-        "outputId": "82ab0a22-9367-4b99-a3ff-4ea37417e43b"
+        "id": "7ba147a8"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Chosen threshold on OpenFake val (max F1): t=0.452 (F1=0.881)\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "                dataset     n  threshold    acc        f1     auroc   tn  fp  \\\n",
-              "0           A(OpenFake)  1000      0.452  0.869  0.880801  0.934774  385  93   \n",
-              "1  B(wildfake_2k_split)   400      0.452  0.940  0.937173  0.983275  197   3   \n",
-              "2             C(DRAGON)   188      0.452  1.000  1.000000  1.000000    5   0   \n",
-              "\n",
-              "   fn   tp  \n",
-              "0  38  484  \n",
-              "1  21  179  \n",
-              "2   0  183  "
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-2c191b03-f588-46be-86fd-2e3ffaf6d370\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>dataset</th>\n",
-              "      <th>n</th>\n",
-              "      <th>threshold</th>\n",
-              "      <th>acc</th>\n",
-              "      <th>f1</th>\n",
-              "      <th>auroc</th>\n",
-              "      <th>tn</th>\n",
-              "      <th>fp</th>\n",
-              "      <th>fn</th>\n",
-              "      <th>tp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>A(OpenFake)</td>\n",
-              "      <td>1000</td>\n",
-              "      <td>0.452</td>\n",
-              "      <td>0.869</td>\n",
-              "      <td>0.880801</td>\n",
-              "      <td>0.934774</td>\n",
-              "      <td>385</td>\n",
-              "      <td>93</td>\n",
-              "      <td>38</td>\n",
-              "      <td>484</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>B(wildfake_2k_split)</td>\n",
-              "      <td>400</td>\n",
-              "      <td>0.452</td>\n",
-              "      <td>0.940</td>\n",
-              "      <td>0.937173</td>\n",
-              "      <td>0.983275</td>\n",
-              "      <td>197</td>\n",
-              "      <td>3</td>\n",
-              "      <td>21</td>\n",
-              "      <td>179</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>C(DRAGON)</td>\n",
-              "      <td>188</td>\n",
-              "      <td>0.452</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.000000</td>\n",
-              "      <td>1.000000</td>\n",
-              "      <td>5</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>183</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-2c191b03-f588-46be-86fd-2e3ffaf6d370')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-2c191b03-f588-46be-86fd-2e3ffaf6d370 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-2c191b03-f588-46be-86fd-2e3ffaf6d370');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "  <div id=\"id_a8030c95-befa-475e-ab42-027b2073e949\">\n",
-              "    <style>\n",
-              "      .colab-df-generate {\n",
-              "        background-color: #E8F0FE;\n",
-              "        border: none;\n",
-              "        border-radius: 50%;\n",
-              "        cursor: pointer;\n",
-              "        display: none;\n",
-              "        fill: #1967D2;\n",
-              "        height: 32px;\n",
-              "        padding: 0 0 0 0;\n",
-              "        width: 32px;\n",
-              "      }\n",
-              "\n",
-              "      .colab-df-generate:hover {\n",
-              "        background-color: #E2EBFA;\n",
-              "        box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "        fill: #174EA6;\n",
-              "      }\n",
-              "\n",
-              "      [theme=dark] .colab-df-generate {\n",
-              "        background-color: #3B4455;\n",
-              "        fill: #D2E3FC;\n",
-              "      }\n",
-              "\n",
-              "      [theme=dark] .colab-df-generate:hover {\n",
-              "        background-color: #434B5C;\n",
-              "        box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "        filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "        fill: #FFFFFF;\n",
-              "      }\n",
-              "    </style>\n",
-              "    <button class=\"colab-df-generate\" onclick=\"generateWithVariable('metrics_df')\"\n",
-              "            title=\"Generate code using this dataframe.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M7,19H8.4L18.45,9,17,7.55,7,17.6ZM5,21V16.75L18.45,3.32a2,2,0,0,1,2.83,0l1.4,1.43a1.91,1.91,0,0,1,.58,1.4,1.91,1.91,0,0,1-.58,1.4L9.25,21ZM18.45,9,17,7.55Zm-12,3A5.31,5.31,0,0,0,4.9,8.1,5.31,5.31,0,0,0,1,6.5,5.31,5.31,0,0,0,4.9,4.9,5.31,5.31,0,0,0,6.5,1,5.31,5.31,0,0,0,8.1,4.9,5.31,5.31,0,0,0,12,6.5,5.46,5.46,0,0,0,6.5,12Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "    <script>\n",
-              "      (() => {\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#id_a8030c95-befa-475e-ab42-027b2073e949 button.colab-df-generate');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      buttonEl.onclick = () => {\n",
-              "        google.colab.notebook.generateWithVariable('metrics_df');\n",
-              "      }\n",
-              "      })();\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "    </div>\n",
-              "  </div>\n"
-            ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "dataframe",
-              "variable_name": "metrics_df",
-              "summary": "{\n  \"name\": \"metrics_df\",\n  \"rows\": 3,\n  \"fields\": [\n    {\n      \"column\": \"dataset\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 3,\n        \"samples\": [\n          \"A(OpenFake)\",\n          \"B(wildfake_2k_split)\",\n          \"C(DRAGON)\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"n\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 421,\n        \"min\": 188,\n        \"max\": 1000,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          1000,\n          400,\n          188\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"threshold\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.0,\n        \"min\": 0.452,\n        \"max\": 0.452,\n        \"num_unique_values\": 1,\n        \"samples\": [\n          0.452\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"acc\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.06557692683660414,\n        \"min\": 0.869,\n        \"max\": 1.0,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          0.869\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"f1\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.05962876033452794,\n        \"min\": 0.8808007279344859,\n        \"max\": 1.0,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          0.8808007279344859\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"auroc\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.03387862391754401,\n        \"min\": 0.934773721925648,\n        \"max\": 1.0,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          0.934773721925648\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"tn\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 190,\n        \"min\": 5,\n        \"max\": 385,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          385\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"fp\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 52,\n        \"min\": 0,\n        \"max\": 93,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          93\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"fn\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 19,\n        \"min\": 0,\n        \"max\": 38,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          38\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"tp\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 174,\n        \"min\": 179,\n        \"max\": 484,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          484\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Saved: artifacts/cross_dataset/cross_dataset_metrics.csv\n",
-            "Saved: artifacts/cross_dataset/threshold_note.txt\n",
-            "Saved plots in: artifacts/cross_dataset\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# =========================\n",
         "# CELL 8: Cross-dataset eval for Issue #38\n",
@@ -2458,32 +2686,11 @@
         "print(\"Backed up export folder to Drive:\", DRIVE_EXPORT_DIR)\n"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "pLOQ3MLa3H-Q",
-        "outputId": "61c38238-864b-40e6-ba38-5d588a675c0f"
+        "id": "pLOQ3MLa3H-Q"
       },
       "id": "pLOQ3MLa3H-Q",
-      "execution_count": 110,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Exported files: ['README.md', 'config.json', 'label_map.json', 'model.pth', 'preprocess.json']\n",
-            "Backed up export folder to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/export/cnn-transfer\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/tmp/ipython-input-105710457.py:36: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).\n",
-            "  \"exported_at_utc\": datetime.utcnow().isoformat() + \"Z\",\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -2500,7 +2707,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 111,
+      "execution_count": null,
       "id": "972c5fae",
       "metadata": {
         "id": "972c5fae"
@@ -2522,24 +2729,11 @@
         "print(\"HF_TOKEN_WRITE set for this runtime:\", \"yes\" if os.environ.get(\"HF_TOKEN_WRITE\") else \"no\")\n"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "OrM2ddRknDfG",
-        "outputId": "f348bfda-c08c-4335-9d52-78b119f41978"
+        "id": "OrM2ddRknDfG"
       },
       "id": "OrM2ddRknDfG",
-      "execution_count": 112,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Paste your Hugging Face WRITE token (input hidden): ··········\n",
-            "HF_TOKEN_WRITE set for this runtime: yes\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -2568,101 +2762,11 @@
         "print(f\"Uploaded to https://huggingface.co/{REPO_ID}\")\n"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 130,
-          "referenced_widgets": [
-            "5bc83e3ab1104eb896a98b755b1c02d5",
-            "6b391897da4d4efaabd4d9808e1ec8f4",
-            "924967b45f464648b7042cbf846fdf23",
-            "fe9ab045d8a34ab09445ee55ef2837c9",
-            "5abbd6edff364d81b4b9b2992f4826e5",
-            "b257e79754554063bbb885f5fe487a63",
-            "5bb4a5cdd5a641ce992f5c8957144d4c",
-            "dd72ac4904da4475931f9e8ad1348f95",
-            "120a46c7a21549a5b94f95af40c3ec44",
-            "3e24ec8bfb144df0ae15e534c5c1c207",
-            "9c49f310ae9e400495a1b2fe2ae5e236",
-            "1f81bcf509784ff59b04105fabe5f853",
-            "ccd8924b06904196a9e12a48e9f17f00",
-            "d4498f47b59c4082ae218c57db0d84d3",
-            "e58598bea9cd4e489ef628e0c279569d",
-            "cbda50617c364372a3d81483213b3fba",
-            "78a190fcfabe4ba28f181655dae16e07",
-            "7eb4fbd16c414b5883ea8301eb9f3fdc",
-            "bf10680035fe467a831fc5a6a6d876b3",
-            "981a20f25f574399874e03ebf641da16",
-            "a6145b51a5eb4b249de69ede0cbecae9",
-            "9a8fc12f13654525a01aa0522ee90262",
-            "348faf1e8f554fa5ba9534bccf20113d",
-            "f260abb9753a4eb2a4d5a785767fc713",
-            "ff3e934a0ff0489cbd75a6faf3e95402",
-            "5de9d5cd8cb04f46b9192e1242d69ff1",
-            "ef84496d828f4413a25f945fc5fa9050",
-            "2e4d8989ee424c00a67b35e911cd4837",
-            "7dbb7d0dda774c8893518e5403159a70",
-            "3331c96dfea64bb994926bb044d1ff16",
-            "63eaf9d6905742748f24f112e778ef29",
-            "b3761f92a01e4619b4c71a7308585888",
-            "3211f5fe4be6407c85d1b2726810c593"
-          ]
-        },
-        "id": "R_IY7zoz76jO",
-        "outputId": "2847e01c-74f8-4f29-c740-7b6a868e6a7b"
+        "id": "R_IY7zoz76jO"
       },
       "id": "R_IY7zoz76jO",
-      "execution_count": 113,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "Processing Files (0 / 0)      : |          |  0.00B /  0.00B            "
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "5bc83e3ab1104eb896a98b755b1c02d5"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "New Data Upload               : |          |  0.00B /  0.00B            "
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "1f81bcf509784ff59b04105fabe5f853"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "  ...rt/cnn-transfer/model.pth:   0%|          | 27.0kB / 16.3MB            "
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "348faf1e8f554fa5ba9534bccf20113d"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Uploaded to https://huggingface.co/DeepFakeDetector/cnn-transfer\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -2677,40 +2781,28 @@
         "print(\"whoami:\", whoami(token=tok))\n"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "MggGR1mzF1V4",
-        "outputId": "25fbb5aa-ff10-4046-af97-265b65538de6"
+        "id": "MggGR1mzF1V4"
       },
       "id": "MggGR1mzF1V4",
-      "execution_count": 114,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "HF_TOKEN_WRITE set: True\n",
-            "Token starts with: hf_pjhyK...\n",
-            "whoami: {'type': 'user', 'id': '69741c1471f36b2a96dc5db2', 'name': 'alifiscool86', 'fullname': 'Md Nafieu Hossain Alif', 'email': 'nafieu.alif@gmail.com', 'emailVerified': True, 'canPay': False, 'billingMode': 'prepaid', 'periodEnd': 1772323200, 'isPro': False, 'avatarUrl': '/avatars/fd79f39be30362b47b440060c7101194.svg', 'orgs': [{'type': 'org', 'id': '69877d9278a9e474fea8bc48', 'name': 'DeepFakeDetector', 'fullname': 'DeepFake Detector - MacAI Society', 'email': 'lukhsaankumar@gmail.com', 'canPay': False, 'billingMode': 'prepaid', 'periodEnd': 1772323200, 'avatarUrl': 'https://cdn-avatars.huggingface.co/v1/production/uploads/69877c9cd590f31fe07578cd/6IhAoE1DNJ6o6MWPkNbP9.jpeg', 'roleInOrg': 'write', 'isEnterprise': False}], 'auth': {'type': 'access_token', 'accessToken': {'displayName': 'something2', 'role': 'write', 'createdAt': '2026-02-21T10:52:32.325Z'}}}\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
       "source": [
         "# =========================\n",
         "# CELL 12: Reload test (download snapshot -> load -> 1 inference)\n",
-        "# Deterministic + token-safe + does not rely on earlier vars except build_model\n",
+        "# Deterministic + token-safe + NO build_model dependency\n",
         "# Saves a note to Drive if DRIVE_RUN_DIR exists\n",
         "# =========================\n",
         "\n",
         "import os, json\n",
         "from pathlib import Path\n",
         "import torch\n",
+        "import torch.nn as nn\n",
         "from huggingface_hub import snapshot_download\n",
         "from PIL import Image\n",
+        "from torchvision import models, transforms\n",
         "\n",
         "REPO_ID = \"DeepFakeDetector/cnn-transfer\"\n",
         "\n",
@@ -2725,7 +2817,7 @@
         "))\n",
         "print(\"Downloaded snapshot to:\", local_repo)\n",
         "\n",
-        "# 2) Load config + preprocess\n",
+        "# 2) Load config + preprocess + label map\n",
         "with open(local_repo / \"config.json\", \"r\") as f:\n",
         "    cfg = json.load(f)\n",
         "\n",
@@ -2736,21 +2828,28 @@
         "    label_map = json.load(f)\n",
         "\n",
         "# Enforce label convention: 0 real, 1 fake\n",
-        "assert label_map.get(\"0\") == \"real\" and label_map.get(\"1\") == \"fake\", f\"Bad label_map.json: {label_map}\"\n",
+        "assert str(label_map.get(\"0\")).lower() == \"real\" and str(label_map.get(\"1\")).lower() == \"fake\", f\"Bad label_map.json: {label_map}\"\n",
         "\n",
-        "# 3) Rebuild model exactly\n",
-        "arch = cfg[\"arch\"]\n",
-        "reload_model = build_model(arch, num_classes=2, freeze_backbone=False).to(\"cpu\")\n",
+        "# 3) Rebuild model exactly (no build_model)\n",
+        "arch = str(cfg.get(\"arch\", \"efficientnet_b0\")).lower()\n",
+        "\n",
+        "def build_from_arch(arch_name: str, num_classes: int = 2):\n",
+        "    if arch_name in [\"efficientnet_b0\", \"effnet_b0\", \"efficientnet\"]:\n",
+        "        m = models.efficientnet_b0(weights=None)  # weights None because we load state_dict\n",
+        "        in_features = m.classifier[1].in_features\n",
+        "        m.classifier[1] = nn.Linear(in_features, num_classes)\n",
+        "        return m\n",
+        "    raise ValueError(f\"Unsupported arch '{arch_name}' in reload test. Add mapping here.\")\n",
+        "\n",
+        "reload_model = build_from_arch(arch, num_classes=2).to(\"cpu\")\n",
         "\n",
         "state = torch.load(local_repo / \"model.pth\", map_location=\"cpu\")\n",
         "reload_model.load_state_dict(state)\n",
         "reload_model.eval()\n",
         "\n",
-        "# 4) Prepare one sample image\n",
-        "# Prefer using your existing OpenFake val sample if available, else try to find any local image in datasets\n",
+        "# 4) Pick one sample image\n",
         "sample_path = None\n",
         "\n",
-        "# Case A: if val_dir is defined earlier (OpenFake val folder), pick the first available image\n",
         "try:\n",
         "    if \"val_dir\" in globals():\n",
         "        for cls in [\"real\", \"fake\"]:\n",
@@ -2763,7 +2862,6 @@
         "except Exception:\n",
         "    pass\n",
         "\n",
-        "# Fallback: search common dataset locations\n",
         "if sample_path is None:\n",
         "    for base in [Path(\"datasets\"), Path(\"/content/datasets\"), Path(\"/content/drive/MyDrive/datasets\")]:\n",
         "        if base.exists():\n",
@@ -2774,29 +2872,39 @@
         "\n",
         "assert sample_path is not None, \"Could not find any image file for inference test.\"\n",
         "\n",
-        "# 5) Apply preprocess using pp info but reuse your val_tfms if it exists (keeps consistent pipeline)\n",
-        "# If val_tfms exists, use it. Otherwise, build a minimal transform from preprocess.json.\n",
-        "try:\n",
-        "    x = val_tfms(Image.open(sample_path).convert(\"RGB\")).unsqueeze(0)\n",
-        "except Exception:\n",
-        "    from torchvision import transforms\n",
+        "# 5) Preprocess\n",
+        "# Prefer using your existing val_tfms/val_tfm if present, otherwise use preprocess.json\n",
+        "img = Image.open(sample_path).convert(\"RGB\")\n",
+        "\n",
+        "x = None\n",
+        "if \"val_tfms\" in globals():\n",
+        "    try:\n",
+        "        x = val_tfms(img).unsqueeze(0)\n",
+        "    except Exception:\n",
+        "        x = None\n",
+        "if x is None and \"val_tfm\" in globals():\n",
+        "    try:\n",
+        "        x = val_tfm(img).unsqueeze(0)\n",
+        "    except Exception:\n",
+        "        x = None\n",
+        "\n",
+        "if x is None:\n",
         "    mean = pp[\"normalize\"][\"mean\"]\n",
         "    std  = pp[\"normalize\"][\"std\"]\n",
         "    size = int(pp[\"input_size\"])\n",
-        "    # center_crop is optional in pp; keep resize only for baseline\n",
         "    tfm = transforms.Compose([\n",
         "        transforms.Resize((size, size)),\n",
         "        transforms.ToTensor(),\n",
         "        transforms.Normalize(mean=mean, std=std),\n",
         "    ])\n",
-        "    x = tfm(Image.open(sample_path).convert(\"RGB\")).unsqueeze(0)\n",
+        "    x = tfm(img).unsqueeze(0)\n",
         "\n",
         "x = x.to(\"cpu\")\n",
         "\n",
         "# 6) Inference\n",
         "with torch.no_grad():\n",
         "    logits = reload_model(x)\n",
-        "    prob_fake = torch.softmax(logits, dim=1)[0, 1].item()  # index 1 == fake (fixed)\n",
+        "    prob_fake = torch.softmax(logits, dim=1)[0, 1].item()\n",
         "\n",
         "thr = float(cfg.get(\"threshold\", 0.5))\n",
         "pred = 1 if prob_fake >= thr else 0\n",
@@ -2807,12 +2915,13 @@
         "print(\"pred:\", pred, \"(0=real,1=fake)\")\n",
         "print(\"Reload test OK.\")\n",
         "\n",
-        "# 7) Save a small note in Drive if available\n",
+        "# 7) Save note in Drive if available\n",
         "try:\n",
         "    if \"DRIVE_RUN_DIR\" in globals():\n",
         "        Path(DRIVE_RUN_DIR).mkdir(parents=True, exist_ok=True)\n",
         "        (Path(DRIVE_RUN_DIR) / \"hf_reload_note.txt\").write_text(\n",
         "            f\"snapshot_download path: {local_repo}\\n\"\n",
+        "            f\"arch: {arch}\\n\"\n",
         "            f\"sample: {sample_path}\\n\"\n",
         "            f\"prob_fake: {prob_fake}\\n\"\n",
         "            f\"threshold: {thr}\\n\"\n",
@@ -2820,42 +2929,42 @@
         "        )\n",
         "        print(\"Saved reload note to Drive:\", Path(DRIVE_RUN_DIR) / \"hf_reload_note.txt\")\n",
         "except Exception as e:\n",
-        "    print(\"Drive note save skipped:\", e)\n"
+        "    print(\"Drive note save skipped:\", e)"
       ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 202,
+          "height": 209,
           "referenced_widgets": [
-            "0a6ead1968c0440499c31bc23f180efc",
-            "ae78bf2b414146aeb1d1cba00748aaff",
-            "92361787cdda4e96885b1993141ba5aa",
-            "1b44a78dea6e4171971127596a272c99",
-            "7e849b9d338e4098afcab85676e10699",
-            "4579098693a645678a86acd2eb7d555b",
-            "1e937859786f44419eb54235f1661e6d",
-            "3fa5a76bb8bf40dbb983121aca5b3e50",
-            "a1b8967d60474cb4bd7a2d87ededbd30",
-            "3698777aa8094d6ea9cc28760db90b62",
-            "781750630d6d4524becb43eae6b5fbce",
-            "79291de2cacd497eb3968e5ab7c773f5",
-            "b0d6b9cd2b8a4356ad34e1193ebbb4d8",
-            "8680cf2cbadf4bd0b8faf4614dfea37d",
-            "4222ed6d835543ffa5f06e5467074196",
-            "234ba6d082fc44bb8d066fd5f95354cb",
-            "f2a161f8d61d459ca8f2bf942689fc86",
-            "747e05b23fe148078f17bb35fb4afc0b",
-            "b211898cb926412aaf992e678b30d978",
-            "5c2c83cc48004586b9ab8f37e7476883",
-            "88701bdf45c745fe81d737ba84badfd5",
-            "1d30e34f63fc457496ef4cb6e0cca297"
+            "5736c29ded704f7e9f93e7437602d3da",
+            "2721d9862ac94d42969c0465b2ba378c",
+            "f5370c8ac7f64e0db4e129e01b9d0bff",
+            "84a0d31c91624655a250d749e5b6aee1",
+            "7fab41cab24f47deba7e3469d3ff1d6f",
+            "c1b315301d8341e2b3766ffc0e3d5a9b",
+            "8cc6dfdf90414ac0b714b4fc75c3bef9",
+            "364913a7268443649b940728cd5e7f37",
+            "22a509024b254df3ace70266dbf59551",
+            "ae7decf07ef74f7abca85ddc56fb5635",
+            "4786901abc9141ffbad5c3f827002dec",
+            "0ab784c130574fb0b34b42e54aa21393",
+            "69b7e70e639940afac14e25b65c4c3f5",
+            "d154bdf0a0a64b508c643fb4f9b39b3c",
+            "427907d2d54f4a9bb4a17ad85dcd3d54",
+            "268d0a68b0f74df2811b66564e9f4595",
+            "d08d5bb8e2e14c58a1805f6f956f290e",
+            "9630c21dbd0a44f285ef018798737c2f",
+            "219dba196add46f6ba54efd8c66fb967",
+            "34d3f079084540b7a37d81720ca2c9a4",
+            "b2dadc4e1c4c4548ab230b6da732285c",
+            "d14042a5da4a49ca8f5d507d8e213aef"
           ]
         },
         "id": "wIxVn0T878ea",
-        "outputId": "c2704797-5b76-42d7-a711-99cf89f94312"
+        "outputId": "363b11c8-ea7a-407e-f96b-a73d035fd960"
       },
       "id": "wIxVn0T878ea",
-      "execution_count": 115,
+      "execution_count": 38,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2866,7 +2975,7 @@
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
-              "model_id": "0a6ead1968c0440499c31bc23f180efc"
+              "model_id": "5736c29ded704f7e9f93e7437602d3da"
             }
           },
           "metadata": {}
@@ -2880,7 +2989,7 @@
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
-              "model_id": "79291de2cacd497eb3968e5ab7c773f5"
+              "model_id": "0ab784c130574fb0b34b42e54aa21393"
             }
           },
           "metadata": {}
@@ -2890,12 +2999,149 @@
           "name": "stdout",
           "text": [
             "Downloaded snapshot to: /root/.cache/huggingface/hub/models--DeepFakeDetector--cnn-transfer/snapshots/2296094e1a97b8ab67311eccc386cc3f85cbde64\n",
-            "Sample: /content/drive/MyDrive/datasets/OpenFake/test/real/test_0000002.jpg\n",
-            "prob_fake: 0.05438036099076271\n",
+            "Sample: /content/datasets/OpenImagesV7/all_real/train_0000000.jpg\n",
+            "prob_fake: 0.6831622123718262\n",
             "threshold: 0.452\n",
-            "pred: 0 (0=real,1=fake)\n",
+            "pred: 1 (0=real,1=fake)\n",
             "Reload test OK.\n",
-            "Saved reload note to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/hf_reload_note.txt\n"
+            "Saved reload note to Drive: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260223_151307/hf_reload_note.txt\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from pathlib import Path\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "from PIL import Image\n",
+        "from torchvision import transforms\n",
+        "\n",
+        "DEVICE = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+        "model.eval().to(DEVICE)\n",
+        "\n",
+        "# Use the same input size and normalization as your reload test pipeline\n",
+        "IM_SIZE = 224\n",
+        "mean = [0.485, 0.456, 0.406]\n",
+        "std  = [0.229, 0.224, 0.225]\n",
+        "tfm = transforms.Compose([\n",
+        "    transforms.Resize((IM_SIZE, IM_SIZE)),\n",
+        "    transforms.ToTensor(),\n",
+        "    transforms.Normalize(mean=mean, std=std),\n",
+        "])\n",
+        "\n",
+        "def collect_probs(folder: str, n=100):\n",
+        "    folder = Path(folder)\n",
+        "    paths = sorted([p for p in folder.rglob(\"*\") if p.suffix.lower() in [\".jpg\",\".jpeg\",\".png\",\".webp\"]])[:n]\n",
+        "    probs = []\n",
+        "    with torch.inference_mode():\n",
+        "        for p in paths:\n",
+        "            img = Image.open(p).convert(\"RGB\")\n",
+        "            x = tfm(img).unsqueeze(0).to(DEVICE)\n",
+        "            prob_fake = torch.softmax(model(x), dim=1)[0, 1].item()\n",
+        "            probs.append(prob_fake)\n",
+        "    probs = np.array(probs, dtype=np.float32)\n",
+        "    return probs\n",
+        "\n",
+        "# TODO: update these paths to a dataset you have\n",
+        "REAL_DIR = \"/content/dataset_local_OpenFake/test/real\"\n",
+        "FAKE_DIR = \"/content/dataset_local_wildfake_2k_split/test/fake\"\n",
+        "\n",
+        "real_probs = collect_probs(REAL_DIR, n=100)\n",
+        "fake_probs = collect_probs(FAKE_DIR, n=100)\n",
+        "\n",
+        "thr = 0.452  # from cfg threshold\n",
+        "real_fpr = float((real_probs >= thr).mean())\n",
+        "fake_tpr = float((fake_probs >= thr).mean())\n",
+        "\n",
+        "print(\"threshold:\", thr)\n",
+        "print(\"real median prob_fake:\", float(np.median(real_probs)), \"FPR on real:\", real_fpr)\n",
+        "print(\"fake median prob_fake:\", float(np.median(fake_probs)), \"TPR on fake:\", fake_tpr)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "RzSmZ7IKTeZs",
+        "outputId": "7aa36862-37ad-4425-dbe8-2ae9d8458e7b"
+      },
+      "id": "RzSmZ7IKTeZs",
+      "execution_count": 42,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "threshold: 0.452\n",
+            "real median prob_fake: 0.07866908609867096 FPR on real: 0.18\n",
+            "fake median prob_fake: 0.8897912502288818 TPR on fake: 0.88\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# =========================\n",
+        "# CELL C: Compare default threshold vs calibrated OpenImages threshold\n",
+        "# Place after you have real_probs and fake_probs from the real/fake sanity test\n",
+        "# =========================\n",
+        "import numpy as np\n",
+        "\n",
+        "if \"real_probs\" not in globals() or \"fake_probs\" not in globals():\n",
+        "    raise NameError(\"real_probs/fake_probs not found. Run your real-vs-fake sanity test cell first.\")\n",
+        "\n",
+        "default_thr = float(globals().get(\"DEFAULT_THRESHOLD\", 0.452))  # from your HF config.json\n",
+        "reco_thr = float(globals().get(\"OPENIMAGES_THRESHOLD_RECOMMENDED\", default_thr))\n",
+        "\n",
+        "def _rate(probs, thr):\n",
+        "    probs = np.array(probs, dtype=np.float32)\n",
+        "    return float((probs >= thr).mean())\n",
+        "\n",
+        "print(\"=== Threshold comparison ===\")\n",
+        "print(\"default_thr:\", default_thr)\n",
+        "print(\"reco_thr (OpenImages calibrated):\", round(reco_thr, 4))\n",
+        "\n",
+        "print(\"\\nIn-distribution real/fake rates\")\n",
+        "print(\"FPR on real at default:\", round(_rate(real_probs, default_thr), 4))\n",
+        "print(\"TPR on fake at default:\", round(_rate(fake_probs, default_thr), 4))\n",
+        "\n",
+        "print(\"FPR on real at reco  :\", round(_rate(real_probs, reco_thr), 4))\n",
+        "print(\"TPR on fake at reco  :\", round(_rate(fake_probs, reco_thr), 4))\n",
+        "\n",
+        "print(\"\\nOpenImages real-only FPR at reco threshold\")\n",
+        "if \"openimages_probs\" in globals():\n",
+        "    print(\"FPR on OpenImages at reco:\", round(_rate(openimages_probs, reco_thr), 4))\n",
+        "else:\n",
+        "    print(\"openimages_probs missing, run Cell A first.\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "P9Ahd81ZWzam",
+        "outputId": "4e43d1ec-1241-4797-a0d7-0957019d26a7"
+      },
+      "id": "P9Ahd81ZWzam",
+      "execution_count": 45,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "=== Threshold comparison ===\n",
+            "default_thr: 0.452\n",
+            "reco_thr (OpenImages calibrated): 0.9607\n",
+            "\n",
+            "In-distribution real/fake rates\n",
+            "FPR on real at default: 0.18\n",
+            "TPR on fake at default: 0.88\n",
+            "FPR on real at reco  : 0.0\n",
+            "TPR on fake at reco  : 0.24\n",
+            "\n",
+            "OpenImages real-only FPR at reco threshold\n",
+            "FPR on OpenImages at reco: 0.0536\n"
           ]
         }
       ]
@@ -2915,28 +3161,11 @@
         "print(\"If upload succeeded, HF repo should contain: model.pth, config.json, preprocess.json, label_map.json, README.md\")\n"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "bACpgdff7-sE",
-        "outputId": "1f1a70fa-cc2b-43fb-8697-1efefffe96f7"
+        "id": "bACpgdff7-sE"
       },
       "id": "bACpgdff7-sE",
-      "execution_count": 116,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Local best checkpoint: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/checkpoints/best_efficientnet_b0.pt\n",
-            "Drive run folder: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618\n",
-            "Drive checkpoints: ['best_efficientnet_b0.pt']\n",
-            "Drive artifacts: []\n",
-            "Drive export: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/export/cnn-transfer\n",
-            "If upload succeeded, HF repo should contain: model.pth, config.json, preprocess.json, label_map.json, README.md\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -3169,272 +3398,11 @@
         "print(\"- folder:\", DRIVE_CROSS_DIR)\n"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 351
-        },
-        "id": "ss_CU8BSHmpa",
-        "outputId": "d9a2c552-23ec-43a8-df87-ab04766e02db"
+        "id": "ss_CU8BSHmpa"
       },
       "id": "ss_CU8BSHmpa",
-      "execution_count": 117,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "A(OpenFake) n= 1000\n",
-            "B(WildFake) n= 400\n",
-            "C(DRAGON)   n= 188\n",
-            "Label map enforced: {'real': 0, 'fake': 1}\n",
-            "Chosen threshold on A(OpenFake) val by max F1: t=0.452 (F1=0.881)\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "      dataset     n  threshold    acc        f1     auroc   tn  fp  fn   tp\n",
-              "0  A_OpenFake  1000      0.452  0.869  0.880801  0.934774  385  93  38  484\n",
-              "1  B_WildFake   400      0.452  0.940  0.937173  0.983275  197   3  21  179\n",
-              "2    C_DRAGON   188      0.452  1.000  1.000000  1.000000    5   0   0  183"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-b134592a-e3e0-4c06-860e-c2cfbc7d39b5\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>dataset</th>\n",
-              "      <th>n</th>\n",
-              "      <th>threshold</th>\n",
-              "      <th>acc</th>\n",
-              "      <th>f1</th>\n",
-              "      <th>auroc</th>\n",
-              "      <th>tn</th>\n",
-              "      <th>fp</th>\n",
-              "      <th>fn</th>\n",
-              "      <th>tp</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>A_OpenFake</td>\n",
-              "      <td>1000</td>\n",
-              "      <td>0.452</td>\n",
-              "      <td>0.869</td>\n",
-              "      <td>0.880801</td>\n",
-              "      <td>0.934774</td>\n",
-              "      <td>385</td>\n",
-              "      <td>93</td>\n",
-              "      <td>38</td>\n",
-              "      <td>484</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>B_WildFake</td>\n",
-              "      <td>400</td>\n",
-              "      <td>0.452</td>\n",
-              "      <td>0.940</td>\n",
-              "      <td>0.937173</td>\n",
-              "      <td>0.983275</td>\n",
-              "      <td>197</td>\n",
-              "      <td>3</td>\n",
-              "      <td>21</td>\n",
-              "      <td>179</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>C_DRAGON</td>\n",
-              "      <td>188</td>\n",
-              "      <td>0.452</td>\n",
-              "      <td>1.000</td>\n",
-              "      <td>1.000000</td>\n",
-              "      <td>1.000000</td>\n",
-              "      <td>5</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>183</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-b134592a-e3e0-4c06-860e-c2cfbc7d39b5')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-b134592a-e3e0-4c06-860e-c2cfbc7d39b5 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-b134592a-e3e0-4c06-860e-c2cfbc7d39b5');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "  <div id=\"id_8b7e44b6-872c-4fbf-8a56-6571e5658e03\">\n",
-              "    <style>\n",
-              "      .colab-df-generate {\n",
-              "        background-color: #E8F0FE;\n",
-              "        border: none;\n",
-              "        border-radius: 50%;\n",
-              "        cursor: pointer;\n",
-              "        display: none;\n",
-              "        fill: #1967D2;\n",
-              "        height: 32px;\n",
-              "        padding: 0 0 0 0;\n",
-              "        width: 32px;\n",
-              "      }\n",
-              "\n",
-              "      .colab-df-generate:hover {\n",
-              "        background-color: #E2EBFA;\n",
-              "        box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "        fill: #174EA6;\n",
-              "      }\n",
-              "\n",
-              "      [theme=dark] .colab-df-generate {\n",
-              "        background-color: #3B4455;\n",
-              "        fill: #D2E3FC;\n",
-              "      }\n",
-              "\n",
-              "      [theme=dark] .colab-df-generate:hover {\n",
-              "        background-color: #434B5C;\n",
-              "        box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "        filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "        fill: #FFFFFF;\n",
-              "      }\n",
-              "    </style>\n",
-              "    <button class=\"colab-df-generate\" onclick=\"generateWithVariable('metrics_df')\"\n",
-              "            title=\"Generate code using this dataframe.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M7,19H8.4L18.45,9,17,7.55,7,17.6ZM5,21V16.75L18.45,3.32a2,2,0,0,1,2.83,0l1.4,1.43a1.91,1.91,0,0,1,.58,1.4,1.91,1.91,0,0,1-.58,1.4L9.25,21ZM18.45,9,17,7.55Zm-12,3A5.31,5.31,0,0,0,4.9,8.1,5.31,5.31,0,0,0,1,6.5,5.31,5.31,0,0,0,4.9,4.9,5.31,5.31,0,0,0,6.5,1,5.31,5.31,0,0,0,8.1,4.9,5.31,5.31,0,0,0,12,6.5,5.46,5.46,0,0,0,6.5,12Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "    <script>\n",
-              "      (() => {\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#id_8b7e44b6-872c-4fbf-8a56-6571e5658e03 button.colab-df-generate');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      buttonEl.onclick = () => {\n",
-              "        google.colab.notebook.generateWithVariable('metrics_df');\n",
-              "      }\n",
-              "      })();\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "    </div>\n",
-              "  </div>\n"
-            ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "dataframe",
-              "variable_name": "metrics_df",
-              "summary": "{\n  \"name\": \"metrics_df\",\n  \"rows\": 3,\n  \"fields\": [\n    {\n      \"column\": \"dataset\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 3,\n        \"samples\": [\n          \"A_OpenFake\",\n          \"B_WildFake\",\n          \"C_DRAGON\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"n\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 421,\n        \"min\": 188,\n        \"max\": 1000,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          1000,\n          400,\n          188\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"threshold\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.0,\n        \"min\": 0.452,\n        \"max\": 0.452,\n        \"num_unique_values\": 1,\n        \"samples\": [\n          0.452\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"acc\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.06557692683660414,\n        \"min\": 0.869,\n        \"max\": 1.0,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          0.869\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"f1\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.05962876033452794,\n        \"min\": 0.8808007279344859,\n        \"max\": 1.0,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          0.8808007279344859\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"auroc\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.03387862391754401,\n        \"min\": 0.934773721925648,\n        \"max\": 1.0,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          0.934773721925648\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"tn\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 190,\n        \"min\": 5,\n        \"max\": 385,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          385\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"fp\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 52,\n        \"min\": 0,\n        \"max\": 93,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          93\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"fn\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 19,\n        \"min\": 0,\n        \"max\": 38,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          38\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"tp\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 174,\n        \"min\": 179,\n        \"max\": 484,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          484\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Saved: artifacts/cross_dataset_metrics.csv\n",
-            "Saved: artifacts/threshold_note.txt\n",
-            "Saved plots in: artifacts/cross_dataset\n",
-            "Backed up to Drive:\n",
-            "- metrics: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/artifacts/cross_dataset_metrics.csv\n",
-            "- note: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/artifacts/threshold_note.txt\n",
-            "- folder: /content/drive/MyDrive/DeepFakeDetector_runs/cnn_transfer_20260221_145618/artifacts/cross_dataset\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     }
   ],
   "metadata": {
@@ -3461,7 +3429,7 @@
     "accelerator": "GPU",
     "widgets": {
       "application/vnd.jupyter.widget-state+json": {
-        "a17cbad31ff744018b5dfc383d3e4313": {
+        "c7383fcce16b4905aaa5445a7fd069e1": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "model_module_version": "1.5.0",
@@ -3476,14 +3444,14 @@
             "_view_name": "HBoxView",
             "box_style": "",
             "children": [
-              "IPY_MODEL_6dd5f95388904f3dafb77f123a2ce5de",
-              "IPY_MODEL_058980ccdc8a41b5835a68bf4c5e47f0",
-              "IPY_MODEL_01f1dab53ad741d795950a9d037d31b9"
+              "IPY_MODEL_f869c4716b63408b8d3cd41d8ac972ee",
+              "IPY_MODEL_877bbcf1f6c04f56b1e2df82c746bce1",
+              "IPY_MODEL_d9771e27654c43729497aa0386972f11"
             ],
-            "layout": "IPY_MODEL_9e1f9d70014c4ecb91fb6baf3dcd07e3"
+            "layout": "IPY_MODEL_46fbdacbdaa94979b0c60e29838566a4"
           }
         },
-        "6dd5f95388904f3dafb77f123a2ce5de": {
+        "f869c4716b63408b8d3cd41d8ac972ee": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "model_module_version": "1.5.0",
@@ -3498,13 +3466,13 @@
             "_view_name": "HTMLView",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_4e0f30ea6c1244e5be22d1fa335b88fd",
+            "layout": "IPY_MODEL_732403fd89bd4145a0b37bc1b5a7910e",
             "placeholder": "​",
-            "style": "IPY_MODEL_6319a545d5c94684bd3245247025f6a0",
+            "style": "IPY_MODEL_ab78c10630e34d3182659c93efd43fef",
             "value": "Download complete: "
           }
         },
-        "058980ccdc8a41b5835a68bf4c5e47f0": {
+        "877bbcf1f6c04f56b1e2df82c746bce1": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "model_module_version": "1.5.0",
@@ -3517,18 +3485,18 @@
             "_view_module": "@jupyter-widgets/controls",
             "_view_module_version": "1.5.0",
             "_view_name": "ProgressView",
-            "bar_style": "success",
+            "bar_style": "info",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_6fe13f08415e4c27a5fae95743cc69ed",
+            "layout": "IPY_MODEL_7b63868d5a8944ceaaca3f0827917cca",
             "max": 1,
             "min": 0,
             "orientation": "horizontal",
-            "style": "IPY_MODEL_3106ab85d5e14210b63501ce92e5f35b",
+            "style": "IPY_MODEL_510fd3b54c6c4d50baea1d378fa2b11d",
             "value": 0
           }
         },
-        "01f1dab53ad741d795950a9d037d31b9": {
+        "d9771e27654c43729497aa0386972f11": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "model_module_version": "1.5.0",
@@ -3543,13 +3511,13 @@
             "_view_name": "HTMLView",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_dd59225f63ee4ba19769972a984bd357",
+            "layout": "IPY_MODEL_1a98080308e14dec97d417ab1c4604ae",
             "placeholder": "​",
-            "style": "IPY_MODEL_a2559add679a43cba5bb5b185545e6f7",
-            "value": " 0.00/0.00 [00:04&lt;?, ?B/s]"
+            "style": "IPY_MODEL_f9b9ea2e40e84ae7a0582da867d248a2",
+            "value": " 0.00/0.00 [00:00&lt;?, ?B/s]"
           }
         },
-        "9e1f9d70014c4ecb91fb6baf3dcd07e3": {
+        "46fbdacbdaa94979b0c60e29838566a4": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -3601,7 +3569,7 @@
             "width": null
           }
         },
-        "4e0f30ea6c1244e5be22d1fa335b88fd": {
+        "732403fd89bd4145a0b37bc1b5a7910e": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -3653,7 +3621,7 @@
             "width": null
           }
         },
-        "6319a545d5c94684bd3245247025f6a0": {
+        "ab78c10630e34d3182659c93efd43fef": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "model_module_version": "1.5.0",
@@ -3668,7 +3636,7 @@
             "description_width": ""
           }
         },
-        "6fe13f08415e4c27a5fae95743cc69ed": {
+        "7b63868d5a8944ceaaca3f0827917cca": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -3720,7 +3688,7 @@
             "width": "20px"
           }
         },
-        "3106ab85d5e14210b63501ce92e5f35b": {
+        "510fd3b54c6c4d50baea1d378fa2b11d": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "model_module_version": "1.5.0",
@@ -3736,7 +3704,7 @@
             "description_width": ""
           }
         },
-        "dd59225f63ee4ba19769972a984bd357": {
+        "1a98080308e14dec97d417ab1c4604ae": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -3788,7 +3756,7 @@
             "width": null
           }
         },
-        "a2559add679a43cba5bb5b185545e6f7": {
+        "f9b9ea2e40e84ae7a0582da867d248a2": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "model_module_version": "1.5.0",
@@ -3803,7 +3771,7 @@
             "description_width": ""
           }
         },
-        "ab7364c7fff9415b86912e7cf606639f": {
+        "88c8cb62564d4be8a51bea5ac71fe728": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "model_module_version": "1.5.0",
@@ -3818,14 +3786,14 @@
             "_view_name": "HBoxView",
             "box_style": "",
             "children": [
-              "IPY_MODEL_ef50a14f074842eabea1118b4ff9a3b8",
-              "IPY_MODEL_65fc736e55534108a5c53dffe37440bd",
-              "IPY_MODEL_fd2869226e3d4c1c90d73c070e403d6a"
+              "IPY_MODEL_4a335999aa994e858e57238173dd64e3",
+              "IPY_MODEL_57c819d2ae6c4178bcb189ae0a7d9ac3",
+              "IPY_MODEL_b45e18ab75d14e98b30b77830b1e960d"
             ],
-            "layout": "IPY_MODEL_9160e205b63148cdbd078db85d46b532"
+            "layout": "IPY_MODEL_501eaca223d74c96a2291a1d45af0705"
           }
         },
-        "ef50a14f074842eabea1118b4ff9a3b8": {
+        "4a335999aa994e858e57238173dd64e3": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "model_module_version": "1.5.0",
@@ -3840,13 +3808,13 @@
             "_view_name": "HTMLView",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_9a10bd8b36384867ae53de50b5e019bc",
+            "layout": "IPY_MODEL_a67092d3167e4c8faa2979668e7b7f68",
             "placeholder": "​",
-            "style": "IPY_MODEL_13ac59433fd446a5b1bde2d44dd5eb63",
+            "style": "IPY_MODEL_4eb7213e634a466c9b31fc91419eb698",
             "value": "Fetching 331 files: 100%"
           }
         },
-        "65fc736e55534108a5c53dffe37440bd": {
+        "57c819d2ae6c4178bcb189ae0a7d9ac3": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "model_module_version": "1.5.0",
@@ -3862,15 +3830,15 @@
             "bar_style": "success",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_407038f302ca43cc9bdbe27b832e429a",
+            "layout": "IPY_MODEL_080065ebf5644f589cbe433dc6997355",
             "max": 331,
             "min": 0,
             "orientation": "horizontal",
-            "style": "IPY_MODEL_562827e04f434fb7adf730ca43ed1184",
+            "style": "IPY_MODEL_9437b3d5d9954c4f8741599fd72ae8c6",
             "value": 331
           }
         },
-        "fd2869226e3d4c1c90d73c070e403d6a": {
+        "b45e18ab75d14e98b30b77830b1e960d": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "model_module_version": "1.5.0",
@@ -3885,13 +3853,13 @@
             "_view_name": "HTMLView",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_11fa00a7ea1c4819b57cf0ff5087d15f",
+            "layout": "IPY_MODEL_7f2910ab7fef4d388067ec8d6aa2b2dc",
             "placeholder": "​",
-            "style": "IPY_MODEL_9b612bca1f28424a9aeda31914b3def8",
-            "value": " 331/331 [00:00&lt;00:00, 4206.34it/s]"
+            "style": "IPY_MODEL_e9415563029149b4b9130ac29db3682b",
+            "value": " 331/331 [00:00&lt;00:00, 3578.91it/s]"
           }
         },
-        "9160e205b63148cdbd078db85d46b532": {
+        "501eaca223d74c96a2291a1d45af0705": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -3943,7 +3911,7 @@
             "width": null
           }
         },
-        "9a10bd8b36384867ae53de50b5e019bc": {
+        "a67092d3167e4c8faa2979668e7b7f68": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -3995,7 +3963,7 @@
             "width": null
           }
         },
-        "13ac59433fd446a5b1bde2d44dd5eb63": {
+        "4eb7213e634a466c9b31fc91419eb698": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "model_module_version": "1.5.0",
@@ -4010,7 +3978,7 @@
             "description_width": ""
           }
         },
-        "407038f302ca43cc9bdbe27b832e429a": {
+        "080065ebf5644f589cbe433dc6997355": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -4062,7 +4030,7 @@
             "width": null
           }
         },
-        "562827e04f434fb7adf730ca43ed1184": {
+        "9437b3d5d9954c4f8741599fd72ae8c6": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "model_module_version": "1.5.0",
@@ -4078,7 +4046,7 @@
             "description_width": ""
           }
         },
-        "11fa00a7ea1c4819b57cf0ff5087d15f": {
+        "7f2910ab7fef4d388067ec8d6aa2b2dc": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -4130,7 +4098,7 @@
             "width": null
           }
         },
-        "9b612bca1f28424a9aeda31914b3def8": {
+        "e9415563029149b4b9130ac29db3682b": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "model_module_version": "1.5.0",
@@ -4145,7 +4113,7 @@
             "description_width": ""
           }
         },
-        "5bc83e3ab1104eb896a98b755b1c02d5": {
+        "5736c29ded704f7e9f93e7437602d3da": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "model_module_version": "1.5.0",
@@ -4160,14 +4128,14 @@
             "_view_name": "HBoxView",
             "box_style": "",
             "children": [
-              "IPY_MODEL_6b391897da4d4efaabd4d9808e1ec8f4",
-              "IPY_MODEL_924967b45f464648b7042cbf846fdf23",
-              "IPY_MODEL_fe9ab045d8a34ab09445ee55ef2837c9"
+              "IPY_MODEL_2721d9862ac94d42969c0465b2ba378c",
+              "IPY_MODEL_f5370c8ac7f64e0db4e129e01b9d0bff",
+              "IPY_MODEL_84a0d31c91624655a250d749e5b6aee1"
             ],
-            "layout": "IPY_MODEL_5abbd6edff364d81b4b9b2992f4826e5"
+            "layout": "IPY_MODEL_7fab41cab24f47deba7e3469d3ff1d6f"
           }
         },
-        "6b391897da4d4efaabd4d9808e1ec8f4": {
+        "2721d9862ac94d42969c0465b2ba378c": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "model_module_version": "1.5.0",
@@ -4182,13 +4150,13 @@
             "_view_name": "HTMLView",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_b257e79754554063bbb885f5fe487a63",
+            "layout": "IPY_MODEL_c1b315301d8341e2b3766ffc0e3d5a9b",
             "placeholder": "​",
-            "style": "IPY_MODEL_5bb4a5cdd5a641ce992f5c8957144d4c",
-            "value": "Processing Files (1 / 1)      : 100%"
+            "style": "IPY_MODEL_8cc6dfdf90414ac0b714b4fc75c3bef9",
+            "value": "Download complete: "
           }
         },
-        "924967b45f464648b7042cbf846fdf23": {
+        "f5370c8ac7f64e0db4e129e01b9d0bff": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "model_module_version": "1.5.0",
@@ -4204,15 +4172,15 @@
             "bar_style": "success",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_dd72ac4904da4475931f9e8ad1348f95",
+            "layout": "IPY_MODEL_364913a7268443649b940728cd5e7f37",
             "max": 1,
             "min": 0,
             "orientation": "horizontal",
-            "style": "IPY_MODEL_120a46c7a21549a5b94f95af40c3ec44",
-            "value": 1
+            "style": "IPY_MODEL_22a509024b254df3ace70266dbf59551",
+            "value": 0
           }
         },
-        "fe9ab045d8a34ab09445ee55ef2837c9": {
+        "84a0d31c91624655a250d749e5b6aee1": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "model_module_version": "1.5.0",
@@ -4227,13 +4195,13 @@
             "_view_name": "HTMLView",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_3e24ec8bfb144df0ae15e534c5c1c207",
+            "layout": "IPY_MODEL_ae7decf07ef74f7abca85ddc56fb5635",
             "placeholder": "​",
-            "style": "IPY_MODEL_9c49f310ae9e400495a1b2fe2ae5e236",
-            "value": " 16.3MB / 16.3MB, 3.88MB/s  "
+            "style": "IPY_MODEL_4786901abc9141ffbad5c3f827002dec",
+            "value": " 0.00/0.00 [00:00&lt;?, ?B/s]"
           }
         },
-        "5abbd6edff364d81b4b9b2992f4826e5": {
+        "7fab41cab24f47deba7e3469d3ff1d6f": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -4285,7 +4253,7 @@
             "width": null
           }
         },
-        "b257e79754554063bbb885f5fe487a63": {
+        "c1b315301d8341e2b3766ffc0e3d5a9b": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -4337,7 +4305,7 @@
             "width": null
           }
         },
-        "5bb4a5cdd5a641ce992f5c8957144d4c": {
+        "8cc6dfdf90414ac0b714b4fc75c3bef9": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "model_module_version": "1.5.0",
@@ -4352,7 +4320,7 @@
             "description_width": ""
           }
         },
-        "dd72ac4904da4475931f9e8ad1348f95": {
+        "364913a7268443649b940728cd5e7f37": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -4404,7 +4372,7 @@
             "width": "20px"
           }
         },
-        "120a46c7a21549a5b94f95af40c3ec44": {
+        "22a509024b254df3ace70266dbf59551": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "model_module_version": "1.5.0",
@@ -4420,7 +4388,7 @@
             "description_width": ""
           }
         },
-        "3e24ec8bfb144df0ae15e534c5c1c207": {
+        "ae7decf07ef74f7abca85ddc56fb5635": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -4472,7 +4440,7 @@
             "width": null
           }
         },
-        "9c49f310ae9e400495a1b2fe2ae5e236": {
+        "4786901abc9141ffbad5c3f827002dec": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "model_module_version": "1.5.0",
@@ -4487,7 +4455,7 @@
             "description_width": ""
           }
         },
-        "1f81bcf509784ff59b04105fabe5f853": {
+        "0ab784c130574fb0b34b42e54aa21393": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HBoxModel",
           "model_module_version": "1.5.0",
@@ -4502,14 +4470,14 @@
             "_view_name": "HBoxView",
             "box_style": "",
             "children": [
-              "IPY_MODEL_ccd8924b06904196a9e12a48e9f17f00",
-              "IPY_MODEL_d4498f47b59c4082ae218c57db0d84d3",
-              "IPY_MODEL_e58598bea9cd4e489ef628e0c279569d"
+              "IPY_MODEL_69b7e70e639940afac14e25b65c4c3f5",
+              "IPY_MODEL_d154bdf0a0a64b508c643fb4f9b39b3c",
+              "IPY_MODEL_427907d2d54f4a9bb4a17ad85dcd3d54"
             ],
-            "layout": "IPY_MODEL_cbda50617c364372a3d81483213b3fba"
+            "layout": "IPY_MODEL_268d0a68b0f74df2811b66564e9f4595"
           }
         },
-        "ccd8924b06904196a9e12a48e9f17f00": {
+        "69b7e70e639940afac14e25b65c4c3f5": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "model_module_version": "1.5.0",
@@ -4524,1039 +4492,13 @@
             "_view_name": "HTMLView",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_78a190fcfabe4ba28f181655dae16e07",
+            "layout": "IPY_MODEL_d08d5bb8e2e14c58a1805f6f956f290e",
             "placeholder": "​",
-            "style": "IPY_MODEL_7eb4fbd16c414b5883ea8301eb9f3fdc",
-            "value": "New Data Upload               : 100%"
-          }
-        },
-        "d4498f47b59c4082ae218c57db0d84d3": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_bf10680035fe467a831fc5a6a6d876b3",
-            "max": 1,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_981a20f25f574399874e03ebf641da16",
-            "value": 1
-          }
-        },
-        "e58598bea9cd4e489ef628e0c279569d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_a6145b51a5eb4b249de69ede0cbecae9",
-            "placeholder": "​",
-            "style": "IPY_MODEL_9a8fc12f13654525a01aa0522ee90262",
-            "value": " 16.3MB / 16.3MB, 3.88MB/s  "
-          }
-        },
-        "cbda50617c364372a3d81483213b3fba": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "78a190fcfabe4ba28f181655dae16e07": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "7eb4fbd16c414b5883ea8301eb9f3fdc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "bf10680035fe467a831fc5a6a6d876b3": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": "20px"
-          }
-        },
-        "981a20f25f574399874e03ebf641da16": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "a6145b51a5eb4b249de69ede0cbecae9": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "9a8fc12f13654525a01aa0522ee90262": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "348faf1e8f554fa5ba9534bccf20113d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_f260abb9753a4eb2a4d5a785767fc713",
-              "IPY_MODEL_ff3e934a0ff0489cbd75a6faf3e95402",
-              "IPY_MODEL_5de9d5cd8cb04f46b9192e1242d69ff1"
-            ],
-            "layout": "IPY_MODEL_ef84496d828f4413a25f945fc5fa9050"
-          }
-        },
-        "f260abb9753a4eb2a4d5a785767fc713": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_2e4d8989ee424c00a67b35e911cd4837",
-            "placeholder": "​",
-            "style": "IPY_MODEL_7dbb7d0dda774c8893518e5403159a70",
-            "value": "  ...rt/cnn-transfer/model.pth: 100%"
-          }
-        },
-        "ff3e934a0ff0489cbd75a6faf3e95402": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_3331c96dfea64bb994926bb044d1ff16",
-            "max": 16320083,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_63eaf9d6905742748f24f112e778ef29",
-            "value": 16320083
-          }
-        },
-        "5de9d5cd8cb04f46b9192e1242d69ff1": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_b3761f92a01e4619b4c71a7308585888",
-            "placeholder": "​",
-            "style": "IPY_MODEL_3211f5fe4be6407c85d1b2726810c593",
-            "value": " 16.3MB / 16.3MB            "
-          }
-        },
-        "ef84496d828f4413a25f945fc5fa9050": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "2e4d8989ee424c00a67b35e911cd4837": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "7dbb7d0dda774c8893518e5403159a70": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "3331c96dfea64bb994926bb044d1ff16": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "63eaf9d6905742748f24f112e778ef29": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "b3761f92a01e4619b4c71a7308585888": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "3211f5fe4be6407c85d1b2726810c593": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "0a6ead1968c0440499c31bc23f180efc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_ae78bf2b414146aeb1d1cba00748aaff",
-              "IPY_MODEL_92361787cdda4e96885b1993141ba5aa",
-              "IPY_MODEL_1b44a78dea6e4171971127596a272c99"
-            ],
-            "layout": "IPY_MODEL_7e849b9d338e4098afcab85676e10699"
-          }
-        },
-        "ae78bf2b414146aeb1d1cba00748aaff": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_4579098693a645678a86acd2eb7d555b",
-            "placeholder": "​",
-            "style": "IPY_MODEL_1e937859786f44419eb54235f1661e6d",
-            "value": "Download complete: 100%"
-          }
-        },
-        "92361787cdda4e96885b1993141ba5aa": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_3fa5a76bb8bf40dbb983121aca5b3e50",
-            "max": 1,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_a1b8967d60474cb4bd7a2d87ededbd30",
-            "value": 1
-          }
-        },
-        "1b44a78dea6e4171971127596a272c99": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_3698777aa8094d6ea9cc28760db90b62",
-            "placeholder": "​",
-            "style": "IPY_MODEL_781750630d6d4524becb43eae6b5fbce",
-            "value": " 16.3M/16.3M [00:05&lt;00:00, 3.91MB/s]"
-          }
-        },
-        "7e849b9d338e4098afcab85676e10699": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "4579098693a645678a86acd2eb7d555b": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "1e937859786f44419eb54235f1661e6d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "3fa5a76bb8bf40dbb983121aca5b3e50": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": "20px"
-          }
-        },
-        "a1b8967d60474cb4bd7a2d87ededbd30": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "3698777aa8094d6ea9cc28760db90b62": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "781750630d6d4524becb43eae6b5fbce": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "79291de2cacd497eb3968e5ab7c773f5": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_b0d6b9cd2b8a4356ad34e1193ebbb4d8",
-              "IPY_MODEL_8680cf2cbadf4bd0b8faf4614dfea37d",
-              "IPY_MODEL_4222ed6d835543ffa5f06e5467074196"
-            ],
-            "layout": "IPY_MODEL_234ba6d082fc44bb8d066fd5f95354cb"
-          }
-        },
-        "b0d6b9cd2b8a4356ad34e1193ebbb4d8": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_f2a161f8d61d459ca8f2bf942689fc86",
-            "placeholder": "​",
-            "style": "IPY_MODEL_747e05b23fe148078f17bb35fb4afc0b",
+            "style": "IPY_MODEL_9630c21dbd0a44f285ef018798737c2f",
             "value": "Fetching 6 files: 100%"
           }
         },
-        "8680cf2cbadf4bd0b8faf4614dfea37d": {
+        "d154bdf0a0a64b508c643fb4f9b39b3c": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "FloatProgressModel",
           "model_module_version": "1.5.0",
@@ -5572,15 +4514,15 @@
             "bar_style": "success",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_b211898cb926412aaf992e678b30d978",
+            "layout": "IPY_MODEL_219dba196add46f6ba54efd8c66fb967",
             "max": 6,
             "min": 0,
             "orientation": "horizontal",
-            "style": "IPY_MODEL_5c2c83cc48004586b9ab8f37e7476883",
+            "style": "IPY_MODEL_34d3f079084540b7a37d81720ca2c9a4",
             "value": 6
           }
         },
-        "4222ed6d835543ffa5f06e5467074196": {
+        "427907d2d54f4a9bb4a17ad85dcd3d54": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "HTMLModel",
           "model_module_version": "1.5.0",
@@ -5595,13 +4537,13 @@
             "_view_name": "HTMLView",
             "description": "",
             "description_tooltip": null,
-            "layout": "IPY_MODEL_88701bdf45c745fe81d737ba84badfd5",
+            "layout": "IPY_MODEL_b2dadc4e1c4c4548ab230b6da732285c",
             "placeholder": "​",
-            "style": "IPY_MODEL_1d30e34f63fc457496ef4cb6e0cca297",
-            "value": " 6/6 [00:04&lt;00:00,  1.04s/it]"
+            "style": "IPY_MODEL_d14042a5da4a49ca8f5d507d8e213aef",
+            "value": " 6/6 [00:00&lt;00:00, 412.37it/s]"
           }
         },
-        "234ba6d082fc44bb8d066fd5f95354cb": {
+        "268d0a68b0f74df2811b66564e9f4595": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -5653,7 +4595,7 @@
             "width": null
           }
         },
-        "f2a161f8d61d459ca8f2bf942689fc86": {
+        "d08d5bb8e2e14c58a1805f6f956f290e": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -5705,7 +4647,7 @@
             "width": null
           }
         },
-        "747e05b23fe148078f17bb35fb4afc0b": {
+        "9630c21dbd0a44f285ef018798737c2f": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "model_module_version": "1.5.0",
@@ -5720,7 +4662,7 @@
             "description_width": ""
           }
         },
-        "b211898cb926412aaf992e678b30d978": {
+        "219dba196add46f6ba54efd8c66fb967": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -5772,7 +4714,7 @@
             "width": null
           }
         },
-        "5c2c83cc48004586b9ab8f37e7476883": {
+        "34d3f079084540b7a37d81720ca2c9a4": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "ProgressStyleModel",
           "model_module_version": "1.5.0",
@@ -5788,7 +4730,7 @@
             "description_width": ""
           }
         },
-        "88701bdf45c745fe81d737ba84badfd5": {
+        "b2dadc4e1c4c4548ab230b6da732285c": {
           "model_module": "@jupyter-widgets/base",
           "model_name": "LayoutModel",
           "model_module_version": "1.2.0",
@@ -5840,7 +4782,7 @@
             "width": null
           }
         },
-        "1d30e34f63fc457496ef4cb6e0cca297": {
+        "d14042a5da4a49ca8f5d507d8e213aef": {
           "model_module": "@jupyter-widgets/controls",
           "model_name": "DescriptionStyleModel",
           "model_module_version": "1.5.0",


### PR DESCRIPTION
<!-- Please use the template below! You can delete sections that are labeled Optional or are not relevant to your PR. Click "Preview" to check that your PR documentation is well formatted --> 

### Description of Changes
<!-- Include 1-2 sentences describing the functional changes this PR makes to the project. -->

### Linked Issue 
<!-- Replace issue_number with this PR's associated issue. Merging the PR will automatically close the linked issue. -->
Closes #issue_number

### Type of Change
<!-- Check the box that applies to your changes -->
- [x] **Model**: Machine learning model development, training, or architecture changes
- [ ] **Data**: Dataset management, preprocessing, or data pipeline work  
- [ ] **Web**: Frontend dashboard or web interface development
- [ ] **API**: Backend API development or FastAPI endpoints
- [x] **Research**: Experimental features or research exploration
- [ ] **Documentation**: Documentation updates or technical writing
- [ ] **Bug Fix**: Fixes a bug or issue
- [ ] **Refactor**: Code cleanup or optimization without functional changes

### Screenshots/Results
<!-- For UI changes: Include screenshots of the affected pages -->
<!-- For model changes: Include training/validation results, performance metrics, or loss curves -->
<!-- For data changes: Include sample outputs or data quality metrics -->

### Assignment Instructions
### OpenImages Real-Only Evaluation & Threshold Calibration

I evaluated the current EfficientNet-B0 baseline on a real-only subset of OpenImagesV7 to measure false positive behavior on natural images.

**Setup**
- Dataset: OpenImagesV7 (224 real images, all labels = real)
- Metric: False Positive Rate (FPR) and score distribution (`prob_fake`)
- Model default threshold (from config): **0.452**

**Results (real-only)**
- At default threshold **0.452**:
  - FPR ≈ **53.6%**
  - Score stats: mean ≈ 0.51, p95 ≈ 0.96, max ≈ 0.99  
  → The model is highly overconfident and flags many real photos as fake.

**Threshold calibration on OpenImages (real-only)**
I swept thresholds to hit target FPR levels:

| Target FPR | Threshold | Actual FPR |
|------------|-----------|------------|
| 20%        | 0.8900    | 20.1%      |
| 10%        | 0.9466    | 10.3%      |
| 5%         | 0.9607    | 5.36%      |
| 1%         | 0.9788    | 1.34%      |

A practical operating point for ~5% FPR on real photos is **threshold = 0.9607**.

**Tradeoff on in-distribution real/fake test set**
Using a standard test split (with both real and fake):

- At default threshold **0.452**:
  - FPR (real) ≈ **18%**
  - TPR (fake) ≈ **88%**
- At calibrated threshold **0.9607**:
  - FPR (real) ≈ **0%**
  - TPR (fake) ≈ **24%**


### Additional Comments
<!-- Any notes about the code changes, follow-up issues, or special considerations -->

## Checklist
- [x] The branch has been rebased with the latest `development` branch
- [x] This PR has the project manager assigned as a reviewer
- [x] This PR has myself assigned as the assignee